### PR TITLE
[MRG+1] Handle the case where encoding is given as a list in Python 2

### DIFF
--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -226,7 +226,10 @@ def write_PN(fp, data_element, padding=b' ', encoding=None):
         val = data_element.value
 
     if isinstance(val[0], compat.text_type) or not in_py2:
-        val = [elem.encode(encoding) for elem in val]
+        try:
+            val = [elem.encode(encoding) for elem in val]
+        except TypeError:
+            val = [elem.encode(encoding[0]) for elem in val]
 
     val = b'\\'.join(val)
 

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -1826,7 +1826,6 @@ class TestWriteNumbers(object):
 
 class TestWritePN(object):
     """Test filewriter.write_PN"""
-    @pytest.mark.skip("Raises exception due to issue #489")
     def test_no_encoding_unicode(self):
         """If PN element has no encoding info, default is used"""
         fp = DicomBytesIO()
@@ -1979,12 +1978,11 @@ class TestWriteNumbers(object):
 
 class TestWritePN(object):
     """Test filewriter.write_PN"""
-    @pytest.mark.skip("Raises exception due to issue #489")
     def test_no_encoding_unicode(self):
         """If PN element as no encoding info, default is used"""
         fp = DicomBytesIO()
         fp.is_little_endian = True
-        elem = DataElement(0x00100010, 'PN', u'\u03b8')
+        elem = DataElement(0x00100010, 'PN', u'\u00e8')
         write_PN(fp, elem)
 
     def test_no_encoding(self):


### PR DESCRIPTION
- fixes #489

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
Note - I had to change the unicode value to a latin1-compatible one in one test because it uses the standard encoding, which is usually latin-1 under Windows.
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
