### PR TITLE
[MRG+1] Allow byte string values for some VRs

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -4,6 +4,8 @@
 Release history
 ===============
 
+.. include:: whatsnew/v1.2.0.rst
+
 .. include:: whatsnew/v1.1.0.rst
 
 .. include:: whatsnew/v1.0.0.rst

--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -4,6 +4,12 @@ Version 1.2.0
 Changelog
 ---------
 
+Enhancements
+............
+
+* Added possibility to set byte strings as value for VRs that use only the
+  default character set (:issue:`624`)
+
 Fixes
 .....
 

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -200,7 +200,7 @@ class DataElement(object):
         #  Last condition covers 'US or SS' etc
         if isString(val) and self.VR not in \
                 ['UT', 'ST', 'LT', 'FL', 'FD', 'AT', 'OB', 'OW', 'OF', 'SL',
-                'SQ', 'SS', 'UL', 'OB/OW', 'OW/OB', 'OB or OW',
+                 'SQ', 'SS', 'UL', 'OB/OW', 'OW/OB', 'OB or OW',
                  'OW or OB', 'UN'] and 'US' not in self.VR:
             if _backslash in val:
                 val = val.split(_backslash)
@@ -239,8 +239,8 @@ class DataElement(object):
         """Convert `val` to an appropriate type for the element's VR."""
 
         # If the value is a byte string and has a VR that can only be encoded
-        # using the default character repertoire, we convert it to a string here
-        # to allow for byte string input in these cases
+        # using the default character repertoire, we convert it to a string
+        # here to allow for byte string input in these cases
         if _is_bytes(val) and self.VR in (
                 'AE', 'AS', 'CS', 'DA', 'DS', 'DT', 'IS', 'TM', 'UI', 'UR'):
             val = val.decode()

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -316,7 +316,7 @@ class WriteDataElementTests(unittest.TestCase):
         self.check_data_element(data_elem, expected)
 
     def test_write_multi_DA(self):
-        data_elem = DataElement(0x0014407E, 'DA', ['20100101', '20101231'])
+        data_elem = DataElement(0x0014407E, 'DA', ['20100101', b'20101231'])
         expected = (b'\x14\x00\x7E\x40'  # tag
                     b'\x12\x00\x00\x00'  # length
                     b'20100101\\20101231 ')  # padded value
@@ -331,11 +331,13 @@ class WriteDataElementTests(unittest.TestCase):
                     b'\x06\x00\x00\x00'  # length
                     b'010203')  # padded value
         self.check_data_element(data_elem, expected)
+        data_elem = DataElement(0x00080030, 'TM', b'010203')
+        self.check_data_element(data_elem, expected)
         data_elem = DataElement(0x00080030, 'TM', time(1, 2, 3))
         self.check_data_element(data_elem, expected)
 
     def test_write_multi_TM(self):
-        data_elem = DataElement(0x0014407C, 'TM', ['082500', '092655'])
+        data_elem = DataElement(0x0014407C, 'TM', ['082500', b'092655'])
         expected = (b'\x14\x00\x7C\x40'  # tag
                     b'\x0E\x00\x00\x00'  # length
                     b'082500\\092655 ')  # padded value
@@ -350,19 +352,51 @@ class WriteDataElementTests(unittest.TestCase):
                     b'\x0E\x00\x00\x00'  # length
                     b'20170101120000')  # value
         self.check_data_element(data_elem, expected)
+        data_elem = DataElement(0x0008002A, 'DT', b'20170101120000')
+        self.check_data_element(data_elem, expected)
         data_elem = DataElement(0x0008002A, 'DT', datetime(2017, 1, 1, 12))
         self.check_data_element(data_elem, expected)
 
     def test_write_multi_DT(self):
         data_elem = DataElement(0x0040A13A, 'DT',
-                                ['20120820120804', '20130901111111'])
+                                ['20120820120804', b'20130901111111'])
         expected = (b'\x40\x00\x3A\xA1'  # tag
                     b'\x1E\x00\x00\x00'  # length
                     b'20120820120804\\20130901111111 ')  # padded value
         self.check_data_element(data_elem, expected)
+        data_elem = DataElement(0x0040A13A, 'DT', u'20120820120804\\20130901111111')
+        self.check_data_element(data_elem, expected)
+        data_elem = DataElement(0x0040A13A, 'DT', b'20120820120804\\20130901111111')
+        self.check_data_element(data_elem, expected)
+
         data_elem = DataElement(0x0040A13A, 'DT',
                                 [datetime(2012, 8, 20, 12, 8, 4),
                                  datetime(2013, 9, 1, 11, 11, 11)])
+        self.check_data_element(data_elem, expected)
+
+    def test_write_ascii_vr_with_padding(self):
+        expected = (b'\x08\x00\x54\x00'  # tag
+                    b'\x0C\x00\x00\x00'  # length
+                    b'CONQUESTSRV ')  # padded value
+        data_elem = DataElement(0x00080054, 'AE', 'CONQUESTSRV')
+        self.check_data_element(data_elem, expected)
+        data_elem = DataElement(0x00080054, 'AE', b'CONQUESTSRV')
+        self.check_data_element(data_elem, expected)
+
+        expected = (b'\x08\x00\x62\x00'  # tag
+                    b'\x06\x00\x00\x00'  # length
+                    b'1.2.3\x00')  # padded value
+        data_elem = DataElement(0x00080062, 'UI', '1.2.3')
+        self.check_data_element(data_elem, expected)
+        data_elem = DataElement(0x00080062, 'UI', b'1.2.3')
+        self.check_data_element(data_elem, expected)
+
+        expected = (b'\x08\x00\x60\x00'  # tag
+                    b'\x04\x00\x00\x00'  # length
+                    b'REG ')
+        data_elem = DataElement(0x00080060, 'CS', 'REG')
+        self.check_data_element(data_elem, expected)
+        data_elem = DataElement(0x00080060, 'CS', b'REG')
         self.check_data_element(data_elem, expected)
 
     def test_write_OD_implicit_little(self):

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -364,9 +364,11 @@ class WriteDataElementTests(unittest.TestCase):
                     b'\x1E\x00\x00\x00'  # length
                     b'20120820120804\\20130901111111 ')  # padded value
         self.check_data_element(data_elem, expected)
-        data_elem = DataElement(0x0040A13A, 'DT', u'20120820120804\\20130901111111')
+        data_elem = DataElement(
+            0x0040A13A, 'DT', u'20120820120804\\20130901111111')
         self.check_data_element(data_elem, expected)
-        data_elem = DataElement(0x0040A13A, 'DT', b'20120820120804\\20130901111111')
+        data_elem = DataElement(
+            0x0040A13A, 'DT', b'20120820120804\\20130901111111')
         self.check_data_element(data_elem, expected)
 
         data_elem = DataElement(0x0040A13A, 'DT',


### PR DESCRIPTION
- all VRs that allow only the default character
  repertoire can now be initialized with a byte string
- closes #624

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
