### PR TITLE
[MRG+1] Fixing issue #640, OverflowError for valuerep IS

### DIFF
--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -139,6 +139,14 @@ class ISPickleTest(unittest.TestCase):
         self.assertEqual(x.original_string,
                          x2.original_string)
 
+    def testLongInt(self):
+        # Check that a long int is read properly
+        # Will not work with enforce_valid_values
+        x = pydicom.valuerep.IS(3103050000)
+        data1_string = pickle.dumps(x)
+        x2 = pickle.loads(data1_string)
+        self.assertEqual(x.real, x2.real)
+
 
 class BadValueReadtests(unittest.TestCase):
     """Unit tests for handling a bad value for a VR

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -147,6 +147,13 @@ class ISPickleTest(unittest.TestCase):
         x2 = pickle.loads(data1_string)
         self.assertEqual(x.real, x2.real)
 
+    def testOverflow(self):
+        original_flag = config.enforce_valid_values
+        config.enforce_valid_values = True
+        with pytest.raises(OverflowError, match="Value exceeds DICOM limits*"):
+            pydicom.valuerep.IS(3103050000)
+        config.enforce_valid_values = original_flag
+
 
 class BadValueReadtests(unittest.TestCase):
     """Unit tests for handling a bad value for a VR

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -23,6 +23,7 @@ from pydicom import valuerep
 from pydicom.util.fixes import timezone
 from pydicom.data import get_testdata_files
 import unittest
+import pytest
 
 try:
     unittest.skipIf

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -465,7 +465,14 @@ class IS(int):
             return ''
         if isinstance(val, (str, compat.text_type)) and val.strip() == '':
             return ''
-        newval = super(IS, cls).__new__(cls, val)
+        # Overflow error in Python 2 for integers too large
+        # while calling super(IS). Fall back on the regular int
+        # casting that will automatically convert the val to long
+        # if needed.
+        try:
+            newval = super(IS, cls).__new__(cls, val)
+        except OverflowError:
+            newval = int(val)
         # check if a float or Decimal passed in, then could have lost info,
         # and will raise error. E.g. IS(Decimal('1')) is ok, but not IS(1.23)
         if isinstance(val, (float, Decimal)) and newval != val:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
Fixes issue #640 


#### What does this implement/fix? Explain your changes.
Fixing issue 640: in Python 2, creating a valuerep IS() with an integer too long would raise an OverflowError. This is handled already in the code with config.enforce_valid_values if the developer decides to use it. Python 3 seems to be behaving differently.

We're just using the regular int() casting method if the built-in super() function doesn't work.

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
