### PR TITLE
[MRG+1] Fix for Dataset slicing not working correctly for (0xFFFF, 0xFFFF)

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1076,9 +1076,8 @@ class Dataset(dict):
 
         # Issue 92: if stop is None then 0xFFFFFFFF + 1 causes overflow in Tag
         if stop == 0x100000000:
-            stop = 0xFFFFFFFF
             slice_tags = [
-                tag for tag in all_tags if Tag(start) <= tag <= Tag(stop)
+                tag for tag in all_tags if Tag(start) <= tag <= Tag(stop - 1)
             ]
         else:
             slice_tags = [

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1045,10 +1045,12 @@ class Dataset(dict):
 
         Parameters
         ----------
-        start : int or None
-            The slice's starting element tag value.
-        stop : int or None
-            The slice's stopping element tag value.
+        start : int or 2-tuple of int or None
+            The slice's starting element tag value, in any format accepted by
+            pydicom.tag.Tag.
+        stop : int or 2-tuple of int or None
+            The slice's stopping element tag value, in any format accepted by
+            pydicom.tag.Tag.
         step : int or None
             The slice's step size.
 
@@ -1074,7 +1076,9 @@ class Dataset(dict):
         if stop is None:
             stop = all_tags[-1] + 1
 
-        # Issue 92: if stop is None then 0xFFFFFFFF + 1 causes overflow in Tag
+        # Issue 92: if `stop` is None then 0xFFFFFFFF + 1 causes overflow in
+        # Tag. The only this occurs if the `stop` parameter value is None
+        # and the dataset contains an (0xFFFF, 0xFFFF) element
         if stop == 0x100000000:
             slice_tags = [
                 tag for tag in all_tags if Tag(start) <= tag <= Tag(stop - 1)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -29,7 +29,7 @@ from pydicom.datadict import (tag_for_keyword, keyword_for_tag,
 from pydicom.tag import Tag, BaseTag, tag_in_exception
 from pydicom.dataelem import DataElement, DataElement_from_raw, RawDataElement
 from pydicom.uid import (UncompressedPixelTransferSyntaxes,
-						 ExplicitVRLittleEndian)
+                         ExplicitVRLittleEndian)
 import pydicom  # for dcmwrite
 import pydicom.charset
 from pydicom.config import logger
@@ -720,7 +720,9 @@ class Dataset(dict):
                     pixel_array = x.get_pixeldata(self)
                     self._pixel_array = self._reshape_pixel_array(pixel_array)
                     if x.needs_to_convert_to_RGB(self):
-                        self._pixel_array = self._convert_YBR_to_RGB(self._pixel_array)
+                        self._pixel_array = self._convert_YBR_to_RGB(
+                            self._pixel_array
+                        )
                     successfully_read_pixel_data = True
                     break
                 except Exception as e:
@@ -747,27 +749,27 @@ class Dataset(dict):
     def decompress(self):
         """Decompresses pixel data and modifies the Dataset in-place
 
-		If not a compressed tranfer syntax, then pixel data is converted
-		to a numpy array internally, but not returned.
+        If not a compressed tranfer syntax, then pixel data is converted
+        to a numpy array internally, but not returned.
 
-		If compressed pixel data, then is decompressed using an image handler,
-		and internal state is updated appropriately:
-		    - TransferSyntax is updated to non-compressed form
-			- is_undefined_length for pixel data is set False
+        If compressed pixel data, then is decompressed using an image handler,
+        and internal state is updated appropriately:
+            - TransferSyntax is updated to non-compressed form
+            - is_undefined_length for pixel data is set False
 
         Returns
         -------
         None
 
-		Raises
+        Raises
         ------
         NotImplementedError
             If the pixel data was originally compressed but file is not
-			ExplicitVR LittleEndian as required by Dicom standard
+            ExplicitVR LittleEndian as required by Dicom standard
         """
         self.convert_pixel_data()
         self.is_decompressed = True
-		# May have been undefined length pixel data, but won't be now
+        # May have been undefined length pixel data, but won't be now
         if 'PixelData' in self:
             self[0x7fe00010].is_undefined_length = False
 

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -682,6 +682,25 @@ class DatasetTests(unittest.TestCase):
         self.assertTrue(
             'SOPInstanceUID' in ds['0x00080018':'0x00080019'])
 
+    def test_getitem_slice_ffff(self):
+        """Test slicing group FFFF tags"""
+        # Issue #92
+        ds = Dataset()
+        ds.CommandGroupLength = 120  # 0000,0000
+        ds.CommandLengthToEnd = 111  # 0000,0001
+        ds.Overlays = 12  # 0000,51B0
+        ds.LengthToEnd = 12  # 0008,0001
+        ds.SOPInstanceUID = '1.2.3.4'  # 0008,0018
+        ds.SkipFrameRangeFlag = 'TEST'  # 0008,9460
+        ds.add_new(0xFFFF0001, 'PN', 'CITIZEN^1')
+        ds.add_new(0xFFFF0002, 'PN', 'CITIZEN^2')
+        ds.add_new(0xFFFF0003, 'PN', 'CITIZEN^3')
+        ds.add_new(0xFFFFFFFE, 'PN', 'CITIZEN^4')
+        ds.add_new(0xFFFFFFFF, 'PN', 'CITIZEN^5')
+
+        ds[:]
+
+
     def test_delitem_slice(self):
         """Test Dataset.__delitem__ using slices."""
         ds = Dataset()

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -700,6 +700,7 @@ class DatasetTests(unittest.TestCase):
 
         assert ds[:][0xFFFFFFFF].value == 'CITIZEN^5'
         assert 0xFFFFFFFF not in ds[0x1000:0xFFFFFFFF]
+        assert 0xFFFFFFFF not in ds[(0x1000):(0xFFFF, 0xFFFF)]
 
     def test_delitem_slice(self):
         """Test Dataset.__delitem__ using slices."""

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -699,7 +699,7 @@ class DatasetTests(unittest.TestCase):
         ds.add_new(0xFFFFFFFF, 'PN', 'CITIZEN^5')
 
         assert ds[:][0xFFFFFFFF].value == 'CITIZEN^5'
-        assert 0xFFFFFFFF not in ds[0x1000:0xFFFFFFF]
+        assert 0xFFFFFFFF not in ds[0x1000:0xFFFFFFFF]
 
     def test_delitem_slice(self):
         """Test Dataset.__delitem__ using slices."""

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -683,7 +683,7 @@ class DatasetTests(unittest.TestCase):
             'SOPInstanceUID' in ds['0x00080018':'0x00080019'])
 
     def test_getitem_slice_ffff(self):
-        """Test slicing group FFFF tags"""
+        """Test slicing with (FFFF,FFFF)"""
         # Issue #92
         ds = Dataset()
         ds.CommandGroupLength = 120  # 0000,0000
@@ -698,8 +698,8 @@ class DatasetTests(unittest.TestCase):
         ds.add_new(0xFFFFFFFE, 'PN', 'CITIZEN^4')
         ds.add_new(0xFFFFFFFF, 'PN', 'CITIZEN^5')
 
-        ds[:]
-
+        assert ds[:][0xFFFFFFFF].value == 'CITIZEN^5'
+        assert 0xFFFFFFFF not in ds[0x1000:0xFFFFFFF]
 
     def test_delitem_slice(self):
         """Test Dataset.__delitem__ using slices."""

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -180,6 +180,16 @@ class WriteFileTests(unittest.TestCase):
         ds.TransferSyntaxUID = '1.1'
         self.assertRaises(ValueError, ds.save_as, self.file_out)
 
+    def test_write_ffff_ffff(self):
+        """Test writing element (FFFF, FFFF) to file #92"""
+        fp = DicomBytesIO()
+        ds = Dataset()
+        ds.file_meta = Dataset()
+        ds.is_little_endian = True
+        ds.is_implicit_VR = True
+        ds.add_new(0xFFFFFFFF, 'LO', '12345')
+        ds.save_as(fp, write_like_original=True)
+
 
 class ScratchWriteDateTimeTests(WriteFileTests):
     """Write and reread simple or multi-value DA/DT/TM data elements"""

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -187,8 +187,12 @@ class WriteFileTests(unittest.TestCase):
         ds.file_meta = Dataset()
         ds.is_little_endian = True
         ds.is_implicit_VR = True
-        ds.add_new(0xFFFFFFFF, 'LO', '12345')
+        ds.add_new(0xFFFFFFFF, 'LO', '123456')
         ds.save_as(fp, write_like_original=True)
+
+        fp.seek(0)
+        ds = dcmread(fp, force=True)
+        assert ds[0xFFFFFFFF].value == b'123456'
 
 
 class ScratchWriteDateTimeTests(WriteFileTests):


### PR DESCRIPTION
#### Reference Issue
Fixes #92 


#### What does this implement/fix? Explain your changes.
When slicing to the end of a Dataset containing a (0xFFFF, 0xFFFF) element, the slice no longer causes an OverflowError