### PR TITLE
[MRG+1] Implemented review comments for #465

### DIFF
--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -9,8 +9,7 @@ from __future__ import absolute_import
 
 # Need zlib and io.BytesIO for deflate-compressed file
 from io import BytesIO
-from os import stat
-import os.path
+import os
 from struct import (Struct, unpack)
 from sys import byteorder
 import warnings
@@ -943,8 +942,8 @@ def read_deferred_data_element(fileobj_type, filename, timestamp,
     if not os.path.exists(filename):
         raise IOError(u"Deferred read -- original file "
                       "{0:s} is missing".format(filename))
-    if stat is not None and (timestamp is not None):
-        statinfo = stat(filename)
+    if timestamp is not None:
+        statinfo = os.stat(filename)
         if statinfo.st_mtime != timestamp:
             warnings.warn("Deferred read warning -- file modification time "
                           "has changed.")

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -90,7 +90,6 @@ class CharsetTests(unittest.TestCase):
                     '\033$B$d$^$@\033(B^\033$B$?$m$&\033(B')
         self.assertEqual(expected, ds.PatientName)
 
-    @pytest.mark.skipif(not in_py2, reason='Fails with python3 due to #466')
     def test_bad_charset(self):
         """Test bad charset defaults to ISO IR 6"""
         # Python 3: elem.value is PersonName3, Python 2: elem.value is str

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1,7 +1,6 @@
 # Copyright 2008-2017 pydicom authors. See LICENSE file for details.
 """Tests for dataset.py"""
 
-import os
 import unittest
 
 import pytest
@@ -15,33 +14,6 @@ from pydicom.filebase import DicomBytesIO
 from pydicom.sequence import Sequence
 from pydicom.tag import Tag
 from pydicom.uid import ImplicitVRLittleEndian, JPEGBaseLineLossy8bit
-
-
-def assert_raises_regex(type_error, message, func, *args, **kwargs):
-    """Test a raised exception against an expected exception.
-
-    Parameters
-    ----------
-    type_error : Exception
-        The expected raised exception.
-    message : str
-        A string that will be used as a regex pattern to match against the
-        actual exception message. If using the actual expected message don't
-        forget to escape any regex special characters like '|', '(', ')', etc.
-    func : callable
-        The function that is expected to raise the exception.
-    args
-        The callable function `func`'s arguments.
-    kwargs
-        The callable function `func`'s keyword arguments.
-
-    Notes
-    -----
-    Taken from https://github.com/glemaitre/specio, BSD 3 license.
-    """
-    with pytest.raises(type_error) as excinfo:
-        func(*args, **kwargs)
-    excinfo.match(message)
 
 
 class DatasetTests(unittest.TestCase):
@@ -275,9 +247,9 @@ class DatasetTests(unittest.TestCase):
     def test_get_raises(self):
         """Test Dataset.get() raises exception when invalid Tag"""
         ds = self.dummy_dataset()
-        assert_raises_regex(TypeError,
-                            'Dataset.get key must be a string or tag',
-                            ds.get, (-0x0010, 0x0010))
+        with pytest.raises(TypeError,
+                           match='Dataset.get key must be a string or tag'):
+            ds.get(-0x0010, 0x0010)
 
     def testGetFromRaw(self):
         """Dataset: get(tag) returns same object as ds[tag] for raw element."""
@@ -881,9 +853,8 @@ class DatasetTests(unittest.TestCase):
             def test(self):
                 raise ValueError("Random ex message!")
 
-        assert_raises_regex(ValueError,
-                            "Random ex message!",
-                            getattr, DSException(), 'test')
+        with pytest.raises(ValueError, match="Random ex message!"):
+                    getattr(DSException(), 'test')
 
     def test_is_uncompressed_transfer_syntax(self):
         """Test Dataset._is_uncompressed_transfer_syntax"""

--- a/pydicom/tests/test_dicomdir.py
+++ b/pydicom/tests/test_dicomdir.py
@@ -12,33 +12,6 @@ from pydicom import read_file
 TEST_FILE = get_testdata_files('DICOMDIR')[0]
 
 
