### PR TITLE
[MRG+1] Enforce the entire PEP8

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,6 +1,2 @@
 pycodestyle:
     max-line-length: 79  # Default is 79 in PEP8
-    ignore:  # Errors and warnings to ignore
-        - E501 # line too long
-        - E402 # module level import not at top of file
-        - E241 # multiple spaces after ‘,’ (removed from the standard checks in v.0.5.0)


### PR DESCRIPTION
#### Reference Issue
<!-- Example: Fixes #1234 -->
continues #396 

#### What does this implement/fix? Explain your changes.
Use the default PEP8, while keeping the `.pep8speaks.yml` so that we can keep track to any change of the pep8 enforcement. 
 
#### Any other comments?
