### PR TITLE
Fixed #666 (DataElement with huge str).

### DIFF
--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -302,10 +302,17 @@ class DataElement(object):
     @property
     def repval(self):
         """Return a str representation of the element's `value`."""
-        byte_VRs = ['OB', 'OW', 'OW/OB', 'OW or OB', 'OB or OW',
-                    'US or SS or OW', 'US or SS']
-        if (self.VR in byte_VRs and len(self.value) > self.maxBytesToDisplay):
-            repVal = "Array of %d bytes" % len(self.value)
+        long_VRs = {"OB", "OD", "OF", "OW", "UN", "UT"}
+        if set(self.VR.split(" or ")) & long_VRs:
+            try:
+                length = len(self.value)
+            except TypeError:
+                pass
+            else:
+                if length > self.maxBytesToDisplay:
+                    return "Array of %d elements" % length
+        if self.VM > self.maxBytesToDisplay:
+            repVal = "Array of %d elements" % self.VM
         elif isinstance(self.value, UID):
             repVal = self.value.name
         else:

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -317,6 +317,23 @@ class DataElementTests(unittest.TestCase):
         with pytest.raises(TypeError):
             elem[0]
 
+    def test_repval_large_elem(self):
+        """Test DataElement.repval doesn't return a huge string for a large
+        value"""
+        elem = DataElement(0x00820003, 'UT', 'a'*1000)
+        assert len(elem.repval) < 100
+
+    def test_repval_large_vm(self):
+        """Test DataElement.repval doesn't return a huge string for a large
+        vm"""
+        elem = DataElement(0x00080054, 'AE', 'a\\'*1000+'a')
+        assert len(elem.repval) < 100
+
+    def test_repval_strange_type(self):
+        """Test DataElement.repval doesn't break with bad types"""
+        elem = DataElement(0x00020001, 'OB', 0)
+        assert len(elem.repval) < 100
+
     def test_private_tag_in_repeater_range(self):
         """Test that an unknown private tag (e.g. a tag not in the private
         dictionary) in the repeater range is not handled as a repeater tag

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -138,30 +138,22 @@ class DatasetTests(unittest.TestCase):
         # messages
         ds = Dataset()
         ds.PatientID = "123456"  # Valid value
-        ds.SmallestImagePixelValue = 0  # Invalid value
+        ds.SmallestImagePixelValue = BadRepr()  # Invalid value
 
-        if compat.in_PyPy:
-            expected_msg = ("With tag (0028, 0106) got exception: "
-                            "'int' has no length")
-        else:
-            expected_msg = ("With tag (0028, 0106) got exception: "
-                            "object of type 'int' has no len()")
+        expected_msg = ("With tag (0028, 0106) got exception: "
+                        "bad repr")
 
-        self.failUnlessExceptionArgs(expected_msg, TypeError, lambda: str(ds))
+        self.failUnlessExceptionArgs(expected_msg, ValueError, lambda: str(ds))
 
     def testTagExceptionWalk(self):
         # When recursing through dataset, a tag number should appear in
         # error messages
         ds = Dataset()
         ds.PatientID = "123456"  # Valid value
-        ds.SmallestImagePixelValue = 0  # Invalid value
+        ds.SmallestImagePixelValue = BadRepr()  # Invalid value
 
-        if compat.in_PyPy:
-            expected_msg = ("With tag (0028, 0106) got exception: "
-                            "'int' has no length")
-        else:
-            expected_msg = ("With tag (0028, 0106) got exception: "
-                            "object of type 'int' has no len()")
+        expected_msg = ("With tag (0028, 0106) got exception: "
+                        "bad repr")
 
         def callback(dataset, data_element):
             return str(data_element)
@@ -169,7 +161,7 @@ class DatasetTests(unittest.TestCase):
         def func(dataset=ds):
             return dataset.walk(callback)
 
-        self.failUnlessExceptionArgs(expected_msg, TypeError, func)
+        self.failUnlessExceptionArgs(expected_msg, ValueError, func)
 
     def dummy_dataset(self):
         # This dataset is used by many of the tests
@@ -1526,3 +1518,8 @@ class FileDatasetTests(unittest.TestCase):
         di = dict()
         expected_diff = {'__class__', '__doc__', '__hash__'}
         assert expected_diff == set(dir(di)) - set(dir(ds))
+
+
+class BadRepr(object):
+    def __repr__(self):
+        raise ValueError("bad repr")


### PR DESCRIPTION
#### Reference Issue
Fixes #666 


#### What does this implement/fix? Explain your changes.
Some `DataElement`s have a large `str` representation ATM, this applies trimming more thoroughly.