### PR TITLE
[MRG] Allow defer_size to be infinite

### DIFF
--- a/pydicom/misc.py
+++ b/pydicom/misc.py
@@ -12,7 +12,7 @@ _size_factors = dict(KB=1024, MB=1024 * 1024, GB=1024 * 1024 * 1024)
 def size_in_bytes(expr):
     """Return the number of bytes for a defer_size argument to dcmread()
     """
-    if expr is None:
+    if expr is None or expr == float('inf'):
         return None
     try:
         return int(expr)

--- a/pydicom/tests/test_misc.py
+++ b/pydicom/tests/test_misc.py
@@ -35,6 +35,7 @@ class TestMisc(object):
         """Test convenience function size_in_bytes()."""
         # None or numbers shall be returned unchanged
         assert size_in_bytes(None) is None
+        assert size_in_bytes(float('inf')) is None
         assert size_in_bytes(1234) == 1234
 
         # string shall be parsed


### PR DESCRIPTION
- fixes #555

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Note - there is not math.inf before Python 3.5.
#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
