### PR TITLE
[MRG+2] Change read_file and write_file to dcmread, dcmwrite

### DIFF
--- a/doc/base_element.rst
+++ b/doc/base_element.rst
@@ -22,7 +22,7 @@ an existing DICOM file::
   >>> from pydicom.data import get_testdata_files
   >>> # get some test data
   >>> filename = get_testdata_files("rtplan.dcm")[0]
-  >>> ds = pydicom.read_file(filename)
+  >>> ds = pydicom.dcmread(filename)
 
 You can display the entire dataset by simply printing its string
 (str or repr) value::
@@ -131,7 +131,7 @@ that :class:`dataelem.DataElement` is returned. If you need the whole
 number::
 
   >>> # reload the data
-  >>> ds = pydicom.read_file(filename)
+  >>> ds = pydicom.dcmread(filename)
   >>> data_element = ds.data_element("PatientName")
   >>> data_element.VR, data_element.value
   ('PN', 'Last^First^mid^pre')
@@ -154,7 +154,7 @@ To work with pixel data, the raw bytes are available through the usual tag::
 
   >>> # read data with actual pixel data
   >>> filename = get_testdata_files("CT_small.dcm")[0]
-  >>> ds = pydicom.read_file(filename)
+  >>> ds = pydicom.dcmread(filename)
   >>> pixel_bytes = ds.PixelData
 
 but to work with them in a more intelligent way, use ``pixel_array``

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -26,7 +26,7 @@ head-first-prone, and save to a new file::
   >>> import pydicom
   >>> from pydicom.data import get_testdata_files
   >>> filename = get_testdata_files("rtplan.dcm")[0]
-  >>> ds = pydicom.read_file(filename)  # plan dataset
+  >>> ds = pydicom.dcmread(filename)  # plan dataset
   >>> ds.PatientName
   'Last^First^mid^pre'
   >>> ds.dir("setup")    # get a list of tags with "setup" somewhere in the name

--- a/doc/ref_guide.rst
+++ b/doc/ref_guide.rst
@@ -9,16 +9,16 @@ Pydicom API's Reference Guide
 File Reading/Parsing
 ====================
 
-The main function to read and parse DICOM files using pydicom is ``read_file``. It is coded in the module
+The main function to read and parse DICOM files using pydicom is ``dcmread``. It is coded in the module
 dicom.filereader, but is also imported when the pydicom package is imported::
 
    >>> import pydicom
-   >>> dataset = pydicom.read_file(...)
+   >>> dataset = pydicom.dcmread(...)
 
 If you need fine control over the reading, you can either call ``read_partial`` or use ``open_dicom``.
 All are documented below:
 
-.. autofunction:: pydicom.filereader.read_file
+.. autofunction:: pydicom.filereader.dcmread
 
 .. autofunction:: pydicom.filereader.read_partial
 

--- a/doc/viewing_images.rst
+++ b/doc/viewing_images.rst
@@ -32,7 +32,7 @@ Here is an example::
   >>> import pydicom
   >>> from pydicom.data import get_testdata_files
   >>> filename = get_testdata_files("CT_small.dcm")[0]
-  >>> ds = pydicom.read_file(filename)
+  >>> ds = pydicom.dcmread(filename)
   >>> plt.imshow(ds.pixel_array, cmap=plt.cm.bone) # doctest: +ELLIPSIS
   <matplotlib.image.AxesImage object at ...>
 

--- a/doc/whatsnew/v1.0.0.rst
+++ b/doc/whatsnew/v1.0.0.rst
@@ -13,6 +13,7 @@ Enhancements
 * fully python3 compatible -- one code-base for both python 2 and python 3
 * package name and the import name match -- now use ``import pydicom`` rather
   than ``import dicom``
+* ``read_file`` changed to ``dcmread`` for greater clarity.  Similarly ``write_file`` becomes ``dcmwrite``.  Previous names still available for backwards compatibility
 * optional GDCM support for reading files with compressed pixel data
 * optional Pillow, jpeg_ls support for reading some compressed pixel data files
 * cleaned up dicom dictionary code, old non-dicom-keyword code removed

--- a/doc/working_with_pixel_data.rst
+++ b/doc/working_with_pixel_data.rst
@@ -17,7 +17,7 @@ it doesn't do anything with pixel data except read in the raw bytes::
   >>> import pydicom
   >>> from pydicom.data import get_testdata_files
   >>> filename = get_testdata_files("MR_small.dcm")[0]
-  >>> ds = pydicom.read_file(filename)
+  >>> ds = pydicom.dcmread(filename)
   >>> ds.PixelData # doctest: +ELLIPSIS
   b'\x89\x03\xfb\x03\xcb\x04\xeb\x04\xf9\x02\x94\x01\x7f...
 

--- a/examples/dicomtree.py
+++ b/examples/dicomtree.py
@@ -44,7 +44,7 @@ def RunTree(w, filename):
 
 def show_file(filename, tree):
     tree.hlist.add("root", text=filename)
-    ds = pydicom.read_file(sys.argv[1])
+    ds = pydicom.dcmread(sys.argv[1])
     ds.decode()  # change strings to unicode
     recurse_tree(tree, ds, "root", False)
     tree.autosetmode()

--- a/examples/image_processing/plot_downsize_image.py
+++ b/examples/image_processing/plot_downsize_image.py
@@ -23,7 +23,7 @@ print(__doc__)
 
 # FIXME: add a full-sized MR image in the testing data
 filename = get_testdata_files('MR_small.dcm')[0]
-ds = pydicom.read_file(filename)
+ds = pydicom.dcmread(filename)
 
 # get the pixel information into a numpy array
 data = ds.pixel_array

--- a/examples/input_output/plot_printing_dataset.py
+++ b/examples/input_output/plot_printing_dataset.py
@@ -47,6 +47,6 @@ def myprint(dataset, indent=0):
 
 
 filename = get_testdata_files('MR_small.dcm')[0]
-ds = pydicom.read_file(filename)
+ds = pydicom.dcmread(filename)
 
 myprint(ds)

--- a/examples/input_output/plot_read_dicom.py
+++ b/examples/input_output/plot_read_dicom.py
@@ -18,7 +18,7 @@ from pydicom.data import get_testdata_files
 print(__doc__)
 
 filename = get_testdata_files('CT_small.dcm')[0]
-dataset = pydicom.read_file(filename)
+dataset = pydicom.dcmread(filename)
 
 # Normal mode:
 print()

--- a/examples/input_output/plot_read_dicom_directory.py
+++ b/examples/input_output/plot_read_dicom_directory.py
@@ -59,7 +59,7 @@ for patient_record in dicom_dir.patient_records:
             image_filenames = [join(base_dir, *image_rec.ReferencedFileID)
                                for image_rec in image_records]
 
-            datasets = [pydicom.read_file(image_filename)
+            datasets = [pydicom.dcmread(image_filename)
                         for image_filename in image_filenames]
 
             patient_names = set(ds.PatientName for ds in datasets)

--- a/examples/input_output/plot_read_rtplan.py
+++ b/examples/input_output/plot_read_rtplan.py
@@ -33,5 +33,5 @@ def list_beams(plan_dataset):
 
 
 filename = get_testdata_files('rtplan.dcm')[0]
-dataset = pydicom.read_file(filename)
+dataset = pydicom.dcmread(filename)
 print(list_beams(dataset))

--- a/examples/input_output/plot_write_dicom.py
+++ b/examples/input_output/plot_write_dicom.py
@@ -68,7 +68,7 @@ ds.save_as(filename_big_endian)
 # reopen the data just for checking
 for filename in (filename_little_endian, filename_big_endian):
     print('Load file {} ...'.format(filename))
-    ds = pydicom.read_file(filename)
+    ds = pydicom.dcmread(filename)
     print(ds)
 
     # remove the created file

--- a/examples/metadata_processing/plot_add_dict_entries.py
+++ b/examples/metadata_processing/plot_add_dict_entries.py
@@ -42,7 +42,7 @@ new_names_dict = dict([(val[4], tag) for tag, val in
 keyword_dict.update(new_names_dict)
 
 # Test that it is working
-ds = Dataset()  # or could get one from read_file, etc
+ds = Dataset()  # or could get one from dcmread, etc
 
 ds.TestOne = 42
 ds.TestTwo = '12345'

--- a/examples/metadata_processing/plot_anonymize.py
+++ b/examples/metadata_processing/plot_anonymize.py
@@ -27,7 +27,7 @@ print(__doc__)
 ###############################################################################
 
 filename = get_testdata_files('MR_small.dcm')[0]
-dataset = pydicom.read_file(filename)
+dataset = pydicom.dcmread(filename)
 
 data_elements = ['PatientID',
                  'PatientBirthDate']

--- a/examples/plot_dicom_difference.py
+++ b/examples/plot_dicom_difference.py
@@ -20,7 +20,7 @@ print(__doc__)
 filename_mr = get_testdata_files('MR_small.dcm')[0]
 filename_ct = get_testdata_files('CT_small.dcm')[0]
 
-datasets = tuple([pydicom.read_file(filename, force=True)
+datasets = tuple([pydicom.dcmread(filename, force=True)
                   for filename in (filename_mr, filename_ct)])
 
 # difflib compare functions require a list of lines, each terminated with

--- a/pydicom/__init__.py
+++ b/pydicom/__init__.py
@@ -35,7 +35,7 @@ Quick Start
 from pydicom.dataelem import DataElement
 from pydicom.dataset import Dataset, FileDataset
 from pydicom.filereader import dcmread, read_file
-from pydicom.dicomio import write_file
+from pydicom.dicomio import dcmwrite, write_file
 from pydicom.sequence import Sequence
 
 from ._version import __version__
@@ -46,6 +46,7 @@ __all__ = ['DataElement',
            'FileDataset',
            'Sequence',
            'dcmread',
+           'dcmwrite',
            'read_file',
            'write_file',
            '__version__',

--- a/pydicom/__init__.py
+++ b/pydicom/__init__.py
@@ -14,7 +14,7 @@ Quick Start
    file::
 
     from pydicom import dicomio
-    dataset = dicomio.read_file("file1.dcm")
+    dataset = dicomio.dcmread("file1.dcm")
     dataset.PatientName = 'anonymous'
     dataset.save_as("file2.dcm")
 
@@ -34,7 +34,7 @@ Quick Start
 
 from pydicom.dataelem import DataElement
 from pydicom.dataset import Dataset, FileDataset
-from pydicom.dicomio import read_file
+from pydicom.filereader import dcmread, read_file
 from pydicom.dicomio import write_file
 from pydicom.sequence import Sequence
 
@@ -45,6 +45,7 @@ __all__ = ['DataElement',
            'Dataset',
            'FileDataset',
            'Sequence',
+           'dcmread',
            'read_file',
            'write_file',
            '__version__',

--- a/pydicom/data/charset_files/charlist.py
+++ b/pydicom/data/charset_files/charlist.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     # Collect summary information from the files
     files_info = []
     for name in names:
-        ds = pydicom.read_file(name)
+        ds = pydicom.dcmread(name)
         ds.decode()
         try:
             files_info.append((name, ds.SpecificCharacterSet, ds.PatientName))

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -29,7 +29,7 @@ from pydicom.datadict import (tag_for_keyword, keyword_for_tag,
 from pydicom.tag import Tag, BaseTag, tag_in_exception
 from pydicom.dataelem import DataElement, DataElement_from_raw, RawDataElement
 from pydicom.uid import UncompressedPixelTransferSyntaxes
-import pydicom  # for write_file
+import pydicom  # for dcmwrite
 import pydicom.charset
 from pydicom.config import logger
 import pydicom.config
@@ -834,7 +834,7 @@ class Dataset(dict):
         DICOM File Format in accordance with DICOM Standard Part 10 Section 7.
         To do so requires that the `Dataset.file_meta` attribute exists and
         contains a Dataset with the required (Type 1) File Meta Information
-        Group elements (see pydicom.filewriter.write_file and
+        Group elements (see pydicom.filewriter.dcmwrite and
         pydicom.filewriter.write_file_meta_info for more information).
 
         If `write_like_original` is True then the Dataset will be written as is
@@ -870,7 +870,7 @@ class Dataset(dict):
             Write a DICOM Dataset to a file.
         pydicom.filewriter.write_file_meta_info
             Write the DICOM File Meta Information Group elements to a file.
-        pydicom.filewriter.write_file
+        pydicom.filewriter.dcmwrite
             Write a DICOM file from a FileDataset instance.
         """
         # Ensure is_little_endian and is_implicit_VR exist
@@ -881,7 +881,7 @@ class Dataset(dict):
                                  "set appropriately before "
                                  "saving.".format(self.__class__.__name__))
 
-        pydicom.write_file(filename, self, write_like_original)
+        pydicom.dcmwrite(filename, self, write_like_original)
 
     def __setattr__(self, name, value):
         """Intercept any attempts to set a value for an instance attribute.

--- a/pydicom/dicomio.py
+++ b/pydicom/dicomio.py
@@ -1,4 +1,4 @@
 # dicomio.py
 """Many point of entry for pydicom read and write functions"""
-from pydicom.filereader import (read_file, read_dicomdir)
+from pydicom.filereader import (dcmread, read_file, read_dicomdir)
 from pydicom.filewriter import write_file

--- a/pydicom/dicomio.py
+++ b/pydicom/dicomio.py
@@ -1,4 +1,4 @@
 # dicomio.py
 """Many point of entry for pydicom read and write functions"""
 from pydicom.filereader import (dcmread, read_file, read_dicomdir)
-from pydicom.filewriter import write_file
+from pydicom.filewriter import dcmwrite, write_file

--- a/pydicom/errors.py
+++ b/pydicom/errors.py
@@ -17,7 +17,7 @@ class InvalidDicomError(Exception):
     have this.)
 
     To force reading the file (because maybe it is a dicom file without
-    a header), use read_file(..., force=True).
+    a header), use dcmread(..., force=True).
     """
 
     def __init__(self, *args):

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -823,6 +823,7 @@ def dcmread(fp, defer_size=None, stop_before_pixels=False,
     # XXX need to store transfer syntax etc.
     return dataset
 
+
 read_file = dcmread  # used read_file until pydicom 1.0. Kept for compatibility
 
 

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -720,7 +720,7 @@ def read_partial(fileobj, stop_when=None, defer_size=None,
 
 
 def dcmread(fp, defer_size=None, stop_before_pixels=False,
-              force=False, specific_tags=None):
+            force=False, specific_tags=None):
     """Read and parse a DICOM dataset stored in the DICOM File Format.
 
     Read a DICOM dataset stored in accordance with the DICOM File Format
@@ -824,6 +824,7 @@ def dcmread(fp, defer_size=None, stop_before_pixels=False,
     return dataset
 
 read_file = dcmread  # used read_file until pydicom 1.0. Kept for compatibility
+
 
 def read_dicomdir(filename="DICOMDIR"):
     """Read a DICOMDIR file and return a DicomDir instance.

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -86,11 +86,11 @@ def data_element_generator(fp,
         and returns True or False. If it returns True,
         read_data_element will just return.
     defer_size : int, str, None, optional
-        See ``read_file`` for parameter info.
+        See ``dcmread`` for parameter info.
     encoding :
         Encoding scheme
     specific_tags : list or None
-        See ``read_file`` for parameter info.
+        See ``dcmread`` for parameter info.
 
     Returns
     -------
@@ -323,12 +323,12 @@ def read_dataset(fp, is_implicit_VR, is_little_endian, bytelength=None,
         See help for data_element_generator for details
     defer_size : int, None, optional
         Size to avoid loading large elements in memory.
-        See ``read_file`` for more parameter info.
+        See ``dcmread`` for more parameter info.
     parent_encoding :
         optional encoding to use as a default in case
         a Specific Character Set (0008,0005) isn't specified
     specific_tags : list or None
-        See ``read_file`` for parameter info.
+        See ``dcmread`` for parameter info.
 
     Returns
     -------
@@ -604,15 +604,15 @@ def read_partial(fileobj, stop_when=None, defer_size=None,
     stop_when :
         Stop condition. See ``read_dataset`` for more info.
     defer_size : int, str, None, optional
-        See ``read_file`` for parameter info.
+        See ``dcmread`` for parameter info.
     force : boolean
-        See ``read_file`` for parameter info.
+        See ``dcmread`` for parameter info.
     specific_tags : list or None
-        See ``read_file`` for parameter info.
+        See ``dcmread`` for parameter info.
 
     Notes
     -----
-    Use ``read_file`` unless you need to stop on some condition other than
+    Use ``dcmread`` unless you need to stop on some condition other than
     reaching pixel data.
 
     Returns
@@ -621,7 +621,7 @@ def read_partial(fileobj, stop_when=None, defer_size=None,
 
     See Also
     --------
-    read_file
+    dcmread
         More generic file reading function.
     """
     # Read File Meta Information
@@ -719,7 +719,7 @@ def read_partial(fileobj, stop_when=None, defer_size=None,
                            is_implicit_VR, is_little_endian)
 
 
-def read_file(fp, defer_size=None, stop_before_pixels=False,
+def dcmread(fp, defer_size=None, stop_before_pixels=False,
               force=False, specific_tags=None):
     """Read and parse a DICOM dataset stored in the DICOM File Format.
 
@@ -772,15 +772,15 @@ def read_file(fp, defer_size=None, stop_before_pixels=False,
     Examples
     --------
     Read and return a dataset stored in accordance with the DICOM File Format
-    >>> ds = pydicom.read_file("rtplan.dcm")
+    >>> ds = pydicom.dcmread("rtplan.dcm")
     >>> ds.PatientName
 
     Read and return a dataset not in accordance with the DICOM File Format
-    >>> ds = pydicom.read_file("rtplan.dcm", force=True)
+    >>> ds = pydicom.dcmread("rtplan.dcm", force=True)
     >>> ds.PatientName
 
     Use within a context manager:
-    >>> with pydicom.read_file("rtplan.dcm") as ds:
+    >>> with pydicom.dcmread("rtplan.dcm") as ds:
     >>>     ds.PatientName
     """
     # Open file if not already a file object
@@ -796,7 +796,7 @@ def read_file(fp, defer_size=None, stop_before_pixels=False,
 
     if config.debugging:
         logger.debug("\n" + "-" * 80)
-        logger.debug("Call to read_file()")
+        logger.debug("Call to dcmread()")
         msg = ("filename:'%s', defer_size='%s', "
                "stop_before_pixels=%s, force=%s, specific_tags=%s")
         logger.debug(msg % (fp.name, defer_size, stop_before_pixels,
@@ -823,11 +823,12 @@ def read_file(fp, defer_size=None, stop_before_pixels=False,
     # XXX need to store transfer syntax etc.
     return dataset
 
+read_file = dcmread  # used read_file until pydicom 1.0. Kept for compatibility
 
 def read_dicomdir(filename="DICOMDIR"):
     """Read a DICOMDIR file and return a DicomDir instance.
 
-    This is a wrapper around read_file, which gives a default file name.
+    This is a wrapper around dcmread, which gives a default file name.
 
     Parameters
     ----------
@@ -843,10 +844,10 @@ def read_dicomdir(filename="DICOMDIR"):
     InvalidDicomError
         Raised if filename is not a DICOMDIR file.
     """
-    # read_file will return a DicomDir instance if file is one.
+    # dcmread will return a DicomDir instance if file is one.
 
     # Read the file as usual.
-    ds = read_file(filename)
+    ds = dcmread(filename)
     # Here, check that it is in fact DicomDir
     if not isinstance(ds, DicomDir):
         msg = u"File '{0}' is not a Media Storage Directory file".format(

--- a/pydicom/fileutil.py
+++ b/pydicom/fileutil.py
@@ -112,7 +112,7 @@ def read_undefined_length_value(fp,
         tag used as and marker for reading
     defer_size : int, None, optional
         Size to avoid loading large elements in memory.
-        See ``filereader.read_file`` for more parameter info.
+        See ``filereader.dcmread`` for more parameter info.
     read_size : int
         Number of bytes to read at one time.
 

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -641,7 +641,7 @@ def write_file_meta_info(fp, file_meta, enforce_standard=True):
         fp.seek(end_of_file_meta)
 
 
-def write_file(filename, dataset, write_like_original=True):
+def dcmwrite(filename, dataset, write_like_original=True):
     """Write `dataset` to the `filename` specified.
 
     If `write_like_original` is True then `dataset` will be written as is
@@ -747,7 +747,7 @@ def write_file(filename, dataset, write_like_original=True):
         Dataset class with relevant attributes and information.
     pydicom.dataset.Dataset.save_as
         Write a DICOM file from a dataset that was read in with dcmread().
-        save_as wraps write_file.
+        save_as wraps dcmwrite.
     """
     # Check that dataset's group 0x0002 elements are only present in the
     #   `dataset.file_meta` Dataset - user may have added them to the wrong
@@ -837,6 +837,8 @@ def write_file(filename, dataset, write_like_original=True):
         if not caller_owns_file:
             fp.close()
 
+
+write_file = dcmwrite  # write_file before pydicom 1.0, kept for compatibility
 
 # Map each VR to a function which can write it
 # for write_numbers, the Writer maps to a tuple (function, struct_format)

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -723,7 +723,7 @@ def write_file(filename, dataset, write_like_original=True):
         Name of file or the file-like to write the new DICOM file to.
     dataset : pydicom.dataset.FileDataset
         Dataset holding the DICOM information; e.g. an object read with
-        pydicom.read_file().
+        pydicom.dcmread().
     write_like_original : bool
         If True (default), preserves the following information from
         the Dataset (and may result in a non-conformant file):
@@ -746,7 +746,7 @@ def write_file(filename, dataset, write_like_original=True):
     pydicom.dataset.FileDataset
         Dataset class with relevant attributes and information.
     pydicom.dataset.Dataset.save_as
-        Write a DICOM file from a dataset that was read in with read_file().
+        Write a DICOM file from a dataset that was read in with dcmread().
         save_as wraps write_file.
     """
     # Check that dataset's group 0x0002 elements are only present in the

--- a/pydicom/misc.py
+++ b/pydicom/misc.py
@@ -10,7 +10,7 @@ _size_factors = dict(KB=1024, MB=1024 * 1024, GB=1024 * 1024 * 1024)
 
 
 def size_in_bytes(expr):
-    """Return the number of bytes for a defer_size argument to read_file()
+    """Return the number of bytes for a defer_size argument to dcmread()
     """
     if expr is None:
         return None

--- a/pydicom/tests/performance/raw_convert_test.py
+++ b/pydicom/tests/performance/raw_convert_test.py
@@ -20,7 +20,7 @@ write_filename = "/tmp/write_test.dcm"
 
 @pytest.mark.skip(reason="This is not an actual pytest test")
 def test_full_read(filename):
-    dataset = pydicom.read_file(filename)
+    dataset = pydicom.dcmread(filename)
     return dataset
 
 

--- a/pydicom/tests/performance/time_test.py
+++ b/pydicom/tests/performance/time_test.py
@@ -79,7 +79,7 @@ reason = "%s Need at least 400 files in %s" % (reason, str(locations))
 @pytest.mark.skipif(len(filenames) < 400,
                     reason=reason)
 def test_full_read():
-    rf = pydicom.read_file
+    rf = pydicom.dcmread
     datasets = [rf(fn) for fn in filenames1]
     return datasets
 
@@ -94,7 +94,7 @@ def test_partial():
 @pytest.mark.skipif(len(filenames) < 400,
                     reason=reason)
 def test_mem_read_full():
-    rf = pydicom.read_file
+    rf = pydicom.dcmread
     str_io = BytesIO
     memory_files = (str_io(open(fn, 'rb').read()) for fn in filenames3)
     [rf(memory_file) for memory_file in memory_files]
@@ -103,7 +103,7 @@ def test_mem_read_full():
 @pytest.mark.skipif(len(filenames) < 400,
                     reason=reason)
 def test_mem_read_small():
-    rf = pydicom.read_file
+    rf = pydicom.dcmread
     str_io = BytesIO  # avoid global lookup, make local instead
     memory_files = (str_io(open(fn, 'rb').read(4000)) for fn in filenames4)
     [rf(memory_file) for memory_file in memory_files]

--- a/pydicom/tests/test_JPEG_LS_transfer_syntax.py
+++ b/pydicom/tests/test_JPEG_LS_transfer_syntax.py
@@ -3,7 +3,7 @@ import sys
 import re
 import pytest
 import pydicom
-from pydicom.filereader import read_file
+from pydicom.filereader import dcmread
 from pydicom.data import get_testdata_files
 
 pillow_missing_message = ("pillow is not available "
@@ -52,10 +52,10 @@ save_dir = os.getcwd()
 
 class Test_JPEG_LS_Lossless_transfer_syntax():
     def setup_method(self, method):
-        self.jpeg_ls_lossless = read_file(jpeg_ls_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_ls_lossless = read_file(emri_jpeg_ls_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
 
     def teardown_method(self, method):

--- a/pydicom/tests/test_RLE_transfer_syntax.py
+++ b/pydicom/tests/test_RLE_transfer_syntax.py
@@ -3,7 +3,7 @@ import sys
 import re
 import pytest
 import pydicom
-from pydicom.filereader import read_file
+from pydicom.filereader import dcmread
 from pydicom.data import get_testdata_files
 
 pillow_missing_message = ("pillow is not available "
@@ -51,10 +51,10 @@ save_dir = os.getcwd()
 
 class Test_RLE_transfer_syntax():
     def setup_method(self, method):
-        self.mr = read_file(mr_name)
-        self.compressed_mr = read_file(compressed_mr_name)
-        self.emri = read_file(emri_name)
-        self.compressed_emri = read_file(compressed_emri_name)
+        self.mr = dcmread(mr_name)
+        self.compressed_mr = dcmread(compressed_mr_name)
+        self.emri = dcmread(emri_name)
+        self.compressed_emri = dcmread(compressed_emri_name)
         self.original_handlers = pydicom.config.image_handlers
 
     def teardown_method(self, method):

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -23,7 +23,7 @@ normal_file = get_testdata_files("CT_small.dcm")[0]
 class charsetTests(unittest.TestCase):
     def testLatin1(self):
         """charset: can read and decode latin_1 file........................"""
-        ds = dicomio.read_file(latin1_file)
+        ds = dicomio.dcmread(latin1_file)
         ds.decode()
         # Make sure don't get unicode encode error on converting to string
         expected = u'Buc^J\xe9r\xf4me'
@@ -44,7 +44,7 @@ class charsetTests(unittest.TestCase):
 
     def testNestedCharacterSets(self):
         """charset: can read and decode SQ with different encodings........."""
-        ds = dicomio.read_file(sq_encoding_file)
+        ds = dicomio.dcmread(sq_encoding_file)
         ds.decode()
 
         # These datasets inside of the SQ cannot be decoded with
@@ -62,23 +62,23 @@ class charsetTests(unittest.TestCase):
 
     def testStandardFile(self):
         """charset: can read and decode standard file without special char.."""
-        ds = dicomio.read_file(normal_file)
+        ds = dicomio.dcmread(normal_file)
         ds.decode()
 
     def testExplicitISO2022_IR6(self):
         """charset: can decode file with multi-valued data elements........."""
-        ds = dicomio.read_file(explicit_ir6_file)
+        ds = dicomio.dcmread(explicit_ir6_file)
         ds.decode()
 
     def testMultiPN(self):
         """charset: can decode file with multi-valued data elements........."""
-        ds = dicomio.read_file(multiPN_file)
+        ds = dicomio.dcmread(multiPN_file)
         ds.decode()
 
     def testEncodingWithSpecificTags(self):
         """Encoding is correctly applied even if  Specific Character Set
         is not in specific tags..."""
-        ds = dicomio.read_file(jp_file, specific_tags=['PatientName'])
+        ds = dicomio.dcmread(jp_file, specific_tags=['PatientName'])
         ds.decode()
         self.assertEqual(1, len(ds))
         expected = ('Yamada^Tarou='

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -10,7 +10,7 @@ from pydicom import compat
 from pydicom.data import get_testdata_files
 from pydicom.dataelem import DataElement, RawDataElement
 from pydicom.dataset import Dataset, FileDataset
-from pydicom.dicomio import read_file
+from pydicom.dicomio import dcmread
 from pydicom.filebase import DicomBytesIO
 from pydicom.sequence import Sequence
 from pydicom.tag import Tag
@@ -766,8 +766,8 @@ class DatasetTests(unittest.TestCase):
 
         # Test deferred read
         test_file = get_testdata_files('MR_small.dcm')[0]
-        ds = read_file(test_file, force=True, defer_size='0.8 kB')
-        ds_ref = read_file(test_file, force=True)
+        ds = dcmread(test_file, force=True, defer_size='0.8 kB')
+        ds_ref = dcmread(test_file, force=True)
         # get_item will follow the deferred read branch
         assert ds.get_item((0x7fe00010)).value == ds_ref.PixelData
 
@@ -853,7 +853,7 @@ class DatasetTests(unittest.TestCase):
     def test_with(self):
         """Test Dataset.__enter__ and __exit__."""
         test_file = get_testdata_files('CT_small.dcm')[0]
-        with read_file(test_file) as ds:
+        with dcmread(test_file) as ds:
             assert ds.PatientName == 'CompressedSamples^CT1'
 
     def test_exit_exception(self):
@@ -917,7 +917,7 @@ class DatasetTests(unittest.TestCase):
     def test_set_convert_private_elem_from_raw(self):
         """Test Dataset.__setitem__ with a raw private element"""
         test_file = get_testdata_files('CT_small.dcm')[0]
-        ds = read_file(test_file, force=True)
+        ds = dcmread(test_file, force=True)
         # 'tag VR length value value_tell is_implicit_VR is_little_endian'
         elem = RawDataElement((0x0043, 0x1029), 'OB', 2, b'\x00\x01', 0,
                               True, True)
@@ -938,7 +938,7 @@ class DatasetTests(unittest.TestCase):
     def test_trait_names(self):
         """Test Dataset.trait_names contains element keywords"""
         test_file = get_testdata_files('CT_small.dcm')[0]
-        ds = read_file(test_file, force=True)
+        ds = dcmread(test_file, force=True)
         names = ds.trait_names()
         assert 'PatientName' in names
         assert 'save_as' in names
@@ -993,8 +993,8 @@ class FileDatasetTests(unittest.TestCase):
 
     def test_equality_file_meta(self):
         """Dataset: equality returns correct value if with metadata"""
-        d = read_file(self.test_file)
-        e = read_file(self.test_file)
+        d = dcmread(self.test_file)
+        e = dcmread(self.test_file)
         self.assertTrue(d == e)
 
         e.is_implicit_VR = not e.is_implicit_VR

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -6,7 +6,7 @@ import tempfile
 import shutil
 import pytest
 import pydicom
-from pydicom.filereader import read_file
+from pydicom.filereader import dcmread
 from pydicom.data import get_testdata_files
 from pydicom.tag import Tag
 from pydicom import compat
@@ -81,10 +81,10 @@ class GDCM_JPEG_LS_Tests_no_gdcm(unittest.TestCase):
             self.unicode_filename = os.path.join(
                 tempfile.gettempdir(), "ДИКОМ.dcm")
             shutil.copyfile(jpeg_ls_lossless_name, self.unicode_filename)
-        self.jpeg_ls_lossless = read_file(self.unicode_filename)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_ls_lossless = read_file(emri_jpeg_ls_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_ls_lossless = dcmread(self.unicode_filename)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None]
 
@@ -103,11 +103,11 @@ class GDCM_JPEG_LS_Tests_no_gdcm(unittest.TestCase):
 
 class GDCM_JPEG2000Tests_no_gdcm(unittest.TestCase):
     def setUp(self):
-        self.jpeg_2k = read_file(jpeg2000_name)
-        self.jpeg_2k_lossless = read_file(jpeg2000_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_2k_lossless = read_file(emri_jpeg_2k_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_2k = dcmread(jpeg2000_name)
+        self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None]
 
@@ -145,8 +145,8 @@ class GDCM_JPEG2000Tests_no_gdcm(unittest.TestCase):
 class GDCM_JPEGlossyTests_no_gdcm(unittest.TestCase):
 
     def setUp(self):
-        self.jpeg_lossy = read_file(jpeg_lossy_name)
-        self.color_3d_jpeg = read_file(color_3d_jpeg_baseline)
+        self.jpeg_lossy = dcmread(jpeg_lossy_name)
+        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None]
 
@@ -174,7 +174,7 @@ class GDCM_JPEGlossyTests_no_gdcm(unittest.TestCase):
 
 class GDCM_JPEGlosslessTests_no_gdcm(unittest.TestCase):
     def setUp(self):
-        self.jpeg_lossless = read_file(jpeg_lossless_name)
+        self.jpeg_lossless = dcmread(jpeg_lossless_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None]
 
@@ -213,10 +213,10 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
             self.unicode_filename = os.path.join(
                 tempfile.gettempdir(), "ДИКОМ.dcm")
             shutil.copyfile(jpeg_ls_lossless_name, self.unicode_filename)
-        self.jpeg_ls_lossless = read_file(self.unicode_filename)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_ls_lossless = read_file(emri_jpeg_ls_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_ls_lossless = dcmread(self.unicode_filename)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [numpy_handler, gdcm_handler]
 
@@ -247,11 +247,11 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
 @pytest.mark.skipif(not test_gdcm_decoder, reason=gdcm_missing_message)
 class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
     def setUp(self):
-        self.jpeg_2k = read_file(jpeg2000_name)
-        self.jpeg_2k_lossless = read_file(jpeg2000_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_2k_lossless = read_file(emri_jpeg_2k_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_2k = dcmread(jpeg2000_name)
+        self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [numpy_handler, gdcm_handler]
 
@@ -301,8 +301,8 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
 class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
 
     def setUp(self):
-        self.jpeg_lossy = read_file(jpeg_lossy_name)
-        self.color_3d_jpeg = read_file(color_3d_jpeg_baseline)
+        self.jpeg_lossy = dcmread(jpeg_lossy_name)
+        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [numpy_handler, gdcm_handler]
 
@@ -338,7 +338,7 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
 @pytest.mark.skipif(not test_gdcm_decoder, reason=gdcm_missing_message)
 class GDCM_JPEGlosslessTests_with_gdcm(unittest.TestCase):
     def setUp(self):
-        self.jpeg_lossless = read_file(jpeg_lossless_name)
+        self.jpeg_lossless = dcmread(jpeg_lossless_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [numpy_handler, gdcm_handler]
 

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -3,7 +3,7 @@ import os
 import sys
 import pytest
 import pydicom
-from pydicom.filereader import read_file
+from pydicom.filereader import dcmread
 from pydicom.data import get_testdata_files
 jpeg_ls_missing_message = ("jpeg_ls is not available "
                            "in this test environment")
@@ -67,10 +67,10 @@ save_dir = os.getcwd()
 
 class jpeg_ls_JPEG_LS_Tests_no_jpeg_ls(unittest.TestCase):
     def setUp(self):
-        self.jpeg_ls_lossless = read_file(jpeg_ls_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_ls_lossless = read_file(emri_jpeg_ls_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None, numpy_handler]
 
@@ -84,11 +84,11 @@ class jpeg_ls_JPEG_LS_Tests_no_jpeg_ls(unittest.TestCase):
 
 class jpeg_ls_JPEG2000Tests_no_jpeg_ls(unittest.TestCase):
     def setUp(self):
-        self.jpeg_2k = read_file(jpeg2000_name)
-        self.jpeg_2k_lossless = read_file(jpeg2000_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_2k_lossless = read_file(emri_jpeg_2k_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_2k = dcmread(jpeg2000_name)
+        self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None, numpy_handler]
 
@@ -109,8 +109,8 @@ class jpeg_ls_JPEG2000Tests_no_jpeg_ls(unittest.TestCase):
 class jpeg_ls_JPEGlossyTests_no_jpeg_ls(unittest.TestCase):
 
     def setUp(self):
-        self.jpeg_lossy = read_file(jpeg_lossy_name)
-        self.color_3d_jpeg = read_file(color_3d_jpeg_baseline)
+        self.jpeg_lossy = dcmread(jpeg_lossy_name)
+        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None, numpy_handler]
 
@@ -139,7 +139,7 @@ class jpeg_ls_JPEGlossyTests_no_jpeg_ls(unittest.TestCase):
 
 class jpeg_ls_JPEGlosslessTests_no_jpeg_ls(unittest.TestCase):
     def setUp(self):
-        self.jpeg_lossless = read_file(jpeg_lossless_name)
+        self.jpeg_lossless = dcmread(jpeg_lossless_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None, numpy_handler]
 
@@ -170,10 +170,10 @@ class jpeg_ls_JPEGlosslessTests_no_jpeg_ls(unittest.TestCase):
     reason=jpeg_ls_missing_message)
 class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
     def setUp(self):
-        self.jpeg_ls_lossless = read_file(jpeg_ls_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_ls_lossless = read_file(emri_jpeg_ls_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [jpeg_ls_handler, numpy_handler]
 
@@ -204,11 +204,11 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
     reason=jpeg_ls_missing_message)
 class jpeg_ls_JPEG2000Tests_with_jpeg_ls(unittest.TestCase):
     def setUp(self):
-        self.jpeg_2k = read_file(jpeg2000_name)
-        self.jpeg_2k_lossless = read_file(jpeg2000_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_2k_lossless = read_file(emri_jpeg_2k_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_2k = dcmread(jpeg2000_name)
+        self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [jpeg_ls_handler, numpy_handler]
 
@@ -230,8 +230,8 @@ class jpeg_ls_JPEG2000Tests_with_jpeg_ls(unittest.TestCase):
 class jpeg_ls_JPEGlossyTests_with_jpeg_ls(unittest.TestCase):
 
     def setUp(self):
-        self.jpeg_lossy = read_file(jpeg_lossy_name)
-        self.color_3d_jpeg = read_file(color_3d_jpeg_baseline)
+        self.jpeg_lossy = dcmread(jpeg_lossy_name)
+        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [jpeg_ls_handler, numpy_handler]
 
@@ -262,7 +262,7 @@ class jpeg_ls_JPEGlossyTests_with_jpeg_ls(unittest.TestCase):
     reason=jpeg_ls_missing_message)
 class jpeg_ls_JPEGlosslessTests_with_jpeg_ls(unittest.TestCase):
     def setUp(self):
-        self.jpeg_lossless = read_file(jpeg_lossless_name)
+        self.jpeg_lossless = dcmread(jpeg_lossless_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [jpeg_ls_handler, numpy_handler]
 

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -3,7 +3,7 @@ import os
 import sys
 import pytest
 import pydicom
-from pydicom.filereader import read_file
+from pydicom.filereader import dcmread
 from pydicom.data import get_testdata_files
 from pydicom.tag import Tag
 numpy_missing_message = ("numpy is not available "
@@ -60,10 +60,10 @@ save_dir = os.getcwd()
 
 class numpy_JPEG_LS_Tests_no_numpy(unittest.TestCase):
     def setUp(self):
-        self.jpeg_ls_lossless = read_file(jpeg_ls_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_ls_lossless = read_file(emri_jpeg_ls_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None]
 
@@ -82,8 +82,8 @@ class numpy_JPEG_LS_Tests_no_numpy(unittest.TestCase):
 
 class numpy_BigEndian_Tests_no_numpy(unittest.TestCase):
     def setUp(self):
-        self.emri_big_endian = read_file(emri_big_endian_name)
-        self.emri_small = read_file(emri_name)
+        self.emri_big_endian = dcmread(emri_big_endian_name)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None]
 
@@ -97,11 +97,11 @@ class numpy_BigEndian_Tests_no_numpy(unittest.TestCase):
 
 class numpy_JPEG2000Tests_no_numpy(unittest.TestCase):
     def setUp(self):
-        self.jpeg_2k = read_file(jpeg2000_name)
-        self.jpeg_2k_lossless = read_file(jpeg2000_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_2k_lossless = read_file(emri_jpeg_2k_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_2k = dcmread(jpeg2000_name)
+        self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None]
 
@@ -141,8 +141,8 @@ class numpy_JPEG2000Tests_no_numpy(unittest.TestCase):
 class numpy_JPEGlossyTests_no_numpy(unittest.TestCase):
 
     def setUp(self):
-        self.jpeg = read_file(jpeg_lossy_name)
-        self.color_3d_jpeg = read_file(color_3d_jpeg_baseline)
+        self.jpeg = dcmread(jpeg_lossy_name)
+        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None]
 
@@ -171,7 +171,7 @@ class numpy_JPEGlossyTests_no_numpy(unittest.TestCase):
 
 class numpy_JPEGlosslessTests_no_numpy(unittest.TestCase):
     def setUp(self):
-        self.jpeg = read_file(jpeg_lossless_name)
+        self.jpeg = dcmread(jpeg_lossless_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None]
 
@@ -202,10 +202,10 @@ class numpy_JPEGlosslessTests_no_numpy(unittest.TestCase):
     reason=numpy_missing_message)
 class numpy_JPEG_LS_Tests_with_numpy(unittest.TestCase):
     def setUp(self):
-        self.jpeg_ls_lossless = read_file(jpeg_ls_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_ls_lossless = read_file(emri_jpeg_ls_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [numpy_handler]
 
@@ -227,8 +227,8 @@ class numpy_JPEG_LS_Tests_with_numpy(unittest.TestCase):
     reason=numpy_missing_message)
 class numpy_BigEndian_Tests_with_numpy(unittest.TestCase):
     def setUp(self):
-        self.emri_big_endian = read_file(emri_big_endian_name)
-        self.emri_small = read_file(emri_name)
+        self.emri_big_endian = dcmread(emri_big_endian_name)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [numpy_handler]
 
@@ -250,11 +250,11 @@ class numpy_BigEndian_Tests_with_numpy(unittest.TestCase):
     reason=numpy_missing_message)
 class numpy_JPEG2000Tests_with_numpy(unittest.TestCase):
     def setUp(self):
-        self.jpeg_2k = read_file(jpeg2000_name)
-        self.jpeg_2k_lossless = read_file(jpeg2000_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_2k_lossless = read_file(emri_jpeg_2k_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_2k = dcmread(jpeg2000_name)
+        self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [numpy_handler]
 
@@ -295,8 +295,8 @@ class numpy_JPEG2000Tests_with_numpy(unittest.TestCase):
 class numpy_JPEGlossyTests_with_numpy(unittest.TestCase):
 
     def setUp(self):
-        self.jpeg = read_file(jpeg_lossy_name)
-        self.color_3d_jpeg = read_file(color_3d_jpeg_baseline)
+        self.jpeg = dcmread(jpeg_lossy_name)
+        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [numpy_handler]
 
@@ -327,7 +327,7 @@ class numpy_JPEGlossyTests_with_numpy(unittest.TestCase):
     reason=numpy_missing_message)
 class numpy_JPEGlosslessTests_with_numpy(unittest.TestCase):
     def setUp(self):
-        self.jpeg = read_file(jpeg_lossless_name)
+        self.jpeg = dcmread(jpeg_lossless_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [numpy_handler]
 

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -3,7 +3,7 @@ import os
 import sys
 import pytest
 import pydicom
-from pydicom.filereader import read_file
+from pydicom.filereader import dcmread
 from pydicom.data import get_testdata_files
 from pydicom.tag import Tag
 pillow_missing_message = ("pillow is not available "
@@ -77,10 +77,10 @@ save_dir = os.getcwd()
 
 class pillow_JPEG_LS_Tests_no_pillow(unittest.TestCase):
     def setUp(self):
-        self.jpeg_ls_lossless = read_file(jpeg_ls_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_ls_lossless = read_file(emri_jpeg_ls_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None, numpy_handler]
 
@@ -98,11 +98,11 @@ class pillow_JPEG_LS_Tests_no_pillow(unittest.TestCase):
 
 class pillow_JPEG2000Tests_no_pillow(unittest.TestCase):
     def setUp(self):
-        self.jpeg_2k = read_file(jpeg2000_name)
-        self.jpeg_2k_lossless = read_file(jpeg2000_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_2k_lossless = read_file(emri_jpeg_2k_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_2k = dcmread(jpeg2000_name)
+        self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None, numpy_handler]
 
@@ -140,8 +140,8 @@ class pillow_JPEG2000Tests_no_pillow(unittest.TestCase):
 class pillow_JPEGlossyTests_no_pillow(unittest.TestCase):
 
     def setUp(self):
-        self.jpeg_lossy = read_file(jpeg_lossy_name)
-        self.color_3d_jpeg = read_file(color_3d_jpeg_baseline)
+        self.jpeg_lossy = dcmread(jpeg_lossy_name)
+        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None, numpy_handler]
 
@@ -169,7 +169,7 @@ class pillow_JPEGlossyTests_no_pillow(unittest.TestCase):
 
 class pillow_JPEGlosslessTests_no_pillow(unittest.TestCase):
     def setUp(self):
-        self.jpeg_lossless = read_file(jpeg_lossless_name)
+        self.jpeg_lossless = dcmread(jpeg_lossless_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [None, numpy_handler]
 
@@ -199,10 +199,10 @@ class pillow_JPEGlosslessTests_no_pillow(unittest.TestCase):
     reason=pillow_missing_message)
 class pillow_JPEG_LS_Tests_with_pillow(unittest.TestCase):
     def setUp(self):
-        self.jpeg_ls_lossless = read_file(jpeg_ls_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_ls_lossless = read_file(emri_jpeg_ls_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [pillow_handler, numpy_handler]
 
@@ -223,11 +223,11 @@ class pillow_JPEG_LS_Tests_with_pillow(unittest.TestCase):
     reason=pillow_missing_message)
 class pillow_JPEG2000Tests_with_pillow(unittest.TestCase):
     def setUp(self):
-        self.jpeg_2k = read_file(jpeg2000_name)
-        self.jpeg_2k_lossless = read_file(jpeg2000_lossless_name)
-        self.mr_small = read_file(mr_name)
-        self.emri_jpeg_2k_lossless = read_file(emri_jpeg_2k_lossless)
-        self.emri_small = read_file(emri_name)
+        self.jpeg_2k = dcmread(jpeg2000_name)
+        self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
+        self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [pillow_handler, numpy_handler]
 
@@ -278,8 +278,8 @@ class pillow_JPEG2000Tests_with_pillow(unittest.TestCase):
 class pillow_JPEGlossyTests_with_pillow(unittest.TestCase):
 
     def setUp(self):
-        self.jpeg_lossy = read_file(jpeg_lossy_name)
-        self.color_3d_jpeg = read_file(color_3d_jpeg_baseline)
+        self.jpeg_lossy = dcmread(jpeg_lossy_name)
+        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [pillow_handler, numpy_handler]
 
@@ -313,7 +313,7 @@ class pillow_JPEGlossyTests_with_pillow(unittest.TestCase):
     reason=pillow_missing_message)
 class pillow_JPEGlosslessTests_with_pillow(unittest.TestCase):
     def setUp(self):
-        self.jpeg_lossless = read_file(jpeg_lossless_name)
+        self.jpeg_lossless = dcmread(jpeg_lossless_name)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [pillow_handler, numpy_handler]
 

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 import pydicom
 import pydicom.config
-from pydicom.filereader import read_file
+from pydicom.filereader import dcmread
 from pydicom.data import get_testdata_files
 
 rle_missing_message = ("RLE decoder (numpy based) is not available "
@@ -77,10 +77,10 @@ save_dir = os.getcwd()
     reason=rle_present_message)
 class rle_RLE_Tests_no_rle(unittest.TestCase):
     def setUp(self):
-        self.mr_small = read_file(mr_name)
-        self.mr_rle = read_file(mr_rle)
-        self.emri = read_file(emri_name)
-        self.emri_rle = read_file(emri_rle)
+        self.mr_small = dcmread(mr_name)
+        self.mr_rle = dcmread(mr_rle)
+        self.emri = dcmread(emri_name)
+        self.emri_rle = dcmread(emri_rle)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [rle_handler, numpy_handler]
 
@@ -98,10 +98,10 @@ class rle_RLE_Tests_no_rle(unittest.TestCase):
     reason=rle_missing_message)
 class rle_RLE_Tests_with_rle(unittest.TestCase):
     def setUp(self):
-        self.mr_small = read_file(mr_name)
-        self.mr_rle = read_file(mr_rle)
-        self.emri_small = read_file(emri_name)
-        self.emri_rle = read_file(emri_rle)
+        self.mr_small = dcmread(mr_name)
+        self.mr_rle = dcmread(mr_rle)
+        self.emri_small = dcmread(emri_name)
+        self.emri_rle = dcmread(emri_rle)
         self.original_handlers = pydicom.config.image_handlers
         pydicom.config.image_handlers = [rle_handler, numpy_handler]
 

--- a/pydicom/tests/test_unicode.py
+++ b/pydicom/tests/test_unicode.py
@@ -19,7 +19,7 @@ class UnicodeFilenames(unittest.TestCase):
             return
 
         try:
-            dicomio.read_file(uni_name)
+            dicomio.dcmread(uni_name)
         except UnicodeEncodeError:
             self.fail("UnicodeEncodeError generated for unicode name")
         # ignore file doesn't exist error

--- a/pydicom/util/codify.py
+++ b/pydicom/util/codify.py
@@ -247,7 +247,7 @@ def code_file(filename, exclude_size=None, include_private=False):
     """
     lines = []
 
-    ds = pydicom.read_file(filename, force=True)
+    ds = pydicom.dcmread(filename, force=True)
 
     # Code a nice header for the python file
     lines.append("# Coded version of DICOM file '{0}'".format(filename))


### PR DESCRIPTION
#### Reference Issue
Fixes #475

#### What does this implement/fix? Explain your changes.
Changes use of `read_file` (code, examples, doc strings) to `dcmread`.  Similarly for `write_file` becoming `dcmwrite`.  Old names are kept as an alias to new name by setting them in `filereader.py` and `filewrite.py` and importing into `__init__.py`.

#### Any other comments?
Was tempted to remove `dicomio` as seems an extra layer (it only has a couple of lines to import the names, nothing else), but left that for another discussion / PR.
