### PR TITLE
[MRG] Use README.md as long description for PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See [Getting Started](https://pydicom.github.io/pydicom/stable/getting_started.h
 for installation and basic information, and the 
 [User Guide](https://pydicom.github.io/pydicom/stable/pydicom_user_guide.html) 
 for an overview of how to use the pydicom library. 
-To contribute to pydicom, read our [contribution guide](CONTRIBUTING.md). 
+To contribute to pydicom, read our [contribution guide](https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md).
 To contribute an example or extension of pydicom that does not belong with 
 the core software, see our contribution repository, 
 [contrib-pydicom](https://www.github.com/pydicom/contrib-pydicom).

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ pydicom is not a DICOM server, and is not primarily about viewing images.
 It is designed to let you
 manipulate data elements in DICOM files with python code.
 
-Limitations -- the main limitation of the current version is that _compressed_ pixel data (e.g. JPEG)
-cannot be altered in an intelligent way as it can for uncompressed pixels.
-Files can always be read and saved, but compressed pixel data cannot easily be modified.
+Limitations -- for files with _compressed_ pixel data, pydicom can decompress 
+it (with additional libraries installed) and allow you to manipulate the data, 
+but can only store changed pixel data as uncompressed. Files can always be 
+read and saved (including compressed pixel data that has not been modified), 
+but once decompressed, modified pixel data cannot be compressed again.
 
 Documentation
 -------------

--- a/setup.py
+++ b/setup.py
@@ -20,24 +20,6 @@ with open(ver_file) as f:
 
 description = "Pure python package for DICOM medical file reading and writing"
 
-long_description = """
-
-pydicom
-=======
-
-pydicom is a pure python package for parsing DICOM files. DICOM is a standard
-(http://medical.nema.org) for communicating medical images and related
-information such as reports and radiotherapy objects.
-
-pydicom makes it easy to read these complex files into natural pythonic
-structures for easy manipulation.  Modified datasets can be written again to
-DICOM format files. See the `Getting Started
-<https://pydicom.github.io/pydicom/stable/getting_started.html>`_ page for
-installation and basic information, and the `Pydicom User Guide
-<https://pydicom.github.io/pydicom/stable/getting_started.html>`_ page for
-an overview of how to use the pydicom library.
-"""
-
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
 _py_modules = []
@@ -68,7 +50,6 @@ AUTHOR_EMAIL = "darcymason@gmail.com"
 MAINTAINER = "Darcy Mason and contributors"
 MAINTAINER_EMAIL = "darcymason@gmail.com"
 DESCRIPTION = description
-LONG_DESCRIPTION = long_description
 URL = "https://github.com/pydicom/pydicom"
 DOWNLOAD_URL = "https://github.com/pydicom/pydicom/archive/master.zip"
 LICENSE = "MIT"
@@ -76,6 +57,11 @@ VERSION = __version__
 REQUIRES = []
 SETUP_REQUIRES = pytest_runner
 TESTS_REQUIRE = ['pytest']
+
+# get long description from README.md
+BASE_PATH = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(BASE_PATH, 'README.md')) as f:
+    LONG_DESCRIPTION = f.read()
 
 
 def data_files_inventory():
@@ -98,7 +84,8 @@ opts = dict(name=NAME,
             author=AUTHOR,
             author_email=AUTHOR_EMAIL,
             description=description,
-            long_description=long_description,
+            long_description=LONG_DESCRIPTION,
+            long_description_content_type='text/markdown',
             url=URL,
             download_url=DOWNLOAD_URL,
             license=LICENSE,
@@ -112,7 +99,6 @@ opts = dict(name=NAME,
             setup_requires=SETUP_REQUIRES,
             tests_require=TESTS_REQUIRE,
             zip_safe=False)
-
 
 if __name__ == '__main__':
     setup(**opts)


### PR DESCRIPTION
- avoids duplication of description

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->

#### What does this implement/fix? Explain your changes.
I noticed that the description in Pypi had a wrong link, so I thought it a good idea to avoid having separate descriptions on GitHub and PyPi and just use the README.md.
This is possible since the new PyPi site is up and running - you can check how it looks on the [PyPi test page](https://test.pypi.org/project/pydicom-test/).