### PR TITLE
[MRG+1] Take SamplesPerPixel into account when correcting ambiguous VR for Pi…

### DIFF
--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -68,9 +68,13 @@ def correct_ambiguous_vr_element(elem, ds, is_little_endian):
                     if ds.BitsAllocated > 8:
                         elem.VR = 'OW'
                     else:
-                        if len(ds.PixelData) / (ds.Rows * ds.Columns) == 2:
+                        nr_pixels = ds.Rows * ds.Columns
+                        if 'SamplesPerPixel' in ds:
+                            nr_pixels *= ds.SamplesPerPixel
+                        pixel_size = len(ds.PixelData) / nr_pixels
+                        if pixel_size == 2:
                             elem.VR = 'OW'
-                        elif len(ds.PixelData) / (ds.Rows * ds.Columns) == 1:
+                        elif pixel_size == 1:
                             elem.VR = 'OB'
             except AttributeError:
                 pass


### PR DESCRIPTION
…xel Data

- fixes crash on reading RGB data with implicit VR
- see #620

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->
I stumbled over this while testing conversion from Explicit to Implicit VR - this should be a pretty straightforward change.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
