### PR TITLE
[MRG+2] Fixed mistake in splitting format string

### DIFF
--- a/pydicom/datadict.py
+++ b/pydicom/datadict.py
@@ -247,8 +247,8 @@ def get_private_entry(tag, private_creator):
         elem_str = "%04x" % tag.elem
         key = "%sxx%s" % (group_str, elem_str[-2:])
         if key not in private_dict:
-            msg = "Tag {0} not in private ".format(key)
-            msg += "dictionary for private creator {1}".format(private_creator)
+            msg = ("Tag {0} not in private dictionary "
+                   "for private creator {1}".format(key, private_creator))
             raise KeyError(msg)
         dict_entry = private_dict[key]
     return dict_entry

--- a/pydicom/tests/test_dictionary.py
+++ b/pydicom/tests/test_dictionary.py
@@ -10,7 +10,7 @@ from pydicom.dataset import Dataset
 from pydicom.tag import Tag
 from pydicom.datadict import (keyword_for_tag, dictionary_description,
                               dictionary_has_tag, repeater_has_tag,
-                              repeater_has_keyword)
+                              repeater_has_keyword, get_private_entry)
 from pydicom.datadict import add_dict_entry, add_dict_entries
 
 
@@ -40,6 +40,25 @@ class DictTests(unittest.TestCase):
         """Test repeater_has_keyword"""
         self.assertTrue(repeater_has_keyword('OverlayData'))
         self.assertFalse(repeater_has_keyword('PixelData'))
+
+    def test_get_private_entry(self):
+        """Test get_private_entry"""
+        # existing entry
+        entry = get_private_entry((0x0903, 0x0011), 'GEIIS PACS')
+        self.assertEqual('US', entry[0])  # VR
+        self.assertEqual('1', entry[1])  # VM
+        self.assertEqual('Significant Flag', entry[2])  # name
+        self.assertFalse(entry[3])  # is retired
+
+        # existing entry in another slot
+        entry = get_private_entry((0x0903, 0x1011), 'GEIIS PACS')
+        self.assertEqual('Significant Flag', entry[2])  # name
+
+        # non-existing entry
+        self.assertRaises(KeyError, get_private_entry,
+                          (0x0903, 0x0011), 'Nonexisting')
+        self.assertRaises(KeyError, get_private_entry,
+                          (0x0903, 0x0091), 'GEIIS PACS')
 
     def testAddEntry(self):
         """dicom_dictionary: Can add and use a single dictionary entry"""


### PR DESCRIPTION
- fixes #441

#### What does this implement/fix? Explain your changes.
Fixes a simple mistake. I searched the code for similar problems, but this the only one of this kind.