### PR TITLE
[MRG] Execute date time tests only for the backport to Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,13 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=true
 
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=false PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=true
+
     - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=false
     - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true
     - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=false

--- a/pydicom/tests/test_fixes.py
+++ b/pydicom/tests/test_fixes.py
@@ -12,7 +12,10 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import tzinfo
 
+import pytest
+
 import pydicom as pydicom_module
+from pydicom import compat
 from pydicom.util.fixes import timezone
 
 pickle_choices = [(pickle, pickle, proto)
@@ -82,6 +85,8 @@ class USTimeZone(tzinfo):
 Eastern = USTimeZone(-5, "Eastern",  "EST", "EDT")
 
 
+@pytest.mark.skipif(not compat.in_py2,
+                    reason='only test the backport to Python 2')
 class TestTimeZone(unittest.TestCase):
     """Backport of datetime.timezone tests.
 


### PR DESCRIPTION
- added Tracis config for Python 3.7
- fixes #668

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
