### PR TITLE
[MRG+1] Fix handling of bit-packed PixelData

### DIFF
--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -142,8 +142,10 @@ def get_pixeldata(dicom_dataset):
         #  See the following for details:
         #  * DICOM 3.5 Sect 8.1.1 (explanation of bit ordering)
         #  * DICOM Annex D (examples of encoding)
+        print("Type: "+str(type(pixel_bytearray[0])))
         for byte in pixel_bytearray:
-            byte = ord(byte)
+            if isinstance(byte, str):
+                byte = ord(byte)
             for bit in range(bit, bit+8):
                 pixel_array[bit] = byte & 1
                 byte >>= 1

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -104,19 +104,7 @@ def get_pixeldata(dicom_dataset):
 
     pixel_bytearray = dicom_dataset.PixelData
 
-    if dicom_dataset.BitsAllocated == 1:
-        # if single bits are used for binary representation, a uint8 array
-        # has to be converted to a binary-valued array (that is 8 times bigger)
-        try:
-            pixel_array = numpy.unpackbits(
-                numpy.frombuffer(pixel_bytearray, dtype='uint8'))
-        except NotImplementedError:
-            # PyPy2 does not implement numpy.unpackbits
-            raise NotImplementedError(
-                'Cannot handle BitsAllocated == 1 on this platform')
-    else:
-        pixel_array = numpy.frombuffer(pixel_bytearray, dtype=numpy_dtype)
-    length_of_pixel_array = pixel_array.nbytes
+    length_of_pixel_array = len(pixel_bytearray)
     expected_length = dicom_dataset.Rows * dicom_dataset.Columns
     if ('NumberOfFrames' in dicom_dataset and
             dicom_dataset.NumberOfFrames > 1):
@@ -126,6 +114,11 @@ def get_pixeldata(dicom_dataset):
         expected_length *= dicom_dataset.SamplesPerPixel
     if dicom_dataset.BitsAllocated > 8:
         expected_length *= (dicom_dataset.BitsAllocated // 8)
+    elif dicom_dataset.BitsAllocated == 1:
+        # need to take the nearest number of bytes that will be needed
+        #  to encode expected_length
+        expected_bit_length = expected_length
+        expected_length = int(expected_length / 8) + (expected_length % 8 > 0)
     padded_length = expected_length
     if expected_length & 1:
         padded_length += 1
@@ -134,8 +127,34 @@ def get_pixeldata(dicom_dataset):
             "Amount of pixel data %d does not "
             "match the expected data %d" %
             (length_of_pixel_array, padded_length))
-    if expected_length != padded_length:
+
+    # the checks above confirmed the amount of data in PixelData is what
+    #  we expect, now we can unpack it
+    if dicom_dataset.BitsAllocated == 1:
+        # if single bits are used for binary representation, a uint8 array
+        # has to be converted to a binary-valued array (that is 8 times bigger)
+        bit = 0
+        pixel_array = \
+            numpy.ndarray(shape=(length_of_pixel_array*8), dtype='uint8')
+        # bit-packed pixels are packed from the right; i.e., the first pixel
+        #  in the image frame corresponds to the first from the right bit of
+        #  the first byte of the packed PixelData!
+        #  See the following for details:
+        #  * DICOM 3.5 Sect 8.1.1 (explanation of bit ordering)
+        #  * DICOM Annex D (examples of encoding)
+        for byte in pixel_bytearray:
+            for bit in range(bit, bit+8):
+                pixel_array[bit] = byte & 1
+                byte >>= 1
+            bit += 1
+    else:
+        pixel_array = numpy.frombuffer(pixel_bytearray, dtype=numpy_dtype)
+
+    if dicom_dataset.BitsAllocated == 1:
+        pixel_array = pixel_array[:expected_bit_length]
+    elif expected_length != padded_length:
         pixel_array = pixel_array[:expected_length]
+
     if should_change_PhotometricInterpretation_to_RGB(dicom_dataset):
         dicom_dataset.PhotometricInterpretation = "RGB"
     return pixel_array

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -143,6 +143,7 @@ def get_pixeldata(dicom_dataset):
         #  * DICOM 3.5 Sect 8.1.1 (explanation of bit ordering)
         #  * DICOM Annex D (examples of encoding)
         for byte in pixel_bytearray:
