### PR TITLE
[MRG+2] DA, TM, DT repval fix

### DIFF
--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -1,0 +1,11 @@
+Version 1.2.0
+=================================
+
+Changelog
+---------
+
+Fixes
+.....
+
+* Removed unused ``original_string`` attribute from the ``DataElement`` class
+  (:pull_request:`660`)

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -304,8 +304,6 @@ class DataElement(object):
                     'US or SS or OW', 'US or SS']
         if (self.VR in byte_VRs and len(self.value) > self.maxBytesToDisplay):
             repVal = "Array of %d bytes" % len(self.value)
-        elif hasattr(self, 'original_string'):  # for VR of IS or DS
-            repVal = repr(self.original_string)
         elif isinstance(self.value, UID):
             repVal = self.value.name
         else:

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -299,13 +299,6 @@ class DataElementTests(unittest.TestCase):
         elem[0].PatientID = '1234'
         assert repr(elem) == repr(elem.value)
 
-    def test_repval_original_string(self):
-        """Test DataElement.repval when original_string is present"""
-        elem = DataElement(0x00100010, 'PN', 'ANON')
-        elem.original_string = 'foo'
-        assert "(0010, 0010) Patient's Name" in str(elem)
-        assert "PN: 'foo'" in str(elem)
-
     @unittest.skipIf(sys.version_info >= (3, ), 'Testing Python 2 behavior')
     def test_unicode(self):
         """Test unicode representation of the DataElement"""

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -349,20 +349,31 @@ class DateTimeTests(unittest.TestCase):
         """DA conversion to datetime.date ..."""
         dicom_date = "19610804"
         da = valuerep.DA(dicom_date)
+        # Assert `da` equals to correct `date`
         datetime_date = date(1961, 8, 4)
         self.assertEqual(da, datetime_date,
                          ("DA {0} not equal to date {1}"
                           .format(dicom_date, datetime_date)))
+        # Assert `da.__repr__` holds original string
+        self.assertEqual(repr(da), '"{0}"'.format(dicom_date),
+                         ('DA {0} string representation is not equal to '
+                          'original DICOM string: {1}').format(da, dicom_date))
 
         dicom_date = "1961.08.04"  # ACR-NEMA Standard 300
         da = valuerep.DA(dicom_date)
+        # Assert `da` equals to correct `date`
         datetime_date = date(1961, 8, 4)
         self.assertEqual(da, datetime_date,
                          ("DA {0} not equal to date {1}"
                           .format(dicom_date, datetime_date)))
+        # Assert `da.__repr__` holds original string
+        self.assertEqual(repr(da), '"{0}"'.format(dicom_date),
+                         ('DA {0} string representation is not equal to '
+                          'original DICOM string: {1}').format(da, dicom_date))
 
         dicom_date = ""
         da = valuerep.DA(dicom_date)
+        # Assert `da` equals to no date
         self.assertEqual(da, None,
                          "DA {0} not None".format(dicom_date))
 
@@ -370,30 +381,49 @@ class DateTimeTests(unittest.TestCase):
         """DT conversion to datetime.datetime ..."""
         dicom_datetime = "1961"
         dt = valuerep.DT(dicom_datetime)
+        # Assert `dt` equals to correct `datetime`
         datetime_datetime = datetime(1961, 1, 1)
         self.assertEqual(dt, datetime_datetime,
                          ("DT {0} not equal to datetime {1}"
                           .format(dicom_datetime,
                                   datetime_datetime)))
+        # Assert `dt.__repr__` holds original string
+        self.assertEqual(repr(dt), '"{0}"'.format(dicom_datetime),
+                         ('DT {0} string representation is not equal to '
+                          'original DICOM string: {1}'
+                          .format(dt, dicom_datetime)))
 
         dicom_datetime = "19610804"
         dt = valuerep.DT(dicom_datetime)
+        # Assert `dt` equals to correct `datetime`
         datetime_datetime = datetime(1961, 8, 4)
         self.assertEqual(dt, datetime_datetime,
                          ("DT {0} not equal to datetime {1}"
                           .format(dicom_datetime,
                                   datetime_datetime)))
+        # Assert `dt.__repr__` holds original string
+        self.assertEqual(repr(dt), '"{0}"'.format(dicom_datetime),
+                         ('DT {0} string representation is not equal to '
+                          'original DICOM string: {1}'
+                          .format(dt, dicom_datetime)))
 
         dicom_datetime = "19610804192430.123"
         dt = valuerep.DT(dicom_datetime)
+        # Assert `dt` equals to correct `datetime`
         datetime_datetime = datetime(1961, 8, 4, 19, 24, 30, 123000)
         self.assertEqual(dt, datetime_datetime,
                          ("DT {0} not equal to datetime {1}"
                           .format(dicom_datetime,
                                   datetime_datetime)))