-def assert_raises_regex(type_error, message, func, *args, **kwargs):
-    """Test a raised exception against an expected exception.
-
-    Parameters
-    ----------
-    type_error : Exception
-        The expected raised exception.
-    message : str
-        A string that will be used as a regex pattern to match against the
-        actual exception message. If using the actual expected message don't
-        forget to escape any regex special characters like '|', '(', ')', etc.
-    func : callable
-        The function that is expected to raise the exception.
-    args
-        The callable function `func`'s arguments.
-    kwargs
-        The callable function `func`'s keyword arguments.
-
-    Notes
-    -----
-    Taken from https://github.com/glemaitre/specio, BSD 3 license.
-    """
-    with pytest.raises(type_error) as excinfo:
-        func(*args, **kwargs)
-    excinfo.match(message)
-
-
 class TestDicomDir(object):
     """Test dicomdir.DicomDir class"""
     def test_read_file(self):
@@ -49,30 +22,18 @@ class TestDicomDir(object):
     def test_invalid_sop_file_meta(self):
         """Test exception raised if SOP Class is not Media Storage Directory"""
         ds = read_file(get_testdata_files('CT_small.dcm')[0])
-        assert_raises_regex(InvalidDicomError,
-                            "SOP Class is not Media Storage "
-                            "Directory \(DICOMDIR\)",
-                            DicomDir,
-                            "some_name",
-                            ds,
-                            b'\x00' * 128,
-                            ds.file_meta,
-                            True,
-                            True)
+        with pytest.raises(InvalidDicomError,
+                           match="SOP Class is not Media Storage "
+                                 "Directory \(DICOMDIR\)"):
+            DicomDir("some_name", ds, b'\x00' * 128, ds.file_meta, True, True)
 
     def test_invalid_sop_no_file_meta(self):
         """Test exception raised if invalid sop class but no file_meta"""
         ds = read_file(get_testdata_files('CT_small.dcm')[0])
-        assert_raises_regex(AttributeError,
-                            "'DicomDir' object has no attribute "
-                            "'DirectoryRecordSequence'",
-                            DicomDir,
-                            "some_name",
-                            ds,
-                            b'\x00' * 128,
-                            None,
-                            True,
-                            True)
+        with pytest.raises(AttributeError,
+                           match="'DicomDir' object has no attribute "
+                                 "'DirectoryRecordSequence'"):
+            DicomDir("some_name", ds, b'\x00' * 128, None, True, True)
 
     def test_parse_records(self):
         """Test DicomDir.parse_records"""

