### PR TITLE
[MRG+1] Remove Group Length while writing a data set

### DIFF
--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -458,6 +458,9 @@ def write_dataset(fp, dataset, parent_encoding=default_encoding):
     tags = sorted(dataset.keys())
 
     for tag in tags:
+        # do not write retired Group Length (see PS3.5, 7.2)
+        if tag.element == 0 and tag.group > 6:
+            continue
         with tag_in_exception(tag):
             # write_data_element(fp, dataset.get_item(tag), dataset_encoding)
             # XXX for writing raw tags without converting to DataElement

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -39,6 +39,7 @@ ct_name = get_testdata_files("CT_small.dcm")[0]
 mr_name = get_testdata_files("MR_small.dcm")[0]
 jpeg_name = get_testdata_files("JPEG2000.dcm")[0]
 no_ts = get_testdata_files("meta_missing_tsyntax.dcm")[0]
+color_pl_name = get_testdata_files("color-pl.dcm")[0]
 datetime_name = mr_name
 
 unicode_name = get_charset_files("chrH31.dcm")[0]
@@ -193,6 +194,15 @@ class WriteFileTests(unittest.TestCase):
         fp.seek(0)
         ds = dcmread(fp, force=True)
         assert ds[0xFFFFFFFF].value == b'123456'
+
+    def test_write_removes_grouplength(self):
+        ds = dcmread(color_pl_name)
+        assert 0x00080000 in ds
+        ds.save_as(self.file_out, write_like_original=True)
+        self.file_out.seek(0)
+        ds = dcmread(self.file_out)
+        # group length has been removed
+        assert 0x00080000 not in ds
 
 
 class ScratchWriteDateTimeTests(WriteFileTests):


### PR DESCRIPTION
- as recommended by PS3.5, chapter 7.2
- closes #32

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
I did the removal unconditionally and didn't add an option as discussed in the issue - the removal seems to have no effect on tests, and I would rather not add complexity if not needed here.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