+        # Assert `dt.__repr__` holds original string
+        self.assertEqual(repr(dt), '"{0}"'.format(dicom_datetime),
+                         ('DT {0} string representation is not equal to '
+                          'original DICOM string: {1}'
+                          .format(dt, dicom_datetime)))
 
         dicom_datetime = "196108041924-1000"
         dt = valuerep.DT(dicom_datetime)
+        # Assert `dt` equals to correct `datetime`
         datetime_datetime = datetime(1961, 8, 4, 19, 24, 0, 0,
                                      timezone(timedelta(seconds=-10 * 3600)))
         self.assertEqual(dt, datetime_datetime,
@@ -403,24 +433,42 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(dt.utcoffset(),
                          timedelta(0, 0, 0, 0, 0, -10),
                          "DT offset did not compare correctly to timedelta")
+        # Assert `dt.__repr__` holds original string
+        self.assertEqual(repr(dt), '"{0}"'.format(dicom_datetime),
+                         ('DT {0} string representation is not equal to '
+                          'original DICOM string: {1}'
+                          .format(dt, dicom_datetime)))
 
     def testTime(self):
         """TM conversion to datetime.time..."""
         dicom_time = "2359"
         tm = valuerep.TM(dicom_time)
+        # Assert `tm` equals to correct `time`
         datetime_time = time(23, 59)
         self.assertEqual(tm, datetime_time,
                          ("TM {0} not equal to time {1}"
                           .format(dicom_time, datetime_time)))
+        # Assert `tm.__repr__` holds original string
+        self.assertEqual(repr(tm), '"{0}"'.format(dicom_time),
+                         ('TM {0} string representation is not equal to '
+                          'original DICOM string: {1}'
+                          .format(tm, dicom_time)))
 
         dicom_time = "235900.123"
         tm = valuerep.TM(dicom_time)
+        # Assert `tm` equals to correct `time`
         datetime_time = time(23, 59, 00, 123000)
         self.assertEqual(tm, datetime_time,
                          ("TM {0} not equal to time {1}"
                           .format(dicom_time, datetime_time)))
+        # Assert `tm.__repr__` holds original string
+        self.assertEqual(repr(tm), '"{0}"'.format(dicom_time),
+                         ('TM {0} string representation is not equal to '
+                          'original DICOM string: {1}'
+                          .format(tm, dicom_time)))
 
         dicom_time = ""
+        # Assert `tm` equals to no `time`
         tm = valuerep.TM(dicom_time)
         self.assertEqual(tm, None,
                          "TM {0} not None".format(dicom_time))

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -111,6 +111,9 @@ class DA(date):
         else:
             return super(DA, self).__str__()
 
+    def __repr__(self):
+        return "\"" + str(self) + "\""
+
 
 class DT(datetime):
     """Store value for DICOM VR DT (DateTime) as datetime.datetime.
@@ -218,6 +221,9 @@ class DT(datetime):
         else:
             return super(DT, self).__str__()
 
+    def __repr__(self):
+        return "\"" + str(self) + "\""
+
 
 class TM(time):
     """Store value for DICOM VR of TM (Time) as datetime.time.
@@ -297,6 +303,9 @@ class TM(time):
             return self.original_string
         else:
             return super(TM, self).__str__()
+
+    def __repr__(self):
+        return "\"" + str(self) + "\""
 
 
 class DSfloat(float):

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -503,7 +503,7 @@ class IS(int):
 
     def __repr__(self):
         if hasattr(self, 'original_string'):
-            return "'" + self.original_string + "'"
+            return "\"" + self.original_string + "\""
         else:
             return "\"" + int.__str__(self) + "\""
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

None, afaict.


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

Adds `__repr__` method to `DA`, `TM`, and `DT` values, to make them symmetrical to `IS` and `DS`.

This allows consumers to be able to obtain the original string as the representation of the `DA`/`TM`/`DT` object, instead of something like: `DA(2018, 6, 18)`

#### Any other comments?
<!--
-->

While going through this issue, I also notice that the `DataElement.repval` property tries to use the `original_string` attribute in order to print out the representation string, before falling back to `repr(self.value)`

This, on its own, is fine. However, as far as I could tell, `original_value` is not used/set in `DataElement` instances, but in value instances (`IS`, `DSfloat`, ...) so the `elif` clause in line `pydicom/dataelem.py:307` is never true.

Since I'm not sure I'm missing something here, I just added an extra if clause to the `repval` property, that tries to use the data element value's original string.

If this is indeed a bug, I'm happing to fix it. Also, if checking `DataElement.original_string` is intentional, I can remove the extra if clause that I added and just rely on the value's `__repr__` method.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
