### PR TITLE
[MRG + 1] Do not install pip twice for pypi

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -91,8 +91,7 @@ elif [[ "$DISTRIB" == "pypy" ]]; then
     # add the binary to the path
     export PATH="$BIN_PATH:$PATH"
     # install pip
-    python -m ensurepip
-    pip install -U pip
+    python -m ensurepip --upgrade
     if [[ "$NUMPY" == "true" ]] && [[ "$PYTHON_VERSION" == "2.7" ]]; then
         python -m pip install git+https://bitbucket.org/pypy/numpy.git
     # numpypy does not work with pypy3 so fall back on numpy


### PR DESCRIPTION
- fixes permission problem if trying to install pip over an existing pip

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
