### PR TITLE
Provide mock 'dicom' import with helpful transition information

### DIFF
--- a/dicom.py
+++ b/dicom.py
@@ -1,0 +1,11 @@
+msg = """
+Pydicom via 'import dicom' has been removed in pydicom version 1.0.
+Please install the `dicom` package to restore function of code relying
+on pydicom 0.9.9 or earlier. E.g. `pip install dicom`.
+Alternatively, most code can easily be converted to pydicom > 1.0 by
+changing import lines from 'import dicom' to 'import pydicom'.
+See the Transition Guide at
+https://pydicom.github.io/pydicom/stable/transition_to_pydicom1.html.
+"""
+
+raise ImportError(msg)

--- a/pydicom/_version.py
+++ b/pydicom/_version.py
@@ -1,6 +1,6 @@
 """Pure python package for DICOM medical file reading and writing."""
 import re
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 __version_info__ = tuple(
     re.match(r'(\d+\.\d+\.\d+).*', __version__).group(1).split('.'))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.0.2
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
 serialize = 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,12 @@ import sys
 from glob import glob
 from setuptools import setup, find_packages
 
+have_dicom = True
+try:
+    import dicom
+except ImportError:
+    have_dicom = False
+
 # get __version__ from _version.py
 base_dir = os.path.dirname(os.path.realpath(__file__))
 ver_file = os.path.join(base_dir,'pydicom', '_version.py')
@@ -34,6 +40,9 @@ an overview of how to use the pydicom library.
 
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
+_py_modules = []
+if not have_dicom:
+    _py_modules = ['dicom']
 
 CLASSIFIERS = [
     "License :: OSI Approved :: MIT License",
@@ -96,6 +105,7 @@ opts = dict(name=NAME,
             keywords=KEYWORDS,
             classifiers=CLASSIFIERS,
             packages=find_packages(),
+            py_modules=_py_modules,
             package_data=PACKAGE_DATA,
             include_package_data=True,
             install_requires=REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 # get __version__ from _version.py
 base_dir = os.path.dirname(os.path.realpath(__file__))
-ver_file = os.path.join(base_dir,'pydicom', '_version.py')
+ver_file = os.path.join(base_dir, 'pydicom', '_version.py')
 with open(ver_file) as f:
     exec(f.read())
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #582 as an alternate choice to PR #583.


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->
Provides a mechanism for a mock `import dicom` if no `dicom` already exists on installation.  With this patch, if someone installs the latest pydicom (>=1.0), then `import dicom` will provide a message and an ImportError exception.

