### PR TITLE
[MRG + 1] Use correct VR for unknown private tags and private creators

### DIFF
--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -473,10 +473,13 @@ def DataElement_from_raw(raw_data_element, encoding=None):
         try:
             VR = dictionary_VR(raw.tag)
         except KeyError:
-
             # just read the bytes, no way to know what they mean
             if raw.tag.is_private:
-                VR = 'OB'
+                # for VR for private tags see PS3.5, 6.2.2
+                if raw.tag.is_private_creator:
+                    VR = 'LO'
+                else:
+                    VR = 'UN'
 
             # group length tag implied in versions < 3.0
             elif raw.tag.element == 0:

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -205,6 +205,11 @@ class BaseTag(BaseTag_base_class):
         """Return True if the tag is private (has an odd group number)."""
         return self.group % 2 == 1
 
+    @property
+    def is_private_creator(self):
+        """Return True if the tag is a private creator."""
+        return self.is_private and 0x0010 <= self.element < 0x0100
+
 
 def TupleTag(group_elem):
     """Fast factory for BaseTag object with known safe (group, elem) tuple"""

--- a/pydicom/tests/test_tag.py
+++ b/pydicom/tests/test_tag.py
@@ -229,6 +229,16 @@ class TestBaseTag(object):
         # Group 0 not private
         assert not BaseTag(0x00000001).is_private
 
+    def test_private_creator(self):
+        """Test BaseTag.is_private_creator returns correct values."""
+        # Non-private tag
+        assert not BaseTag(0x00080010).is_private_creator
+        # private creator have element 0x0010 - 0x00FF
+        assert not BaseTag(0x0009000F).is_private_creator
+        assert BaseTag(0x00090010).is_private_creator
+        assert BaseTag(0x000900FF).is_private_creator
+        assert not BaseTag(0x00090100).is_private_creator
+
     def test_base_class(self):
         """Test the class BaseTag inherits from."""
         if in_py2:


### PR DESCRIPTION
- see PS3.5 6.2.2 and 7.8.1
- see #620 

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->
Private tag VR was always set to OB. I'm not sure if we also shall take into account the private dictionary while reading private tags from implicit VR files, so I left that out - if it is wanted, I can add this.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
