### PR TITLE
[MRG] Fixed pytest warnings

### DIFF
--- a/doc/working_with_pixel_data.rst
+++ b/doc/working_with_pixel_data.rst
@@ -60,7 +60,7 @@ they must be written back to the ``PixelData`` attribute:
   for n,val in enumerate(ds.pixel_array.flat): # example: zero anything < 300
       if val < 300:
           ds.pixel_array.flat[n]=0
-  ds.PixelData = ds.pixel_array.tostring()
+  ds.PixelData = ds.pixel_array.tobytes()
   ds.save_as("newfilename.dcm")
 
   import os

--- a/examples/image_processing/plot_downsize_image.py
+++ b/examples/image_processing/plot_downsize_image.py
@@ -34,7 +34,7 @@ print('The downsampled image has {} x {} voxels'.format(
     data_downsampling.shape[0], data_downsampling.shape[1]))
 
 # copy the data back to the original data set
-ds.PixelData = data_downsampling.tostring()
+ds.PixelData = data_downsampling.tobytes()
 # update the information regarding the shape of the data array
 ds.Rows, ds.Columns = data_downsampling.shape
 

--- a/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -152,13 +152,13 @@ def get_pixeldata(dicom_dataset):
     if len(pixel_bytearray) > n_bytes:
         # We make sure that all the bytes after are in fact zeros
         padding = pixel_bytearray[n_bytes:]
-        if numpy.any(numpy.fromstring(padding, numpy.byte)):
+        if numpy.any(numpy.frombuffer(padding, numpy.byte)):
             pixel_bytearray = pixel_bytearray[:n_bytes]
         else:
             # We revert to the old behavior which should then result
             #   in a Numpy error later on.
             pass
-    pixel_array = numpy.fromstring(pixel_bytearray, dtype=numpy_dtype)
+    pixel_array = numpy.frombuffer(pixel_bytearray, dtype=numpy_dtype)
     length_of_pixel_array = pixel_array.nbytes
     expected_length = dicom_dataset.Rows * dicom_dataset.Columns
 

--- a/pydicom/pixel_data_handlers/jpeg_ls_handler.py
+++ b/pydicom/pixel_data_handlers/jpeg_ls_handler.py
@@ -120,17 +120,17 @@ def get_pixeldata(dicom_dataset):
         # print len(CompressedPixelDataSeq)
         for frame in CompressedPixelDataSeq:
             decompressed_image = jpeg_ls.decode(
-                numpy.fromstring(frame, dtype=numpy.uint8))
+                numpy.frombuffer(frame, dtype=numpy.uint8))
             UncompressedPixelData += decompressed_image.tobytes()
     else:
         # single compressed frame
         CompressedPixelData = pydicom.encaps.defragment_data(
             dicom_dataset.PixelData)
         decompressed_image = jpeg_ls.decode(
-            numpy.fromstring(CompressedPixelData, dtype=numpy.uint8))
+            numpy.frombuffer(CompressedPixelData, dtype=numpy.uint8))
         UncompressedPixelData = decompressed_image.tobytes()
 
-    pixel_array = numpy.fromstring(UncompressedPixelData, numpy_format)
+    pixel_array = numpy.frombuffer(UncompressedPixelData, numpy_format)
     if should_change_PhotometricInterpretation_to_RGB(dicom_dataset):
         dicom_dataset.PhotometricInterpretation = "RGB"
 

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -101,7 +101,7 @@ def get_pixeldata(dicom_dataset):
 
     pixel_bytearray = dicom_dataset.PixelData
 
