### PR TITLE
[MRG+2] Fix generic_jpeg_file_header from being a tuple of bytes

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1060,7 +1060,6 @@ class Dataset(dict):
             already_have = False
         elif self._pixel_id != id(self.PixelData):
             already_have = False
-        already_have = False
         if not already_have and not self._is_uncompressed_transfer_syntax():
             try:
                 # print("Pixel Data is compressed")

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -963,7 +963,9 @@ class Dataset(dict):
             generic_jpeg_file_header = (b'\xff\xd8\xff\xe0\x00\x10JFIF\x00',
                                         b'\x01\x01\x01\x00\x01\x00\x01\x00',
                                         b'\x00')
+            generic_jpeg_file_header = b''.join(generic_jpeg_file_header)
             frame_start_from = 2
+
         elif (self.file_meta.TransferSyntaxUID in
                 pydicom.uid.JPEG2000CompressedPixelTransferSyntaxes):
             generic_jpeg_file_header = b''

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -960,10 +960,9 @@ class Dataset(dict):
             if self.BitsAllocated > 8:
                 raise NotImplementedError("JPEG Lossy only supported if Bits "
                                           "Allocated = 8")
-            generic_jpeg_file_header = (b'\xff\xd8\xff\xe0\x00\x10JFIF\x00',
-                                        b'\x01\x01\x01\x00\x01\x00\x01\x00',
+            generic_jpeg_file_header = (b'\xff\xd8\xff\xe0\x00\x10JFIF\x00'
+                                        b'\x01\x01\x01\x00\x01\x00\x01\x00'
                                         b'\x00')
-            generic_jpeg_file_header = b''.join(generic_jpeg_file_header)
             frame_start_from = 2
 
         elif (self.file_meta.TransferSyntaxUID in
@@ -1061,6 +1060,7 @@ class Dataset(dict):
             already_have = False
         elif self._pixel_id != id(self.PixelData):
             already_have = False
+        already_have = False
         if not already_have and not self._is_uncompressed_transfer_syntax():
             try:
                 # print("Pixel Data is compressed")

--- a/pydicom/filebase.py
+++ b/pydicom/filebase.py
@@ -88,7 +88,7 @@ class DicomIO(object):
             num_bytes = len(bytes_read)
             if num_bytes < length:
                 start_pos = self.tell() - num_bytes
-                msg = ("Unexpected end of file. Read {0} bytes of {1} ",
+                msg = ("Unexpected end of file. Read {0} bytes of {1} "
                        "expected starting at position 0x{2:x}".format(
                            len(bytes_read), length, start_pos))
                 raise EOFError(msg)

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -366,8 +366,8 @@ def write_data_element(fp, data_element, encoding=default_encoding):
     VR = data_element.VR
     if not fp.is_implicit_VR:
         if len(VR) != 2:
-            msg = ("Cannot write ambiguous VR of '{}' for data element with ",
-                   "tag {}.\nSet the correct VR before writing, or use an ",
+            msg = ("Cannot write ambiguous VR of '{}' for data element with "
+                   "tag {}.\nSet the correct VR before writing, or use an "
                    "implicit VR transfer syntax".format(
                        VR, repr(data_element.tag)))
             raise ValueError(msg)


### PR DESCRIPTION
Fixes issue #444

Fixes generic_jpeg_file_header from being a tuple of bytes to bytes by joining.