+            byte = ord(byte)
             for bit in range(bit, bit+8):
                 pixel_array[bit] = byte & 1
                 byte >>= 1

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -142,7 +142,6 @@ def get_pixeldata(dicom_dataset):
         #  See the following for details:
         #  * DICOM 3.5 Sect 8.1.1 (explanation of bit ordering)
         #  * DICOM Annex D (examples of encoding)
-        print("Type: "+str(type(pixel_bytearray[0])))
         for byte in pixel_bytearray:
             if isinstance(byte, str):
                 byte = ord(byte)

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -1,6 +1,7 @@
 """Use the numpy package to decode pixel transfer syntaxes."""
 import sys
 import pydicom.uid
+from pydicom import compat
 have_numpy = True
 try:
     import numpy
@@ -143,7 +144,7 @@ def get_pixeldata(dicom_dataset):
         #  * DICOM 3.5 Sect 8.1.1 (explanation of bit ordering)
         #  * DICOM Annex D (examples of encoding)
         for byte in pixel_bytearray:
-            if isinstance(byte, str):
+            if compat.in_py2:
                 byte = ord(byte)
             for bit in range(bit, bit+8):
                 pixel_array[bit] = byte & 1

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -264,9 +264,6 @@ class numpy_BigEndian_Tests_with_numpy(unittest.TestCase):
 
 
 @pytest.mark.skipif(not have_numpy_handler, reason=numpy_missing_message)
-@pytest.mark.skipif(
-    in_py2 and platform.python_implementation() == 'PyPy',
-    reason='PyPy2 does not implement unpackbits')
 class OneBitAllocatedTests(unittest.TestCase):
     def setUp(self):
         self.original_handlers = pydicom.config.image_handlers
@@ -288,26 +285,6 @@ class OneBitAllocatedTests(unittest.TestCase):
         assert unpacked_data[0][0][0] == 0
         assert unpacked_data[2][511][511] == 0
         assert unpacked_data[1][256][256] == 1
-
-
-@pytest.mark.skipif(not have_numpy_handler, reason=numpy_missing_message)
-@pytest.mark.skipif(
-    not in_py2 or platform.python_implementation() != 'PyPy',
-    reason='Testing PyPy2 exception only')
-class OneBitAllocatedTestsPyPy2(unittest.TestCase):
-    def setUp(self):
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [numpy_handler]
-
-    def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
-
-    def test_unpack_pixel_data(self):
-        dataset = dcmread(one_bit_allocated_name)
-        packed_data = dataset.PixelData
-        assert len(packed_data) == 3 * 512 * 512 / 8
-        with pytest.raises(NotImplementedError):
-            _ = dataset.pixel_array
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
#### Reference Issue
Aims to resolve the problem identified in https://github.com/pydicom/pydicom/pull/293#pullrequestreview-109529983

#### What does this implement/fix? Explain your changes.

* bits were unpacked from the left, which was incorrect, see discussion in
https://github.com/pydicom/pydicom/pull/293#pullrequestreview-109529983.
Correct unpack order implemented now, whereas first pixel from the left in
the image frame corresponds to the first bit from the right in the packed
PixelData
* fixed consistency checks verifying the size of the PixelData
* reordered the code to perform unpacking after consistency checks
* removed the dependency on numpy.unpackbits and the associated exception

#### Any other comments?
The functionality of the code was verified using the DICOM Segmentation image
dataset being developed in this PR (3x23x38, which illustrates a case where
bits of the individual frame are not aligned at the byte boundary, and the total
length of pixel bits is less than the number of bits required to encode the bytes
in PixelData): https://github.com/QIICR/dcmqi/pull/334,
and this issue: https://github.com/QIICR/dcmqi/issues/341. In turn, consistency of
the rendering of that dataset with the implementation was confirmed for independent
implementations (Brainlab and DCMTK dcm2pnm).

We might consider existing tests, since they are not sufficient to identify the bug in the original implementation of the feature (wrong bit pack order) and incorrect calculation of the expected pixel length for datasets where frame is not byte-aligned.