### PR TITLE
[WIP] Fix dataset copy

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1131,6 +1131,13 @@ class Dataset(dict):
                     for elem in dataset.iterall():
                         yield elem
 
+    def copy(self):
+        """Copy the entire dataset.
+
+        Overrides method inherited from dict.
+        """
+        return self[:]
+
     def walk(self, callback, recursive=True):
         """Iterate through the DataElements and run `callback` on each.
 

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -716,6 +716,20 @@ class DatasetTests(unittest.TestCase):
         assert 0xFFFFFFFF not in ds[0x1000:0xFFFFFFFF]
         assert 0xFFFFFFFF not in ds[(0x1000):(0xFFFF, 0xFFFF)]
 
+    def testCopy(self):
+        """Dataset: copy correctly copies the dataset"""
+        d = Dataset()
+        d.SOPInstanceUID = '1.2.3.4'
+        d.BeamSequence = []
+        beam_seq = Dataset()
+        beam_seq.PatientID = '1234'
+        beam_seq.PatientName = 'ANON'
+        d.BeamSequence.append(beam_seq)
+
+        e = d.copy()
+        self.assertTrue(d.SOPInstanceUID == e.SOPInstanceUID)
+        self.assertTrue(d.BeamSequence == e.BeamSequence)
+
     def test_delitem_slice(self):
         """Test Dataset.__delitem__ using slices."""
         ds = Dataset()


### PR DESCRIPTION
Dataset inherits a `copy` method from `dict`, it is however broken because it only performs a shallow copy, which doesn't make sense in the context of a dataset. Added test which shows this, and overrided said method.