### PR TITLE
Updated release notes for 1.1.0 release

### DIFF
--- a/doc/whatsnew/v1.1.0.rst
+++ b/doc/whatsnew/v1.1.0.rst
@@ -4,22 +4,38 @@ Version 1.1.0
 Changelog
 ---------
 
-Minor changes
-.............
+Enhancements
+............
 
 * ``UID.__str__`` no longer returns the UID name (when known). The UID name is
   still available using the ``UID.name`` property.
-* ``Dataset`` equality now only compares the dataset's ``DataElements`` (#464).
+* ``Dataset`` equality now only compares the dataset's ``DataElements``
+  (:issue:`464`)
+* the ``codify`` script now supports VRs OD and OL, and works in Python 3
+  (:issue:`498`); documentation has been added for ``codify``
+* the performance for reading and writing datasets has been improved to
+  be better than in pydicom 0.9.9 (:issue:`605`, :issue:`512`)
+* added support for bit-packed pixel data (:issue:`292`)
+* updated DICOM dictionary for 2018b edition
+* added full API documentation to pydicom documentation (:issue:`649`)
 
 Fixes
 .....
 
-* ``UID`` should behave as expected for a python ``str`` subclass (#256).
-* group length elements in groups above 0x0006 removed on writing (#32).
+* ``UID`` should behave as expected for a python ``str`` subclass
+  (:issue:`256`)
+* group length elements in groups above 0x0006 removed on writing
+  (:issue:`32`)
 * fixed ``write_PN`` raising a ``TypeError`` when called with a non-iterable
-  encoding parameter (#489).
+  encoding parameter (:issue:`489`)
+* fixed padding for some odd-sized image data (:issue:`599`)
+* removed unneeded warning for incorrect date string length (:issue:`597`)
 * fixed ``Dataset`` not slicing correctly when an (0xFFFF,0xFFFF) element is
-  present (#92).
+  present (:issue:`92`)
+* use correct VR for unknown private tags and private creators (:issue:`620`)
+* fixed crash on reading RGB data with implicit VR (:issue:`620`)
+* parent encoding was not used in sequences without own encoding (:issue:`625`)
+* fixed error handling for values too large to fit in VR IS (:issue:`640`)
 
 Other
 -----


### PR DESCRIPTION
- added proper links to related issues

Here is the [preview](https://10-65673081-gh.circle-artifacts.com/0/home/ubuntu/pydicom/doc/_build/html/whatsnew/v1.1.0.html).
I scanned all check-ins from the last release - if there will be more before the release, we have to add that, of course.