### PR TITLE
[MRG+1] Slight improvement of read performance of sequences

### DIFF
--- a/pydicom/datadict.py
+++ b/pydicom/datadict.py
@@ -67,6 +67,7 @@ def add_dict_entry(tag, VR, keyword, description, VM='1', is_retired=''):
 
     Examples
     --------
+    >>> from pydicom import Dataset
     >>> add_dict_entry(0x10011001, "UL", "TestOne", "Test One")
     >>> add_dict_entry(0x10011002, "DS", "TestTwo", "Test Two", VM='3')
     >>> ds = Dataset()
@@ -95,16 +96,17 @@ def add_dict_entries(new_entries_dict):
 
     Examples
     --------
+    >>> from pydicom import Dataset
     >>> new_dict_items = {
-            0x10011001: ('UL', '1', "Test One", '', 'TestOne'),
-            0x10011002: ('DS', '3', "Test Two", '', 'TestTwo'),
-            }
+    ...        0x10011001: ('UL', '1', "Test One", '', 'TestOne'),
+    ...        0x10011002: ('DS', '3', "Test Two", '', 'TestTwo'),
+    ... }
     >>> add_dict_entries(new_dict_items)
     >>> ds = Dataset()
     >>> ds.TestOne = 'test'
     >>> ds.TestTwo = ['1', '2', '3']
 
-    add_dict_entry(0x10011001, "UL", "TestOne", "Test One")
+    >>> add_dict_entry(0x10011001, "UL", "TestOne", "Test One")
     >>> ds = Dataset()
     >>> ds.TestOne = 'test'
     """
@@ -217,11 +219,13 @@ def repeater_has_tag(tag):
     return (mask_match(tag) in RepeatersDictionary)
 
 
+REPEATER_KEYWORDS = [val[4] for val in RepeatersDictionary.values()]
+
+
 def repeater_has_keyword(keyword):
     """Return True if the DICOM repeaters element
        exists with `keyword`."""
-    repeater_keywords = [val[4] for val in RepeatersDictionary.values()]
-    return (keyword in repeater_keywords)
+    return keyword in REPEATER_KEYWORDS
 
 
 # PRIVATE DICTIONARY handling


### PR DESCRIPTION
- cache repeater keywords for faster lookup
- see #621

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->
The repeater tag lookup was at the top of the cProfile output, so this is an easy fix.
For the SR file I tested (which has a lot of sequences as most SR have) this decreased the read time by 30% - not that much, but I thought it is worth the small change.

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
