### PR TITLE
Remove lossy JPEG 2000 from PIL-supported formats

### DIFF
--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -29,7 +29,6 @@ PillowSupportedTransferSyntaxes = [
     pydicom.uid.JPEGLossless,
     pydicom.uid.JPEGBaseLineLossy12bit,
     pydicom.uid.JPEG2000Lossless,
-    pydicom.uid.JPEG2000Lossy,
 ]
 PillowJPEG2000TransferSyntaxes = [
     pydicom.uid.JPEG2000Lossless,

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -32,7 +32,6 @@ PillowSupportedTransferSyntaxes = [
 ]
 PillowJPEG2000TransferSyntaxes = [
     pydicom.uid.JPEG2000Lossless,
-    pydicom.uid.JPEG2000Lossy,
 ]
 PillowJPEGTransferSyntaxes = [
     pydicom.uid.JPEGBaseLineLossy8bit,


### PR DESCRIPTION
#539 demonstrates that Pillow does not handle lossy JPEG 2000 compression properly. Such unstable behaviour should probably be disabled by default.

I can't see any existing tests that this change would break as the lossy JPEG file (`JPEG2000.dcm`) is not being decompressed there.