### PR TITLE
[MRG+2] Fixes problem for files with implicit VR file meta - closes #503

### DIFF
--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -495,7 +495,7 @@ def _read_file_meta_info(fp):
     #   data element: if it fails, retry loading the file meta with an
     #   implicit VR (issue #503)
     try:
-        file_meta[file_meta.keys()[0]]
+        file_meta[list(file_meta)[0].tag]
     except NotImplementedError:
         fp.seek(start_file_meta)
         file_meta = read_dataset(fp, is_implicit_VR=True,

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -490,10 +490,12 @@ def _read_file_meta_info(fp):
                              stop_when=_not_group_0002)
     if not file_meta:
         return file_meta
-    # Test the file meta for correct interpretation: if it fails, retry
-    #   loading the file meta with an implicit VR (issue #503)
+
+    # Test the file meta for correct interpretation by requesting the first
+    #   data element: if it fails, retry loading the file meta with an
+    #   implicit VR (issue #503)
     try:
-        file_meta.get("TransferSyntaxUID")
+        file_meta[file_meta.keys()[0]]
     except NotImplementedError:
         fp.seek(start_file_meta)
         file_meta = read_dataset(fp, is_implicit_VR=True,

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -461,7 +461,7 @@ def _read_command_set_elements(fp):
     return command_set
 
 
-def _read_file_meta_info(fp, is_implicit_VR=False):
+def _read_file_meta_info(fp):
     """Return a Dataset containing any File Meta (0002,eeee) elements in `fp`.
 
     File Meta elements are always Explicit VR Little Endian (as per PS3.10
@@ -486,9 +486,20 @@ def _read_file_meta_info(fp, is_implicit_VR=False):
         return tag.group != 2
 
     start_file_meta = fp.tell()
-    file_meta = read_dataset(fp, is_implicit_VR=is_implicit_VR,
-                             is_little_endian=True,
+    file_meta = read_dataset(fp, is_implicit_VR=False, is_little_endian=True,
                              stop_when=_not_group_0002)
+    if not file_meta:
+        return file_meta
+    # Test the file meta for correct interpretation: if it fails, retry
+    #   loading the file meta with an implicit VR (issue #503)
+    try:
+        file_meta.get("TransferSyntaxUID")
+    except NotImplementedError:
+        fp.seek(start_file_meta)
+        file_meta = read_dataset(fp, is_implicit_VR=True,
+                                 is_little_endian=True,
+                                 stop_when=_not_group_0002)
+
     # Log if the Group Length doesn't match actual length
     if 'FileMetaInformationGroupLength' in file_meta:
         # FileMetaInformationGroupLength must be 12 bytes long and its value
@@ -502,14 +513,6 @@ def _read_file_meta_info(fp, is_implicit_VR=False):
                         "bytes)."
                         .format(file_meta.FileMetaInformationGroupLength,
                                 length_file_meta))
-
-    # Test the file meta for correct interpretation: if it fails, retry
-    #   loading the file meta with an implicit VR (issue #503)
-    try:
-        file_meta.get("TransferSyntaxUID")
-    except NotImplementedError:
-        fp.seek(start_file_meta)
-        file_meta = _read_file_meta_info(fp, is_implicit_VR=True)
 
     return file_meta
 

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -486,7 +486,8 @@ def _read_file_meta_info(fp, is_implicit_VR=False):
         return tag.group != 2
 
     start_file_meta = fp.tell()
-    file_meta = read_dataset(fp, is_implicit_VR=is_implicit_VR, is_little_endian=True,
+    file_meta = read_dataset(fp, is_implicit_VR=is_implicit_VR,
+                             is_little_endian=True,
                              stop_when=_not_group_0002)
     # Log if the Group Length doesn't match actual length
     if 'FileMetaInformationGroupLength' in file_meta:
@@ -502,8 +503,8 @@ def _read_file_meta_info(fp, is_implicit_VR=False):
                         .format(file_meta.FileMetaInformationGroupLength,
                                 length_file_meta))
 
-    # Test the file meta for correct interpretation: if it fails, retry loading the file meta with
-    #   an implicit VR (issue #503)
+    # Test the file meta for correct interpretation: if it fails, retry
+    #   loading the file meta with an implicit VR (issue #503)
     try:
         file_meta.get("TransferSyntaxUID")
     except NotImplementedError:

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -664,6 +664,17 @@ class ReaderTests(unittest.TestCase):
         self.assertTrue(ds.preamble is None)
         self.assertEqual(ds.file_meta, Dataset())
 
+    def test_file_meta_dataset_implicit_vr(self):
+        """Test reading a file meta dataset that is implicit VR"""
+
+        bytestream = (b'\x02\x00\x10\x00\x12\x00\x00\x00'
+                      b'\x31\x2e\x32\x2e\x38\x34\x30\x2e'
+                      b'\x31\x30\x30\x30\x38\x2e\x31\x2e'
+                      b'\x32\x00')
+        fp = BytesIO(bytestream)
+        ds = read_file(fp, force=True)
+        self.assertTrue('TransferSyntaxUID' in ds.file_meta)
+
     def test_no_dataset(self):
         """Test reading no elements or preamble produces empty Dataset"""
         bytestream = b''


### PR DESCRIPTION
#### Reference Issue
Fixes #503 

#### What does this implement/fix?
When reading a DICOM file with an implicit VR file meta, pydicom raises a NotImplementedError (Unknown Value Representation), as it tries to read the file meta as explicit VR. This edit catches the exception and retries to read the file meta using the implicit VR.

It seems that my edits do not affect the unit tests (the same number of tests fail on my machine when I switch to the master branch), but I'm not entirely sure if I run them correctly. I did not yet add a unit test for my edits: would that be required?