### PR TITLE
[MRG+1] Added check for BaseTag in Tag() to avoid costly checks

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -552,7 +552,7 @@ class Dataset(dict):
                     self.fileobj_type, self.filename, self.timestamp,
                     data_elem)
 
-            if tag != (0x08, 0x05):
+            if tag != BaseTag(0x00080005):
                 character_set = self._character_set
             else:
                 character_set = default_encoding

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -272,8 +272,8 @@ def data_element_generator(fp,
                 fp.seek(fp_tell() + length)
                 continue
 
-            if defer_size is not None and length > defer_size and tag != (
-                    0x08, 0x05):
+            if (defer_size is not None and length > defer_size and
+                    tag != BaseTag(0x00080005)):
                 # Flag as deferred by setting value to None, and skip bytes
                 value = None
                 logger_debug("Defer size exceeded. "
@@ -292,7 +292,7 @@ def data_element_generator(fp,
                                                            value[:12], dotdot))
 
             # If the tag is (0008,0005) Specific Character Set, then store it
-            if tag == (0x08, 0x05):
+            if tag == BaseTag(0x00080005):
                 from pydicom.values import convert_string
                 encoding = convert_string(value, is_little_endian,
                                           encoding=default_encoding)
@@ -409,7 +409,7 @@ def read_dataset(fp, is_implicit_VR, is_little_endian, bytelength=None,
             # Read data elements. Stop on some errors, but return what was read
             tag = raw_data_element.tag
             # Check for ItemDelimiterTag --dataset is an item in a sequence
-            if tag == (0xFFFE, 0xE00D):
+            if tag == BaseTag(0xFFFEE00D):
                 break
             raw_data_elements[tag] = raw_data_element
     except StopIteration:

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -65,6 +65,9 @@ def Tag(arg, arg2=None):
     -------
     pydicom.tag.BaseTag
     """
+    if isinstance(arg, BaseTag):
+        return arg
+
     if arg2 is not None:
         arg = (arg, arg2)  # act as if was passed a single tuple
 

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -163,7 +163,7 @@ class BaseTag(BaseTag_base_class):
     def __eq__(self, other):
         """Return True if `self` equals `other`."""
         # Check if comparing with another Tag object; if not, create a temp one
-        if not isinstance(other, BaseTag):
+        if not isinstance(other, BaseTag_base_class):
             try:
                 other = Tag(other)
             except Exception:


### PR DESCRIPTION
- closes #605

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
This is a trivial change to avoid all the checks in `Tag` (well, all but the new check) if the key is already a `BaseTag`, which is the case in the writing code.
This reduces the write time for my test data set from 627 to 410 msec (the reference in pydicom 0.9.9 took 388 msec, so there is still way for improvement).
EDIT: after the second commit, write performance is about the same as in 0.9.9.

<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
