### PR TITLE
[MRG] Do not try to test Jpeg2000 lossy image with pillow

### DIFF
--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -338,16 +338,8 @@ class pillow_JPEG2000Tests_with_pillow(unittest.TestCase):
                 "(mean == {1})".format(b.mean(), a.mean()))
 
     def test_jpeg2000_lossy(self):
-        a = self.sc_rgb_jpeg2k_gdcm_KY.pixel_array
-        b = self.ground_truth_sc_rgb_jpeg2k_gdcm_KY_gdcm.pixel_array
-        if have_numpy_testing:
-            numpy.testing.assert_array_equal(a, b)
-        else:
-            self.assertEqual(
-                a.mean(),
-                b.mean(),
-                "Decoded pixel data is not all {0} "
-                "(mean == {1})".format(b.mean(), a.mean()))
+        with pytest.raises(NotImplementedError):
+            _ = self.sc_rgb_jpeg2k_gdcm_KY.pixel_array
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
- support has been removed due to incorrect pillow implementation

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
