### PR TITLE
[MRG] Fix escape sequences that are deprecated in Python 3.6

### DIFF
--- a/pydicom/uid.py
+++ b/pydicom/uid.py
@@ -17,8 +17,8 @@ PYDICOM_ROOT_UID = '1.2.826.0.1.3680043.8.498.'
 PYDICOM_IMPLEMENTATION_UID = PYDICOM_ROOT_UID + '1'
 
 # Regexes for valid UIDs and valid UID prefixes
-RE_VALID_UID = '^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*$'
-RE_VALID_UID_PREFIX = '^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*\.$'
+RE_VALID_UID = r'^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*$'
+RE_VALID_UID_PREFIX = r'^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*\.$'
 
 
 class UID(str):

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -31,9 +31,9 @@ extra_length_VRs = ('OB', 'OD', 'OF', 'OL', 'OW', 'SQ', 'UC', 'UN', 'UR', 'UT')
 text_VRs = ('SH', 'LO', 'ST', 'LT', 'UC', 'UR', 'UT')
 
 match_string = b''.join([
-    b'(?P<single_byte>', b'(?P<family_name>[^=\^]*)',
-    b'\^?(?P<given_name>[^=\^]*)', b'\^?(?P<middle_name>[^=\^]*)',
-    b'\^?(?P<name_prefix>[^=\^]*)', b'\^?(?P<name_suffix>[^=\^]*)', b')',
+    b'(?P<single_byte>', br'(?P<family_name>[^=\^]*)',
+    br'\^?(?P<given_name>[^=\^]*)', br'\^?(?P<middle_name>[^=\^]*)',
+    br'\^?(?P<name_prefix>[^=\^]*)', br'\^?(?P<name_suffix>[^=\^]*)', b')',
     b'=?(?P<ideographic>[^=]*)', b'=?(?P<phonetic>[^=]*)$'
 ])
 


### PR DESCRIPTION
This PR fixes escape sequences that are deprecated in Python 3.6 by using raw strings/bytes.

https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior