### PR TITLE
[MRG+2] Update the read_size of read_undefined_length_value() to 8KiB #436

### DIFF
--- a/pydicom/fileutil.py
+++ b/pydicom/fileutil.py
@@ -96,7 +96,7 @@ def read_undefined_length_value(fp,
                                 is_little_endian,
                                 delimiter_tag,
                                 defer_size=None,
-                                read_size=128):
+                                read_size=1024*8):
     """Read until the delimiter tag found and return the value;
      ignore the delimiter.
 


### PR DESCRIPTION
Update the read_size of read_undefined_length_value() to 8KiB to improve performance. Closes #436

After profiling, the read_size of read_undefined_length_value() is too low at 128B. Increasing it to a few kilobyted greatly improves performance (15MB file by x4; 50MB file by x10).
