### PR TITLE
Add tag_for_name back in with deprecation warning

### DIFF
--- a/pydicom/datadict.py
+++ b/pydicom/datadict.py
@@ -1,12 +1,6 @@
-# datadict.py
+# Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 # -*- coding: utf-8 -*-
 """Access dicom dictionary information"""
-
-# Copyright (c) 2008-2012 Darcy Mason
-# This file is part of pydicom, released under a modified MIT license.
-#    See the file LICENSE included with this distribution, also
-#    available at https://github.com/pydicom/pydicom
-#
 
 from pydicom.config import logger
 from pydicom.tag import Tag
@@ -206,6 +200,14 @@ def tag_for_keyword(keyword):
     """Return the dicom tag corresponding to keyword,
        or None if none exist."""
     return keyword_dict.get(keyword)
+
+
+def tag_for_name(name):
+    """Deprecated -- use tag_for_keyword"""
+    msg = "tag_for_name is deprecated.  Use tag_for_keyword instead"
+    warnings.warn(msg, DeprecationWarning)
+
+    return tag_for_keyword(name)
 
 
 def repeater_has_tag(tag):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #554.

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->
Adds the pydicom < 1.0 `tag_for_name` function back in for DeprecationWarning purposes.   Does not have complete functionality of the old one, i.e. it does not accept names other than dicom keywords.  

The old pydicom short names, etc. will still throw an error, so this is not completely backwards compatible.
 
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
