### PR TITLE
[MRG+1] CI/FIX load right python version in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,11 +13,11 @@ environment:
       PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Miniconda3-x64"
+    - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Miniconda3-x64"
+    - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
 


### PR DESCRIPTION
Only Python 3.4 was loaded in appveyor because the path to the binary was wrong.