### PR TITLE
[MRG] Tag can be constructed from a list of two integral types now

### DIFF
--- a/pydicom/compat.py
+++ b/pydicom/compat.py
@@ -19,9 +19,11 @@ in_PyPy = 'PyPy' in sys.version
 if in_py2:
     text_type = unicode
     string_types = (str, unicode)
+    number_types = (int, long)
 else:
     text_type = str
     string_types = (str, )
+    number_types = (int, )
 
 if in_py2:
     # Have to run through exec as the code is a syntax error in py 3

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -72,14 +72,16 @@ def Tag(arg, arg2=None):
         if len(arg) != 2:
             raise ValueError("Tag must be an int or a 2-tuple")
 
-        # Check argument types aren't mixed (i.e. str and int)
-        arg_types = set([type(arg[0]), type(arg[1])])
-        if len(arg_types) != 1:
-            raise ValueError("Both arguments for Tag must be the same type.")
-
-        # Double str parameters
-        if isinstance(arg[0], (str, compat.text_type)):
-            arg = (int(arg[0], 16), int(arg[1], 16))
+        valid = False
+        if isinstance(arg[0], compat.string_types):
+            valid = isinstance(arg[1], (str, compat.string_types))
+            if valid:
+                arg = (int(arg[0], 16), int(arg[1], 16))
+        elif isinstance(arg[0], compat.number_types):
+            valid = isinstance(arg[1], compat.number_types)
+        if not valid:
+            raise ValueError("Both arguments for Tag must be the same type, "
+                             "either string or int.")
 
         if arg[0] > 0xFFFF or arg[1] > 0xFFFF:
             raise OverflowError("Groups and elements of tags must each "

--- a/pydicom/tests/test_tag.py
+++ b/pydicom/tests/test_tag.py
@@ -291,6 +291,10 @@ class TestTag(object):
         pytest.raises(ValueError, Tag, ['0x10', '0x20', '0x03'])
         pytest.raises(ValueError, Tag, [0x1000])
         pytest.raises(ValueError, Tag, ['0x10'])
+
+        # Must be int or string
+        pytest.raises(ValueError, Tag, [1., 2.])
+
         # Must be 32-bit
         pytest.raises(OverflowError, Tag, [65536, 0])
         pytest.raises(OverflowError, Tag, [0, 65536])
@@ -305,6 +309,12 @@ class TestTag(object):
         pytest.raises(ValueError, Tag, [0x01, 0x02], '0x01')
         pytest.raises(ValueError, Tag, ['0x01', '0x02'], '0x01')
         pytest.raises(ValueError, Tag, ['0x01', '0x02'], 0x01)
+
+    @pytest.mark.skipIf(not in_py2, reason='Long type only in Python 2')
+    def test_mixed_long_int(self):
+        assert Tag([0x1000, long(0x2000)]) == BaseTag(0x10002000)
+        assert Tag([long(0x1000), 0x2000]) == BaseTag(0x10002000)
+        assert Tag([long(0x1000), long(0x2000)]) == BaseTag(0x10002000)
 
     def test_tag_single_str(self):
         """Test creating a Tag from a single str."""

--- a/pydicom/tests/test_tag.py
+++ b/pydicom/tests/test_tag.py
@@ -1,6 +1,7 @@
 # Copyright 2008-2017 pydicom authors. See LICENSE file for details.
 """Test suite for tag.py"""
 import sys
+import unittest
 
 import pytest
 
@@ -310,7 +311,7 @@ class TestTag(object):
         pytest.raises(ValueError, Tag, ['0x01', '0x02'], '0x01')
         pytest.raises(ValueError, Tag, ['0x01', '0x02'], 0x01)
 
-    @pytest.mark.skipIf(not in_py2, reason='Long type only in Python 2')
+    @unittest.skipIf(not in_py2, 'Long type only exists in Python 2')
     def test_mixed_long_int(self):
         assert Tag([0x1000, long(0x2000)]) == BaseTag(0x10002000)
         assert Tag([long(0x1000), 0x2000]) == BaseTag(0x10002000)


### PR DESCRIPTION
… even if they are different

- handles the case with mixed int and long in Python2
- fixes #553

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
