### PR TITLE
[MRG+1] DicomIO.read: changed default for need_exact_length to False

### DIFF
--- a/pydicom/filebase.py
+++ b/pydicom/filebase.py
@@ -34,7 +34,7 @@ class DicomIO(object):
         return unpack(b"<HH", bytes_read)
 
     def read_be_tag(self):
-        """Read and return two unsigned shorts (little endian)
+        """Read and return two unsigned shorts (big endian)
            from the file."""
         bytes_read = self.read(4, need_exact_length=True)
         return unpack(b">HH", bytes_read)

--- a/pydicom/filebase.py
+++ b/pydicom/filebase.py
@@ -30,19 +30,13 @@ class DicomIO(object):
     def read_le_tag(self):
         """Read and return two unsigned shorts (little endian)
            from the file."""
-        bytes_read = self.read(4)
-        if len(bytes_read) < 4:
-            # needed for reading "next" tag when at end of file
-            raise EOFError
+        bytes_read = self.read(4, need_exact_length=True)
         return unpack(b"<HH", bytes_read)
 
     def read_be_tag(self):
         """Read and return two unsigned shorts (little endian)
            from the file."""
-        bytes_read = self.read(4)
-        if len(bytes_read) < 4:
-            # needed for reading "next" tag when at end of file
-            raise EOFError
+        bytes_read = self.read(4, need_exact_length=True)
         return unpack(b">HH", bytes_read)
 
     def write_tag(self, tag):
@@ -67,7 +61,7 @@ class DicomIO(object):
            little endian byte order"""
         return unpack(b"<L", self.read(4))[0]
 
-    def read(self, length=None, need_exact_length=True):
+    def read(self, length=None, need_exact_length=False):
         """Reads the required length, returns
         EOFError if gets less
 

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -14,10 +14,12 @@ import shutil
 import sys
 import tempfile
 import unittest
+
+from pydicom.filebase import DicomBytesIO
 from pydicom.util.testing.warncheck import assertWarns
 from pydicom.dataset import Dataset, FileDataset
 from pydicom.dataelem import DataElement
-from pydicom.filereader import read_file
+from pydicom.filereader import read_file, data_element_generator
 from pydicom.errors import InvalidDicomError
 from pydicom.tag import Tag, TupleTag
 from pydicom.uid import ImplicitVRLittleEndian
@@ -667,6 +669,22 @@ class ReaderTests(unittest.TestCase):
         self.assertTrue(ds.preamble is None)
         self.assertEqual(ds.file_meta, Dataset())
         self.assertEqual(ds[:], Dataset())
+
+    def test_read_file_does_not_raise(self):
+        """Test that reading from DicomBytesIO does not raise on EOF.
+        Regression test for #358."""
+        ds = read_file(mr_name)
+        fp = DicomBytesIO()
+        ds.save_as(fp)
+        fp.seek(0)
+        de_gen = data_element_generator(fp, False, True)
+        try:
+            while True:
+                next(de_gen)
+        except StopIteration:
+            pass
+        except EOFError:
+            self.fail('Unexpected EOFError raised')
 
 
 class ReadDataElementTests(unittest.TestCase):

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -1314,7 +1314,7 @@ class TestWriteNonStandard(unittest.TestCase):
         ds.Status = 0x0000
         ds.save_as(self.fp, write_like_original=True)
         self.fp.seek(0)
-        self.assertRaises(EOFError, self.fp.read, 128)
+        self.assertRaises(EOFError, self.fp.read, 128, need_exact_length=True)
         self.fp.seek(0)
         self.assertNotEqual(self.fp.read(4), b'DICM')
         # Ensure Command Set Elements written as little endian implicit VR


### PR DESCRIPTION
- avoids EOFError for standard invocation to match default read behavior
- fixes #358

#### What does this implement/fix? Explain your changes.
See #358: currently, DicomIO.read() raises an exception by default, if the number of read bytes is less than the length argument. This does not match the standard behavior of other read() functions and leads to unexpected behavior (in the given case just an incorrect warning).
The argument `need_exact_length` controls this behavior - if it is set to False (now the default) the exception is not raised. Where it was needed, the code has been adapted.
