### PR TITLE
[MRG] Fixed syntax of regex check used for doc deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,8 @@ jobs:
       - deploy:
           name: Deploy documentation
           command: |
-            if [[ "${CIRCLE_BRANCH}" =~ "/^master$|^[0-9]+\.[0-9]+\.X$/" ]]; then
-              bash build_tools/circle/push_doc.sh
+            if [[ "${CIRCLE_BRANCH}" =~ ^master$|^[0-9]+\.[0-9]+\.X$ ]]; then
+              bash ./build_tools/circle/push_doc.sh
+            else
+              echo Not pushing ${CIRCLE_BRANCH}
             fi


### PR DESCRIPTION
- docs have not been pushed due to the expression failing
- see #656

#### Any other comments?

Note I didn't succeed to test the actual push in my branch - I only checked that it was executed, but the checkout failed due to the wrong branch.
