### PR TITLE
[MRG] Raise ValueError for invalid pixel data with undefined length

### DIFF
--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -414,6 +414,17 @@ def write_data_element(fp, data_element, encoding=default_encoding):
     if (hasattr(data_element, "is_undefined_length")
             and data_element.is_undefined_length):
         is_undefined_length = True
+        if data_element.tag == 0x7fe00010:  # pixel data
+            starts_with_item_tag = False
+            if fp.is_little_endian:
+                if data_element.value.startswith(b'\xfe\xff\x00\xe0'):
+                    starts_with_item_tag = True
+            else:
+                if data_element.value.startswith(b'\xff\xfe\xe0\x00'):
+                    starts_with_item_tag = True
+            if not starts_with_item_tag:
+                raise ValueError('Pixel Data with undefined length must '
+                                 'start with an an item tag')
     location = fp.tell()
     fp.seek(length_location)
     if not fp.is_implicit_VR and VR not in extra_length_VRs:

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -414,14 +414,14 @@ def write_data_element(fp, data_element, encoding=default_encoding):
     if (hasattr(data_element, "is_undefined_length")
             and data_element.is_undefined_length):
         is_undefined_length = True
+        # valid pixel data with undefined length shall contain encapsulated
+        # data, e.g. sequence items - raise ValueError otherwise (see #238)
         if data_element.tag == 0x7fe00010:  # pixel data
-            starts_with_item_tag = False
+            val = data_element.value
             if fp.is_little_endian:
-                if data_element.value.startswith(b'\xfe\xff\x00\xe0'):
-                    starts_with_item_tag = True
+                starts_with_item_tag = val.startswith(b'\xfe\xff\x00\xe0')
             else:
-                if data_element.value.startswith(b'\xff\xfe\xe0\x00'):
-                    starts_with_item_tag = True
+                starts_with_item_tag = val.startswith(b'\xff\xfe\xe0\x00')
             if not starts_with_item_tag:
                 raise ValueError('Pixel Data with undefined length must '
                                  'start with an an item tag')

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -418,13 +418,12 @@ def write_data_element(fp, data_element, encoding=default_encoding):
         # data, e.g. sequence items - raise ValueError otherwise (see #238)
         if data_element.tag == 0x7fe00010:  # pixel data
             val = data_element.value
-            if fp.is_little_endian:
-                starts_with_item_tag = val.startswith(b'\xfe\xff\x00\xe0')
-            else:
-                starts_with_item_tag = val.startswith(b'\xff\xfe\xe0\x00')
-            if not starts_with_item_tag:
+            if (fp.is_little_endian and not
+                    val.startswith(b'\xfe\xff\x00\xe0') or
+                    not fp.is_little_endian and
+                    not val.startswith(b'\xff\xfe\xe0\x00')):
                 raise ValueError('Pixel Data with undefined length must '
-                                 'start with an an item tag')
+                                 'start with an item tag')
     location = fp.tell()
     fp.seek(length_location)
     if not fp.is_implicit_VR and VR not in extra_length_VRs:

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -41,7 +41,6 @@ except AttributeError:
     except ImportError:
         print("unittest2 is required for testing in python2.6")
 
-
 rtplan_name = get_testdata_files("rtplan.dcm")[0]
 rtdose_name = get_testdata_files("rtdose.dcm")[0]
 ct_name = get_testdata_files("CT_small.dcm")[0]
@@ -263,8 +262,8 @@ class WriteDataElementTests(unittest.TestCase):
         # Was issue 74
         data_elem = DataElement(0x00280009, "AT", [])
         expected = hex2bytes((
-            " 28 00 09 00"   # (0028,0009) Frame Increment Pointer
-            " 00 00 00 00"   # length 0
+            " 28 00 09 00"  # (0028,0009) Frame Increment Pointer
+            " 00 00 00 00"  # length 0
         ))
         write_data_element(self.f1, data_elem)
         got = self.f1.getvalue()
@@ -1729,6 +1728,72 @@ class TestWriteFileMetaInfoNonStandard(unittest.TestCase):
         ref_meta = deepcopy(meta)
         write_file_meta_info(self.fp, meta, enforce_standard=False)
         self.assertEqual(meta, ref_meta)
