### PR TITLE
[MRG+2] Allow no encoding in DataElement_from_raw in Python 2

### DIFF
--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -14,6 +14,8 @@ A DataElement has a tag,
 from __future__ import absolute_import
 from collections import namedtuple
 
+from pydicom.charset import default_encoding
+
 from pydicom import config  # don't import datetime_conversion directly
 from pydicom import compat
 from pydicom.config import logger
@@ -459,6 +461,8 @@ def DataElement_from_raw(raw_data_element, encoding=None):
     # filereader->Dataset->convert_value->filereader
     # (for SQ parsing)
 
+    if in_py2:
+        encoding = encoding or default_encoding
     from pydicom.values import convert_value
     raw = raw_data_element
 

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -9,6 +9,10 @@
 
 import unittest
 
+import sys
+
+from pydicom.charset import default_encoding
+
 from pydicom.dataelem import DataElement
 from pydicom.dataelem import RawDataElement, DataElement_from_raw
 from pydicom.dataset import Dataset
@@ -201,16 +205,39 @@ class DataElementTests(unittest.TestCase):
 
 
 class RawDataElementTests(unittest.TestCase):
-    def setUp(self):
+    def testKeyError(self):
+        """RawDataElement: conversion of unknown tag throws KeyError..."""
         # raw data element -> tag VR length value
         #                       value_tell is_implicit_VR is_little_endian'
         # Unknown (not in DICOM dict), non-private, non-group 0 for this test
-        self.raw1 = RawDataElement(Tag(0x88880002), None, 4, 0x1111,
-                                   0, True, True)
+        raw = RawDataElement(Tag(0x88880002), None, 4, 0x1111,
+                             0, True, True)
+        self.assertRaises(KeyError, DataElement_from_raw, raw)
 
-    def testKeyError(self):
-        """RawDataElement: conversion of unknown tag throws KeyError........"""
-        self.assertRaises(KeyError, DataElement_from_raw, self.raw1)
+    def testValidTag(self):
+        """RawDataElement: conversion of known tag succeeds..."""
+        raw = RawDataElement(Tag(0x00080020), 'DA', 8, b'20170101',
+                             0, False, True)
+        element = DataElement_from_raw(raw, default_encoding)
+        self.assertEqual(element.name, 'Study Date')
+        self.assertEqual(element.VR, 'DA')
+        self.assertEqual(element.value, '20170101')
+
+    @unittest.skipIf(sys.version_info >= (3, ), 'Testing Python 2 behavior')
+    def testTagWithoutEncodingPython2(self):
+        """RawDataElement: no encoding needed in Python 2."""
+        raw = RawDataElement(Tag(0x00104000), 'LT', 23,
+                             b'comment\\comment2\\comment3',
+                             0, False, True)
+        element = DataElement_from_raw(raw)
+        self.assertEqual(element.name, 'Patient Comments')
+
+    @unittest.skipIf(sys.version_info < (3, ), 'Testing Python 3 behavior')
+    def testTagWithoutEncodingPython3(self):
+        """RawDataElement: raises if no encoding given in Python 3."""
+        self.assertRaises(TypeError, RawDataElement(Tag(0x00104000), 'LT', 14,
+                                                    b'comment1\\comment2',
+                                                    0, False, True))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- fixes #123

#### What does this implement/fix? Explain your changes.
`dataelem.DataElement_from_raw` has a second encoding parameter that is needed in Python 3.
With default value `None` for this parameter it could raise under Python 2, which was not intented.
This just replaces this default parameter with a sensible one under Python 2.