### PR TITLE
[MRG+1] Add first version of pep8speaks

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,6 @@
+pycodestyle:
+    max-line-length: 79  # Default is 79 in PEP8
+    ignore:  # Errors and warnings to ignore
+        - E501
+        - E402
+        - E241


### PR DESCRIPTION
A pep8 configuration replicating most of the configuration in `.pep8` config file. 