### PR TITLE
[MRG+2] Added possibility to inline sort MultiValue

### DIFF
--- a/pydicom/multival.py
+++ b/pydicom/multival.py
@@ -80,3 +80,6 @@ class MultiValue(MutableSequence):
 
     def __eq__(self, other):
         return self._list == other
+
+    def sort(self, key=None, reverse=False):
+        self._list.sort(key=key, reverse=reverse)

--- a/pydicom/tests/test_multival.py
+++ b/pydicom/tests/test_multival.py
@@ -100,6 +100,14 @@ class MultiValuetests(unittest.TestCase):
         multival = MultiValue(DSfloat, range(7))
         deepcopy(multival)
 
+    def testSorting(self):
+        """MultiValue: allow inline sort."""
+        multival = MultiValue(DS, [12, 33, 5, 7, 1])
+        multival.sort()
+        self.assertEqual([1, 5, 7, 12, 33], multival)
+        multival.sort(reverse=True)
+        self.assertEqual([33, 12, 7, 5, 1], multival)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pydicom/tests/test_multival.py
+++ b/pydicom/tests/test_multival.py
@@ -107,6 +107,8 @@ class MultiValuetests(unittest.TestCase):
         self.assertEqual([1, 5, 7, 12, 33], multival)
         multival.sort(reverse=True)
         self.assertEqual([33, 12, 7, 5, 1], multival)
+        multival.sort(key=str)
+        self.assertEqual([1, 12, 33, 5, 7], multival)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- see https://github.com/pydicom/contrib-pydicom/issues/5

#### What does this implement/fix? Explain your changes.
For more convenient usage of ``MultiValue`` inline sorting has been added, as used in ``pydicom_series.py`` (see mentioned issue).