### PR TITLE
Remove __del__ from DicomIO to fix memory leak in python < 3.4

### DIFF
--- a/pydicom/filebase.py
+++ b/pydicom/filebase.py
@@ -22,9 +22,6 @@ class DicomIO(object):
     def __init__(self, *args, **kwargs):
         self._implicit_VR = True   # start with this by default
 
-    def __del__(self):
-        self.close()
-
     def read_le_tag(self):
         """Read and return two unsigned shorts (little endian) from the file."""
         bytes_read = self.read(4)


### PR DESCRIPTION
Closes #371.

Python < 3.4:
No expected change in behaviour as `DicomIO.__del__` won't be called as its not being garbage collected.

Python >= 3.4:
`filewriter.file_write()` no longer closes the passed `filename` object if its a `DicomIO` subclass.