### PR TITLE
[MRG+1] Fix dir(Dataset) not working correctly for subclasses

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -336,9 +336,9 @@ class Dataset(dict):
         # Force zip object into a list in case of python3. Also backwards
         # compatible
         meths = set(
-            list(zip(*inspect.getmembers(Dataset, inspect.isroutine)))[0])
+            list(zip(*inspect.getmembers(self.__class__, inspect.isroutine)))[0])
         props = set(
-            list(zip(*inspect.getmembers(Dataset, inspect.isdatadescriptor)))[
+            list(zip(*inspect.getmembers(self.__class__, inspect.isdatadescriptor)))[
                 0])
         dicom_names = set(self.dir())
         alldir = sorted(props | meths | dicom_names)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -335,11 +335,10 @@ class Dataset(dict):
         """
         # Force zip object into a list in case of python3. Also backwards
         # compatible
-        meths = set(
-            list(zip(*inspect.getmembers(self.__class__, inspect.isroutine)))[0])
-        props = set(
-            list(zip(*inspect.getmembers(self.__class__, inspect.isdatadescriptor)))[
-                0])
+        meths = set(list(zip(
+            *inspect.getmembers(self.__class__, inspect.isroutine)))[0])
+        props = set(list(zip(
+            *inspect.getmembers(self.__class__, inspect.isdatadescriptor)))[0])
         dicom_names = set(self.dir())
         alldir = sorted(props | meths | dicom_names)
         return alldir

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -324,6 +324,11 @@ class DatasetTests(unittest.TestCase):
         assert callable(ds.test_func)
         assert 'test_func' in dir(ds)
 
+        ds = Dataset()
+        assert hasattr(ds, 'group_dataset')
+        assert callable(ds.group_dataset)
+        assert 'group_dataset' in dir(ds)
+
     def test_dir(self):
         """Dataset.dir() returns sorted list of named data_elements."""
         ds = self.dummy_dataset()

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -313,6 +313,17 @@ class DatasetTests(unittest.TestCase):
             'Johnny',
             "set by tag failed")
 
+    def test_dir_subclass(self):
+        """Dataset.__dir__ returns class specific dir"""
+        class DSP(Dataset):
+            def test_func(self):
+                pass
+
+        ds = DSP()
+        assert hasattr(ds, 'test_func')
+        assert callable(ds.test_func)
+        assert 'test_func' in dir(ds)
+
     def test_dir(self):
         """Dataset.dir() returns sorted list of named data_elements."""
         ds = self.dummy_dataset()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
Fixes #486

#### What does this implement/fix? Explain your changes.
`Dataset.__dir__ `now class specific 