### PR TITLE
jpegls_decompress

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -820,19 +820,23 @@ class Dataset(dict):
                     last_exception = e
                     continue
             if not successfully_read_pixel_data:
-                handlers_tried = " ".join(
-                    [str(x) for x in pydicom.config.image_handlers])
-                logger.info("%s did not support this transfer syntax",
-                            handlers_tried)
-                self._pixel_array = None
-                self._pixel_id = None
-                if last_exception:
-                    raise last_exception
-                else:
-                    msg = ("No available image handler could "
-                           "decode this transfer syntax {}".format(
-                               self.file_meta.TransferSyntaxUID.name))
-                    raise NotImplementedError(msg)
+				if self.PixelData.find('PADDING') > 0:
+                    self.PixelData = self.PixelData[0:len(self.PixelData) - 15] + self.PixelData[len(self.PixelData) - 2:len(self.PixelData)]
+                    self.convert_pixel_data()
+				else:
+					handlers_tried = " ".join(
+						[str(x) for x in pydicom.config.image_handlers])
+					logger.info("%s did not support this transfer syntax",
+								handlers_tried)
+					self._pixel_array = None
+					self._pixel_id = None
+					if last_exception:
+						raise last_exception
+					else:
+						msg = ("No available image handler could "
+							   "decode this transfer syntax {}".format(
+								   self.file_meta.TransferSyntaxUID.name))
+						raise NotImplementedError(msg)
             # is this guaranteed to work if memory is re-used??
             self._pixel_id = id(self.PixelData)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
NO

#### What does this implement/fix? Explain your changes.
Enhance the decompress function for the JPEG 2000 Image Compression (Lossless Only) dicom file.

When I invoked the ds.pixel_array function for some JPEG 2000 Image Compression (Lossless Only) dicom files, it throws an exception :"broken data stream when reading image file".  I found the root cause for this error is the PixelData contains the "padding" value. After remove the information, the pixel_array function can work successfully. Here is the sample related dicom file link: https://pan.baidu.com/s/1Qlo6GeQzlFZf7ZAjM_uSsA

Thank you  :)

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