--- a/pydicom/tests/test_encaps.py
+++ b/pydicom/tests/test_encaps.py
@@ -9,13 +9,6 @@ from pydicom.encaps import (generate_pixel_data_fragment, get_frame_offsets,
 from pydicom.filebase import DicomBytesIO
 
 
-def assert_raises_regex(type_error, message, func, *args, **kwargs):
-    """Taken from https://github.com/glemaitre/specio, BSD 3 license."""
-    with pytest.raises(type_error) as excinfo:
-        func(*args, **kwargs)
-    excinfo.match(message)
-
-
 class TestGetFrameOffsets(object):
     """Test encaps.get_frame_offsets"""
     def test_bad_tag(self):
@@ -26,10 +19,10 @@ class TestGetFrameOffsets(object):
                      b'\x01\x02\x03\x04\x05\x06\x07\x08'
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
-        assert_raises_regex(ValueError,
-                            "Unexpected tag '\(fffe, e100\)' when "
-                            "parsing the Basic Table Offset item.",
-                            get_frame_offsets, fp)
+        with pytest.raises(ValueError,
+                           match="Unexpected tag '\(fffe, e100\)' when "
+                                 "parsing the Basic Table Offset item."):
+            get_frame_offsets(fp)
 
     def test_bad_length_multiple(self):
         """Test raises exception if the item length is not a multiple of 4."""
@@ -39,10 +32,10 @@ class TestGetFrameOffsets(object):
                      b'\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A'
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
-        assert_raises_regex(ValueError,
-                            "The length of the Basic Offset Table item is not "
-                            "a multiple of 4.",
-                            get_frame_offsets, fp)
+        with pytest.raises(ValueError,
+                           match="The length of the Basic Offset Table item"
+                                 " is not a multiple of 4."):
+            get_frame_offsets(fp)
 
     def test_zero_length(self):
         """Test reading BOT with zero length"""
@@ -79,9 +72,9 @@ class TestGetFrameOffsets(object):
                      b'\x00\x00\x00\x00'
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = False
-        assert_raises_regex(ValueError,
-                            "'fp.is_little_endian' must be True",
-                            get_frame_offsets, fp)
+        with pytest.raises(ValueError,
+                           match="'fp.is_little_endian' must be True"):
+            get_frame_offsets(fp)
 
 
 class TestGeneratePixelDataFragment(object):
@@ -94,11 +87,11 @@ class TestGeneratePixelDataFragment(object):
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
         fragments = generate_pixel_data_fragment(fp)
-        assert_raises_regex(ValueError,
-                            "Undefined item length at offset 4 when "
-                            "parsing the encapsulated pixel data "
-                            "fragments.",
-                            next, fragments)
+        with pytest.raises(ValueError,
+                           match="Undefined item length at offset 4 when "
+                                 "parsing the encapsulated pixel data "
+                                 "fragments."):
+            next(fragments)
         pytest.raises(StopIteration, next, fragments)
 
     def test_item_sequence_delimiter(self):
@@ -131,11 +124,11 @@ class TestGeneratePixelDataFragment(object):
         fp.is_little_endian = True
         fragments = generate_pixel_data_fragment(fp)
         assert next(fragments) == b'\x01\x00\x00\x00'
-        assert_raises_regex(ValueError,
-                            "Unexpected tag '\(0010, 0010\)' at offset 12 "
-                            "when parsing the encapsulated pixel data "
-                            "fragment items.",
-                            next, fragments)
+        with pytest.raises(ValueError,
+                           match="Unexpected tag '\(0010, 0010\)' at offset "
+                                 "12 when parsing the encapsulated pixel data "
+                                 "fragment items."):
+            next(fragments)
         pytest.raises(StopIteration, next, fragments)
 
     def test_single_fragment_no_delimiter(self):
@@ -200,9 +193,9 @@ class TestGeneratePixelDataFragment(object):
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = False
         fragments = generate_pixel_data_fragment(fp)
-        assert_raises_regex(ValueError,
-                            "'fp.is_little_endian' must be True",
-                            next, fragments)
+        with pytest.raises(ValueError,
+                           match="'fp.is_little_endian' must be True"):
+            next(fragments)
         pytest.raises(StopIteration, next, fragments)
 
 
@@ -669,10 +662,10 @@ class TestReadItem(object):
                      b'\x00\x00\x00\x01'
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
-        assert_raises_regex(ValueError,
-                            "Encapsulated data fragment had Undefined Length"
-                            " at data position 0x4",
-                            read_item, fp)
+        with pytest.raises(ValueError,
+                           match="Encapsulated data fragment had Undefined "
+                                 "Length at data position 0x4"):
+            read_item(fp)
 
     def test_item_sequence_delimiter(self):
         """Test non-zero length seq delimiter reads correctly."""

--- a/pydicom/tests/test_errors.py
+++ b/pydicom/tests/test_errors.py
@@ -6,43 +6,21 @@ import pytest
 from pydicom.errors import InvalidDicomError
 
 
-def assert_raises_regex(type_error, message, func, *args, **kwargs):
-    """Test a raised exception against an expected exception.
-
-    Parameters
-    ----------
-    type_error : Exception
-        The expected raised exception.
-    message : str
-        A string that will be used as a regex pattern to match against the
-        actual exception message. If using the actual expected message don't
-        forget to escape any regex special characters like '|', '(', ')', etc.
-    func : callable
-        The function that is expected to raise the exception.
-    args
-        The callable function `func`'s arguments.
-    kwargs
-        The callable function `func`'s keyword arguments.
-
-    Notes
-    -----
-    Taken from https://github.com/glemaitre/specio, BSD 3 license.
-    """
-    with pytest.raises(type_error) as excinfo:
-        func(*args, **kwargs)
-    excinfo.match(message)
-
-
 def test_message():
     """Test InvalidDicomError with a message"""
+
     def _test():
         raise InvalidDicomError('test msg')
-    assert_raises_regex(InvalidDicomError, 'test msg', _test)
+    with pytest.raises(InvalidDicomError, match='test msg'):
+        _test()
 
 
 def test_no_message():
     """Test InvalidDicomError with no message"""
+
     def _test():
         raise InvalidDicomError
-    assert_raises_regex(InvalidDicomError,
-                        'The specified file is not a valid DICOM file.', _test)
+    with pytest.raises(InvalidDicomError,
+                       match='The specified file is not a valid DICOM '
+                             'file.'):
+        _test()

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # -*- coding: utf-8 -*-
 """unittest tests for pydicom.filereader module"""
 # Copyright (c) 2010-2012 Darcy Mason
@@ -9,8 +8,6 @@
 import gzip
 from io import BytesIO
 import os
-from os import stat
-import os.path
 from re import compile
 import shutil
 import sys
@@ -26,10 +23,7 @@ from pydicom.filereader import dcmread
 from pydicom.dataelem import DataElement, DataElement_from_raw
 from pydicom.errors import InvalidDicomError
 from pydicom.filebase import DicomBytesIO
-from pydicom.filereader import (read_file, data_element_generator,
-                                read_dataset, read_sequence,
-                                read_sequence_item, read_file_meta_info,
-                                read_dicomdir)
+from pydicom.filereader import data_element_generator
 from pydicom.tag import Tag, TupleTag
 from pydicom.uid import ImplicitVRLittleEndian
 import pydicom.valuerep
@@ -997,10 +991,10 @@ class TestDataElementGenerator(object):
     def test_little_endian_explicit(self):
         """Test reading little endian explicit VR data"""
         # (0010, 0010) PatientName PN 6 ABCDEF
-        bytestream = b'\x10\x00\x10\x00' \
-                     b'\x50\x4E' \
-                     b'\x06\x00' \
-                     b'\x41\x42\x43\x44\x45\x46'
+        bytestream = (b'\x10\x00\x10\x00'
+                      b'PN'
+                      b'\x06\x00'
+                      b'ABCDEF')
         fp = BytesIO(bytestream)
         # fp, is_implicit_VR, is_little_endian,
         gen = data_element_generator(fp, False, True)
@@ -1012,78 +1006,25 @@ class TestDataElementGenerator(object):
         # (0010, 0010) PatientName PN 6 ABCDEF
         bytestream = b'\x10\x00\x10\x00' \
                      b'\x06\x00\x00\x00' \
-                     b'\x41\x42\x43\x44\x45\x46'
+                     b'ABCDEF'
         fp = BytesIO(bytestream)
-        # fp, is_implicit_VR, is_little_endian,
-        gen = data_element_generator(fp, True, True)
+        gen = data_element_generator(fp, is_implicit_VR=True,
+                                     is_little_endian=True)
         elem = DataElement(0x00100010, 'PN', 'ABCDEF')
         assert elem == DataElement_from_raw(next(gen), 'ISO_IR 100')
-
-    def test_extra_length_vr(self):
-        pass
-
-    def test_undefined_length(self):
-        pass
 
     def test_big_endian_explicit(self):
         """Test reading big endian explicit VR data"""
         # (0010, 0010) PatientName PN 6 ABCDEF
         bytestream = b'\x00\x10\x00\x10' \
-                     b'\x50\x4E' \
+                     b'PN' \
                      b'\x00\x06' \
-                     b'\x41\x42\x43\x44\x45\x46'
+                     b'ABCDEF'
         fp = BytesIO(bytestream)
         # fp, is_implicit_VR, is_little_endian,
         gen = data_element_generator(fp, False, False)
         elem = DataElement(0x00100010, 'PN', 'ABCDEF')
         assert elem == DataElement_from_raw(next(gen), 'ISO_IR 100')
-
-    def test_stop_when(self):
-        pass
-
-    def test_encoding(self):
-        pass
-
-    def test_specific_tags(self):
-        pass
-
-    def test_debugging(self):
-        pass
-
-
-class TestReadDataset(object):
-    """Test filereader.read_dataset"""
-    def test(self):
-        """"""
-        pass
-
-
-class TestReadSequence(object):
-    """Test filereader.read_sequence"""
-    def test(self):
-        """"""
-        pass
-
-
-class TestReadSequenceItem(object):
-    """Test filereader.read_sequence_item"""
-    def test(self):
-        """"""
-        pass
-
-
-class TestReadFileMetaInfo(object):
-    """Test filereader.read_file_meta_info"""
-    def test(self):
-        """"""
-        pass
-
-
-class TestReadDicomDir(object):
-    """Test filereader.read_dicomdir"""
-    def test(self):
-        """"""
-        pass
 
 
 if __name__ == "__main__":

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -8,7 +8,6 @@
 import gzip
 from io import BytesIO
 import os
-from re import compile
 import shutil
 import sys
 import tempfile
@@ -95,57 +94,6 @@ emri_jpeg_2k_lossless = get_testdata_files(
 color_3d_jpeg_baseline = get_testdata_files("color3d_jpeg_baseline.dcm")[0]
 dir_name = os.path.dirname(sys.argv[0])
 save_dir = os.getcwd()
-
-
-def assert_warns_regex(type_warn, message, func, *args, **kwargs):
-    """Test a warning against an expected warning.
-
-    Only tests that the first `type_warn` warning fired matches the expected
-    warning.
-
-    Parameters
-    ----------
-    type_warn : Warning
-        The expected warning.
-    message : str
-        A string that will be used as a regex pattern to match against the
-        actual warning message. If using the actual expected message don't
-        forget to escape any regex special characters like '|', '(', ')', etc.
-    func : callable
-        The function that is expected to fire the warning.
-    args
-        The callable function `func`'s arguments.
-    kwargs
-        The callable function `func`'s keyword arguments.
-
-    Raises
-    ------
-    AssertionError
-        If the regex pattern in `message` doesn't match the actual warning.
-    """
-    with pytest.warns(None) as wrnrecord:
-        func(*args, **kwargs)
-
-    wrn = wrnrecord.pop(type_warn)
-    regex = compile(message)
-    if regex.search(str(wrn.message)) is None:
-        msg = "Pattern '{}' not found in warnings".format(message)
-        raise AssertionError(msg)
-
-
-def isClose(a, b, epsilon=0.000001):
-    """Compare within some tolerance, to avoid machine roundoff differences"""
-    try:
-        a.append  # see if is a list
-    except BaseException:  # (is not)
-        return abs(a - b) < epsilon
-    else:
-        if len(a) != len(b):
-            return False
-        for ai, bi in zip(a, b):
-            if abs(ai - bi) > epsilon:
-                return False
-        return True
 
 
 class ReaderTests(unittest.TestCase):
@@ -861,10 +809,10 @@ class DeferredReadTests(unittest.TestCase):
         def read_value():
             ds.PixelData
 
-        assert_warns_regex(UserWarning,
-                           "Deferred read warning -- file modification "
-                           "time has changed",
-                           read_value)
+        with pytest.warns(UserWarning,
+                          match="Deferred read warning -- file modification "
+                                "time has changed"):
+            read_value()
 
     def testFileExists(self):
         """Deferred read raises error if file no longer exists....."""

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from datetime import date, datetime, time, timedelta
 from io import BytesIO
 import os
-import os.path
 import unittest
 
 from struct import unpack
@@ -44,33 +43,6 @@ datetime_name = mr_name
 
 unicode_name = get_charset_files("chrH31.dcm")[0]
 multiPN_name = get_charset_files("chrFrenMulti.dcm")[0]
-
-
-def assert_raises_regex(type_error, message, func, *args, **kwargs):
-    """Test a raised exception against an expected exception.
-
-    Parameters
-    ----------
-    type_error : Exception
-        The expected raised exception.
-    message : str
-        A string that will be used as a regex pattern to match against the
-        actual exception message. If using the actual expected message don't
-        forget to escape any regex special characters like '|', '(', ')', etc.
-    func : callable
-        The function that is expected to raise the exception.
-    args
-        The callable function `func`'s arguments.
-    kwargs
-        The callable function `func`'s keyword arguments.
-
-    Notes
-    -----
-    Taken from https://github.com/glemaitre/specio, BSD 3 license.
-    """
-    with pytest.raises(type_error) as excinfo:
-        func(*args, **kwargs)
-    excinfo.match(message)
 
 
 def files_identical(a, b):
@@ -607,12 +579,10 @@ class WriteDataElementTests(unittest.TestCase):
         fp.is_implicit_VR = True
         fp.is_little_endian = True
         elem = DataElement(0x00100010, 'ZZ', 'Test')
-        assert_raises_regex(NotImplementedError,
-                            "write_data_element: unknown Value "
-                            "Representation 'ZZ'",
-                            write_data_element,
-                            fp,
-                            elem)
+        with pytest.raises(NotImplementedError,
+                           match="write_data_element: unknown Value "
+                                 "Representation 'ZZ'"):
+            write_data_element(fp, elem)
 
 
 class TestCorrectAmbiguousVR(unittest.TestCase):
@@ -1832,12 +1802,9 @@ class TestWriteNumbers(object):
         fp.is_little_endian = True
         elem = DataElement(0x00100010, 'US', b'\x00')
         fmt = 'H'
-        assert_raises_regex(IOError,
-                            "for data_element:\n\(0010, 0010\)",
-                            write_numbers,
-                            fp,
-                            elem,
-                            fmt)
+        with pytest.raises(IOError,
+                           match="for data_element:\n\(0010, 0010\)"):
+            write_numbers(fp, elem, fmt)
 
     def test_write_big_endian(self):
         """Test writing big endian"""
@@ -1853,14 +1820,14 @@ class TestWritePN(object):
     """Test filewriter.write_PN"""
     @pytest.mark.skip("Raises exception due to issue #489")
     def test_no_encoding_unicode(self):
-        """If PN element as no encoding info, default is used"""
+        """If PN element has no encoding info, default is used"""
         fp = DicomBytesIO()
         fp.is_little_endian = True
         elem = DataElement(0x00100010, 'PN', u'\u03b8')
         write_PN(fp, elem)
 
     def test_no_encoding(self):
-        """If PN element as no encoding info, default is used"""
+        """If PN element has no encoding info, default is used"""
         fp = DicomBytesIO()
         fp.is_little_endian = True
         elem = DataElement(0x00100010, 'PN', 'Test')
@@ -1988,12 +1955,9 @@ class TestWriteNumbers(object):
         fp.is_little_endian = True
         elem = DataElement(0x00100010, 'US', b'\x00')
         fmt = 'H'
-        assert_raises_regex(IOError,
-                            "for data_element:\n\(0010, 0010\)",
-                            write_numbers,
-                            fp,
-                            elem,
-                            fmt)
+        with pytest.raises(IOError,
+                           match="for data_element:\n\(0010, 0010\)"):
+            write_numbers(fp, elem, fmt)
 
     def test_write_big_endian(self):
         """Test writing big endian"""

--- a/pydicom/tests/test_misc.py
+++ b/pydicom/tests/test_misc.py
@@ -46,4 +46,5 @@ class TestMisc(object):
 
         with pytest.raises(ValueError):
             size_in_bytes('2 TB')
+        with pytest.raises(ValueError):
             size_in_bytes('KB 2')

--- a/pydicom/tests/test_uid.py
+++ b/pydicom/tests/test_uid.py
@@ -75,7 +75,7 @@ class TestUID(object):
         assert not self.uid == 'Explicit VR Little Endian'
         # Issue 96
         assert not self.uid == 3
-        assert not self.uid is None
+        assert self.uid is not None
 
     def test_inequality(self):
         """Test that UID.__ne__ works."""

--- a/pydicom/tests/test_values.py
+++ b/pydicom/tests/test_values.py
@@ -8,33 +8,6 @@ from pydicom.values import (convert_value, converters, convert_tag,
                             convert_ATvalue, convert_DA_string)
 
 
-def assert_raises_regex(type_error, message, func, *args, **kwargs):
-    """Test a raised exception against an expected exception.
-
-    Parameters
-    ----------
-    type_error : Exception
-        The expected raised exception.
-    message : str
-        A string that will be used as a regex pattern to match against the
-        actual exception message. If using the actual expected message don't
-        forget to escape any regex special characters like '|', '(', ')', etc.
-    func : callable
-        The function that is expected to raise the exception.
-    args
-        The callable function `func`'s arguments.
-    kwargs
-        The callable function `func`'s keyword arguments.
-
-    Notes
-    -----
-    Taken from https://github.com/glemaitre/specio, BSD 3 license.
-    """
-    with pytest.raises(type_error) as excinfo:
-        func(*args, **kwargs)
-    excinfo.match(message)
-
-
 class TestConvertTag(object):
     def test_big_endian(self):
         """Test convert_tag with a big endian byte string"""
@@ -144,9 +117,9 @@ class TestConvertValue(object):
         converter_func = converters['PN']
         del converters['PN']
 
-        assert_raises_regex(NotImplementedError,
-                            "Unknown Value Representation 'PN'",
-                            convert_value, 'PN', None)
+        with pytest.raises(NotImplementedError,
+                           match="Unknown Value Representation 'PN'"):
+            convert_value('PN', None)
 
         # Fix converters
         converters['PN'] = converter_func


### PR DESCRIPTION
- replaced assert_raises_regex() with standard with pytest.raises()
- removed empty tests
- minor formatting changes
- closes #543

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Implemented most of the review comments, with 2 exceptions:
- I removed the empty tests instead of marking them (they should probably be implemented next time one of the untested classes is touched)
- I left a TODO in the code (hexutil.hex2bytes) with the corresponsing tests skipped - I will handle this another day either by writing a separate issue, or providing a PR

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
