### PR TITLE
[MRG] Do not install already installed wheel package

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -90,7 +90,7 @@ elif [[ "$DISTRIB" == "pypy" ]]; then
     export PATH="$BIN_PATH:$PATH"
     # install pip
     python -m ensurepip
-    pip install -U pip wheel
+    pip install -U pip
     if [[ "$NUMPY" == "true" ]] && [[ "$PYTHON_VERSION" == "2.7" ]]; then
         python -m pip install git+https://bitbucket.org/pypy/numpy.git
     # numpypy does not work with pypy3 so fall back on numpy


### PR DESCRIPTION
- fixes #507

#### What does this implement/fix? Explain your changes.
Uninstalling the old wheel package while installing the new one caused a permission problem, probably because the package was in use. As wheel is already installed, there is no need to replace it. 