### PR TITLE
[WIP] FIX infer __version_info__ from __version__

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
 
   # Installed prebuilt dependencies from conda
   - "conda install pip numpy nose wheel pytest matplotlib -y -q"
-  - "conda install -y -q setuptools packaging"
+  - "conda install -y -q setuptools"
   - "pip install nose-timer nose-exclude"
 
   # Install other pydicom dependencies

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -109,7 +109,7 @@ conda update --yes --quiet conda
 conda create -n $CONDA_ENV_NAME --yes --quiet python=3
 source activate $CONDA_ENV_NAME
 
-conda install --yes --quiet pip setuptools packaging numpy matplotlib sphinx \
+conda install --yes --quiet pip setuptools numpy matplotlib sphinx \
       pillow sphinx_rtd_theme numpydoc
 conda install --yes --quiet -c conda-forge gdcm
 pip install sphinx-gallery

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -38,7 +38,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # provided versions
     conda create -n testenv --yes python=$PYTHON_VERSION pip
     source activate testenv
-    conda install --yes nose pytest pytest-cov packaging setuptools
+    conda install --yes nose pytest pytest-cov setuptools
     if [[ "$NUMPY" == "true" ]]; then
         conda install --yes numpy
     fi
@@ -67,7 +67,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # Create a new virtualenv using system site packages for python, numpy
     virtualenv --system-site-packages testvenv
     source testvenv/bin/activate
-    pip install nose nose-timer pytest pytest-cov codecov packaging setuptools
+    pip install nose nose-timer pytest pytest-cov codecov setuptools
 
 elif [[ "$DISTRIB" == "pypy" ]]; then
     # This is to see if we are supporting pypy. With pypy3, numpypy is not
@@ -99,8 +99,7 @@ elif [[ "$DISTRIB" == "pypy" ]]; then
     elif [[ "$NUMPY" == "true" ]]; then
         python -m pip install cython numpy
     fi
-    python -m pip install nose nose-timer pytest pytest-cov codecov packaging \
-           setuptools
+    python -m pip install nose nose-timer pytest pytest-cov codecov setuptools
 fi
 
 python --version

--- a/pydicom/__init__.py
+++ b/pydicom/__init__.py
@@ -32,7 +32,6 @@ Quick Start
 
 """
 
-from packaging import version
 
 from pydicom.dataelem import DataElement
 from pydicom.dataset import Dataset, FileDataset
@@ -40,10 +39,7 @@ from pydicom.filereader import dcmread, read_file
 from pydicom.filewriter import dcmwrite, write_file
 from pydicom.sequence import Sequence
 
-from ._version import __version__
-
-__version_info__ = tuple(
-    int(x) for x in version.parse(__version__).base_version.split('.'))
+from ._version import __version__, __version_info__
 
 __all__ = ['DataElement',
            'Dataset',

--- a/pydicom/_version.py
+++ b/pydicom/_version.py
@@ -1,4 +1,4 @@
 """Pure python package for DICOM medical file reading and writing."""
 
 __version__ = '1.1.0.dev0'
-__version_info__ = (1, 1, 0)
+__version_info__ = tuple(__version__.split('.')[:3])

--- a/pydicom/_version.py
+++ b/pydicom/_version.py
@@ -1,4 +1,6 @@
 """Pure python package for DICOM medical file reading and writing."""
+import re
 
 __version__ = '1.1.0.dev0'
-__version_info__ = tuple(__version__.split('.')[:3])
+__version_info__ = tuple(
+    re.match(r'(\d+\.\d+\.\d+).*', __version__).group(1).split('.'))

--- a/pydicom/_version.py
+++ b/pydicom/_version.py
@@ -1,3 +1,4 @@
 """Pure python package for DICOM medical file reading and writing."""
 
 __version__ = '1.1.0.dev0'
+__version_info__ = (1, 1, 0)

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -2,7 +2,6 @@
 """Functions related to writing DICOM data."""
 from __future__ import absolute_import
 from struct import pack
-from packaging import version
 
 from pydicom import compat
 from pydicom.compat import in_py2
@@ -18,7 +17,7 @@ from pydicom.uid import (PYDICOM_IMPLEMENTATION_UID, ImplicitVRLittleEndian,
                          UncompressedPixelTransferSyntaxes)
 from pydicom.valuerep import extra_length_VRs
 from pydicom.values import convert_numbers
-from pydicom._version import __version__
+from pydicom._version import __version_info__
 
 
 def correct_ambiguous_vr_element(elem, ds, is_little_endian):
@@ -599,7 +598,7 @@ def write_file_meta_info(fp, file_meta, enforce_standard=True):
 
         if 'ImplementationVersionName' not in file_meta:
             file_meta.ImplementationVersionName = (
-                'PYDICOM ' + version.parse(__version__).base_version)
+                'PYDICOM ' + ".".join(str(x) for x in __version_info__))
 
         # Check that required File Meta Elements are present
         missing = []

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -6,7 +6,6 @@ from datetime import date, datetime, time, timedelta
 from io import BytesIO
 import os
 import unittest
-from packaging import version as pversion
 
 from struct import unpack
 from tempfile import TemporaryFile
@@ -14,7 +13,7 @@ from tempfile import TemporaryFile
 import pytest
 
 from pydicom._storage_sopclass_uids import CTImageStorage
-from pydicom import config, __version__
+from pydicom import config, __version_info__
 from pydicom.data import get_testdata_files, get_charset_files
 from pydicom.dataset import Dataset, FileDataset
 from pydicom.dataelem import DataElement
@@ -44,6 +43,8 @@ datetime_name = mr_name
 
 unicode_name = get_charset_files("chrH31.dcm")[0]
 multiPN_name = get_charset_files("chrFrenMulti.dcm")[0]
+
+base_version = '.'.join(str(i) for i in __version_info__)
 
 
 def files_identical(a, b):
@@ -1062,7 +1063,7 @@ class TestWriteToStandard(object):
     def test_write_no_file_meta(self):
         """Test writing a dataset with no file_meta"""
         fp = DicomBytesIO()
-        version = 'PYDICOM ' + pversion.parse(__version__).base_version
+        version = 'PYDICOM ' + base_version
         ds = dcmread(rtplan_name)
         transfer_syntax = ds.file_meta.TransferSyntaxUID
         ds.file_meta = Dataset()
@@ -1219,7 +1220,7 @@ class TestWriteFileMetaInfoToStandard(object):
         test_length = unpack('<I', fp.read(4))[0]
         assert test_length == (61 + class_length
                                + version_length
-                               + len(pversion.parse(__version__).base_version))
+                               + len(base_version))
         # Check original file meta is unchanged/updated
         assert meta.FileMetaInformationGroupLength == test_length
         assert meta.FileMetaInformationVersion == b'\x00\x01'
@@ -1228,8 +1229,7 @@ class TestWriteFileMetaInfoToStandard(object):
         assert meta.TransferSyntaxUID == '1.3'
         # Updated to meet standard
         assert meta.ImplementationClassUID == PYDICOM_IMPLEMENTATION_UID
-        assert meta.ImplementationVersionName == (
-            'PYDICOM ' + pversion.parse(__version__).base_version)
+        assert meta.ImplementationVersionName == 'PYDICOM ' + base_version
 
     def test_version(self):
         """Test that the value for FileMetaInformationVersion is OK."""


### PR DESCRIPTION
To actually benefit from bumpversion, `__version_info__` should be automatically inferred from `__version__`.