+
+
+class TestWriteUndefinedLengthPixelData(unittest.TestCase):
+    """Test write_data_element() for pixel data with undefined length."""
+
+    def setUp(self):
+        self.fp = DicomBytesIO()
+
+    def test_little_endian_correct_data(self):
+        """Pixel data starting with an item tag is written."""
+        self.fp.is_little_endian = True
+        self.fp.is_implicit_VR = False
+        pixel_data = DataElement(0x7fe00010, 'OB',
+                                 b'\xfe\xff\x00\xe0'
+                                 b'\x00\x01\x02\x03',
+                                 is_undefined_length=True)
+        write_data_element(self.fp, pixel_data)
+
+        expected = (b'\xe0\x7f\x10\x00'  # tag
+                    b'OB\x00\x00'  # VR
+                    b'\xff\xff\xff\xff'  # length
+                    b'\xfe\xff\x00\xe0\x00\x01\x02\x03'  # contents
+                    b'\xfe\xff\xdd\xe0\x00\x00\x00\x00')  # SQ delimiter
+        self.fp.seek(0)
+        assert self.fp.read() == expected
+
+    def test_big_endian_correct_data(self):
+        """Pixel data starting with an item tag is written."""
+        self.fp.is_little_endian = False
+        self.fp.is_implicit_VR = False
+        pixel_data = DataElement(0x7fe00010, 'OB',
+                                 b'\xff\xfe\xe0\x00'
+                                 b'\x00\x01\x02\x03',
+                                 is_undefined_length=True)
+        write_data_element(self.fp, pixel_data)
+        expected = (b'\x7f\xe0\x00\x10'  # tag
+                    b'OB\x00\x00'  # VR
+                    b'\xff\xff\xff\xff'  # length
+                    b'\xff\xfe\xe0\x00\x00\x01\x02\x03'  # contents
+                    b'\xff\xfe\xe0\xdd\x00\x00\x00\x00')  # SQ delimiter
+        self.fp.seek(0)
+        assert self.fp.read() == expected
+
+    def test_little_endian_incorrect_data(self):
+        """Writing pixel data not starting with an item tag raises."""
+        self.fp.is_little_endian = True
+        self.fp.is_implicit_VR = False
+        pixel_data = DataElement(0x7fe00010, 'OB',
+                                 b'\xff\xff\x00\xe0'
+                                 b'\x00\x01\x02\x03'
+                                 b'\xfe\xff\xdd\xe0',
+                                 is_undefined_length=True)
+        with pytest.raises(ValueError):
+            write_data_element(self.fp, pixel_data)
+
+    def test_big_endian_incorrect_data(self):
+        """Writing pixel data not starting with an item tag raises."""
+        self.fp.is_little_endian = False
+        self.fp.is_implicit_VR = False
+        pixel_data = DataElement(0x7fe00010, 'OB',
+                                 b'\x00\x00\x00\x00'
+                                 b'\x00\x01\x02\x03'
+                                 b'\xff\xfe\xe0\xdd',
+                                 is_undefined_length=True)
+        with pytest.raises(ValueError):
+            write_data_element(self.fp, pixel_data)
 
 
 if __name__ == "__main__":

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -1780,7 +1780,8 @@ class TestWriteUndefinedLengthPixelData(unittest.TestCase):
                                  b'\x00\x01\x02\x03'
                                  b'\xfe\xff\xdd\xe0',
                                  is_undefined_length=True)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='Pixel Data .* must '
+                                             'start with an item tag'):
             write_data_element(self.fp, pixel_data)
 
     def test_big_endian_incorrect_data(self):
@@ -1792,7 +1793,8 @@ class TestWriteUndefinedLengthPixelData(unittest.TestCase):
                                  b'\x00\x01\x02\x03'
                                  b'\xff\xfe\xe0\xdd',
                                  is_undefined_length=True)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='Pixel Data .+ must '
+                                             'start with an item tag'):
             write_data_element(self.fp, pixel_data)
 
 


### PR DESCRIPTION
- pixel data with undefined length shall start with an item delimiter
- fixes #238 by raising an exception that clarifies the problem

#### What does this implement/fix? Explain your changes.
see discussion in #238