### PR TITLE
[MRG] Remove numpy as depency by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ DOWNLOAD_URL = "https://github.com/pydicom/pydicom/archive/master.zip"
 LICENSE = "MIT"
 VERSION = __version__
 # PACKAGE_DATA = {'pydicom': ['../tests/tests_files/*']}
-REQUIRES = ["numpy"]
+REQUIRES = []
 
 opts = dict(name=NAME,
             version=__version__,


### PR DESCRIPTION
closes #403 

Remove numpy from the `setup.py` such that pip does not install it.