### PR TITLE
[MRG+2] Avoid infinite recursion in UID properties

### DIFF
--- a/pydicom/tests/test_uid.py
+++ b/pydicom/tests/test_uid.py
@@ -184,15 +184,17 @@ class TestUID(object):
     def test_name_with_equal_hash(self):
         """Test that UID name works for UID with same hash as predefined UID.
         """
-        uid = UID('1.2.3')
-        # force the equal hash to reproduce the problem
-        original_hash = UID.__hash__
-        UID.__hash__ = lambda val: hash(JPEGLSLossy)
-        try:
-            # Issue 499 - infinite recursion
-            assert uid.name == '1.2.3'
-        finally:
-            UID.__hash__ = original_hash
+        class MockedUID(UID):
+            # Force the UID to return the same hash as one of the
+            # uid dictionary entries (any will work).
+            # The resulting hash collision forces the usage of the `eq`
+            # operator while checking for containment in the uid dictionary
+            # (regression test for issue #499)
+            def __hash__(self):
+                return hash(JPEGLSLossy)
+
+        uid = MockedUID('1.2.3')
+        assert uid.name == '1.2.3'
 
     def test_type(self):
         """Test that UID.type works."""

--- a/pydicom/tests/test_uid.py
+++ b/pydicom/tests/test_uid.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from pydicom.uid import UID, generate_uid, PYDICOM_ROOT_UID
+from pydicom.uid import UID, generate_uid, PYDICOM_ROOT_UID, JPEGLSLossy
 
 
 class TestGenerateUID(object):
@@ -61,8 +61,6 @@ class TestUID(object):
         assert not self.uid == 'Explicit VR Little Endian'
         # Issue 96
         assert not self.uid == 3
-        is_none = self.uid is None
-        assert not is_none
 
     def test_inequality(self):
         """Test that UID.__ne__ works."""
@@ -74,7 +72,6 @@ class TestUID(object):
         assert self.uid != 'Explicit VR Little Endian'
         # Issue 96
         assert self.uid != 3
-        assert self.uid is not None
 
     def test_hash(self):
         """Test that UID.__hash_- works."""
@@ -187,10 +184,15 @@ class TestUID(object):
     def test_name_with_equal_hash(self):
         """Test that UID name works for UID with same hash as predefined UID.
         """
-        uid_string = '1.3.12.2.1107.5.2.18.41538.2017072416190348328326500'
-        uid = UID(uid_string)
-        # Issue 499 - infinite recursion
-        assert uid.name == uid_string
+        uid = UID('1.2.3')
+        # force the equal hash to reproduce the problem
+        original_hash = UID.__hash__
+        UID.__hash__ = lambda val: hash(JPEGLSLossy)
+        try:
+            # Issue 499 - infinite recursion
+            assert uid.name == '1.2.3'
+        finally:
+            UID.__hash__ = original_hash
 
     def test_type(self):
         """Test that UID.type works."""

--- a/pydicom/tests/test_uid.py
+++ b/pydicom/tests/test_uid.py
@@ -61,7 +61,8 @@ class TestUID(object):
         assert not self.uid == 'Explicit VR Little Endian'
         # Issue 96
         assert not self.uid == 3
-        assert not self.uid is None
+        is_none = self.uid is None
+        assert not is_none
 
     def test_inequality(self):
         """Test that UID.__ne__ works."""
@@ -182,6 +183,14 @@ class TestUID(object):
         """Test that UID.name works."""
         assert self.uid.name == 'Implicit VR Little Endian'
         assert UID('1.2.840.10008.5.1.4.1.1.2').name == 'CT Image Storage'
+
+    def test_name_with_equal_hash(self):
+        """Test that UID name works for UID with same hash as predefined UID.
+        """
+        uid_string = '1.3.12.2.1107.5.2.18.41538.2017072416190348328326500'
+        uid = UID(uid_string)
+        # Issue 499 - infinite recursion
+        assert uid.name == uid_string
 
     def test_type(self):
         """Test that UID.type works."""

--- a/pydicom/uid.py
+++ b/pydicom/uid.py
@@ -162,15 +162,16 @@ class UID(str):
     @property
     def name(self):
         """Return the UID name from the UID dictionary."""
-        if self in UID_dictionary:
+        uid_string = str.__str__(self)
+        if uid_string in UID_dictionary:
             return UID_dictionary[self][0]
 
-        return str.__str__(self)
+        return uid_string
 
     @property
     def type(self):
         """Return the UID type from the UID dictionary."""
-        if self in UID_dictionary:
+        if str.__str__(self) in UID_dictionary:
             return UID_dictionary[self][1]
 
         return ''
@@ -178,7 +179,7 @@ class UID(str):
     @property
     def info(self):
         """Return the UID info from the UID dictionary."""
-        if self in UID_dictionary:
+        if str.__str__(self) in UID_dictionary:
             return UID_dictionary[self][2]
 
         return ''
@@ -186,7 +187,7 @@ class UID(str):
     @property
     def is_retired(self):
         """Return True if the UID is retired, False otherwise or if private."""
-        if self in UID_dictionary:
+        if str.__str__(self) in UID_dictionary:
             return bool(UID_dictionary[self][3])
 
         return False


### PR DESCRIPTION
- fixes #499

#### What does this implement/fix? Explain your changes.
- avoids infinite recursion while accessing UID properties if the UID happens to have the same hash as a predefined UID