-    pixel_array = numpy.fromstring(pixel_bytearray, dtype=numpy_dtype)
+    pixel_array = numpy.frombuffer(pixel_bytearray, dtype=numpy_dtype)
     length_of_pixel_array = pixel_array.nbytes
     expected_length = dicom_dataset.Rows * dicom_dataset.Columns
     if ('NumberOfFrames' in dicom_dataset and

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -207,7 +207,8 @@ def get_pixeldata(dicom_dataset):
     logger.debug(
         "Successfully read %s pixel bytes",
         len(UncompressedPixelData))
-    pixel_array = numpy.fromstring(UncompressedPixelData, numpy_format)
+    pixel_array = numpy.copy(
+        numpy.frombuffer(UncompressedPixelData, numpy_format))
     if (dicom_dataset.file_meta.TransferSyntaxUID in
             PillowJPEG2000TransferSyntaxes and
             dicom_dataset.BitsStored == 16):

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -60,7 +60,7 @@ class DatasetTests(unittest.TestCase):
                            "'PixelRepresentation'")
         msg = "(" + "|".join(
             [msg_from_gdcm, msg_from_numpy, msg_from_pillow]) + ")"
-        with self.assertRaisesRegexp(AttributeError, msg):
+        with pytest.raises(AttributeError, match=msg):
             ds.pixel_array
 
     def test_attribute_error_in_property_correct_debug(self):

--- a/pydicom/tests/test_filebase.py
+++ b/pydicom/tests/test_filebase.py
@@ -258,7 +258,7 @@ class TestDicomFile(object):
     """Test filebase.DicomFile() function"""
     def test_read(self):
         """Test the function"""
-        fp = DicomFile(TEST_FILE, 'rb')
-        assert not fp.parent.closed
-        assert 'CT_small.dcm' in fp.name
-        assert fp.read(2) == b'\x49\x49'
+        with DicomFile(TEST_FILE, 'rb') as fp:
+            assert not fp.parent.closed
+            assert 'CT_small.dcm' in fp.name
+            assert fp.read(2) == b'\x49\x49'

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -874,7 +874,7 @@ class ReadTruncatedFileTests(unittest.TestCase):
                "Unexpected end of file. Read.*bytes of.*expected|"
                "'str' object has no attribute 'reshape'|"
                "'bytes' object has no attribute 'reshape')")
-        with self.assertRaisesRegexp(AttributeError, msg):
+        with pytest.raises(AttributeError, match=msg):
             mr.pixel_array
 
 

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -74,7 +74,10 @@ class WriteFileTests(unittest.TestCase):
     def setUp(self):
         self.file_out = TemporaryFile('w+b')
 
-    def compare(self, in_filename, decode=False):
+    def tearDown(self):
+        self.file_out.close()
+
+    def compare(self, in_filename):
         """Read Dataset from in_filename, write to file, compare"""
         with open(in_filename, 'rb') as f:
             bytes_in = BytesIO(f.read())
@@ -119,12 +122,12 @@ class WriteFileTests(unittest.TestCase):
     def testUnicode(self):
         """Ensure decoded string DataElements
            are written to file properly"""
-        self.compare(unicode_name, decode=True)
+        self.compare(unicode_name)
 
     def testMultiPN(self):
         """Ensure multiple Person Names are written
            to the file correctly."""
-        self.compare(multiPN_name, decode=True)
+        self.compare(multiPN_name)
 
     def testJPEG2000(self):
         """Input file, write back and verify
@@ -186,6 +189,7 @@ class ScratchWriteDateTimeTests(WriteFileTests):
 
     def tearDown(self):
         config.datetime_conversion = False
+        self.file_out.close()
 
     def test_multivalue_DA(self):
         """Write DA/DT/TM data elements.........."""

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -167,7 +167,7 @@ def convert_numbers(byte_string, is_little_endian, struct_format):
     length = len(byte_string)
 
     if length % bytes_per_value != 0:
-        logger.warn("Expected length to be even multiple of number size")
+        logger.warning("Expected length to be even multiple of number size")
 
     format_string = "%c%u%c" % (endianChar, length // bytes_per_value,
                                 struct_format)


### PR DESCRIPTION
- replaced numpy.fromstring() by frombuffer()
- replaced assertRaisesRegexp() by pytest.raises()
- make sure opened files are closed
- replaced warn() by warning()
- fixes #559

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
There is one place in the pillow handler I'm not sure about: I replaced `numpy.fromstring()` by `numpy.copy(numpy.frombuffer())` (the copy is needed because afterwards the highest bit is masked out). This should basically do the same, but I'm not sure if it may be a performance problem. 
Someone with better numpy knowledge please comment.
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
