### PR TITLE
[MRG] Improve performance for multi-frame pixel data

### DIFF
--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -12,3 +12,5 @@ Fixes
 
 * Removed unused ``original_string`` attribute from the ``DataElement`` class
   (:pull_request:`660`)
+* Improve performance for Python 3 when dealing with compressed multi-frame
+  Pixel Data with pillow and jpeg-ls (:issue:`682`).

--- a/pydicom/pixel_data_handlers/jpeg_ls_handler.py
+++ b/pydicom/pixel_data_handlers/jpeg_ls_handler.py
@@ -111,7 +111,7 @@ def get_pixeldata(dicom_dataset):
         numpy_format = numpy_format.newbyteorder('S')
 
     # decompress here
-    UncompressedPixelData = b''
+    UncompressedPixelData = bytearray()
     if ('NumberOfFrames' in dicom_dataset and
             dicom_dataset.NumberOfFrames > 1):
         # multiple compressed frames
@@ -121,7 +121,7 @@ def get_pixeldata(dicom_dataset):
         for frame in CompressedPixelDataSeq:
             decompressed_image = jpeg_ls.decode(
                 numpy.frombuffer(frame, dtype=numpy.uint8))
-            UncompressedPixelData += decompressed_image.tobytes()
+            UncompressedPixelData.extend(decompressed_image.tobytes())
     else:
         # single compressed frame
         CompressedPixelData = pydicom.encaps.defragment_data(

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -174,7 +174,7 @@ def get_pixeldata(dicom_dataset):
         generic_jpeg_file_header = b''
         frame_start_from = 0
     try:
-        UncompressedPixelData = b''
+        UncompressedPixelData = bytearray()
         if ('NumberOfFrames' in dicom_dataset and
                 dicom_dataset.NumberOfFrames > 1):
             # multiple compressed frames
@@ -189,7 +189,7 @@ def get_pixeldata(dicom_dataset):
                     decompressed_image = PILImg.open(fio)
                 except IOError as e:
                     raise NotImplementedError(e.strerror)
-                UncompressedPixelData += decompressed_image.tobytes()
+                UncompressedPixelData.extend(decompressed_image.tobytes())
         else:
             # single compressed frame
             UncompressedPixelData = pydicom.encaps.defragment_data(

--- a/pydicom/tests/test_util.py
+++ b/pydicom/tests/test_util.py
@@ -134,7 +134,7 @@ class TestCodify(object):
 
     def test_code_file(self, capsys):
         """Test utils.codify.code_file"""
-        filename = get_testdata_files("rtplan")[0]
+        filename = get_testdata_files("rtplan.dcm")[0]
         args = ["--save-as", r"c:\temp\testout.dcm", filename]
         codify_main(100, args)
         out, err = capsys.readouterr()


### PR DESCRIPTION
#### Reference Issue
#682


#### What does this implement/fix? Explain your changes.
Switch to using `bytearray` when building the uncompressed pixel data rather than `bytes`. Also changed one of the test_util tests to use the full filename because it kept using 'rtplan.dump' instead of 'rtplan.dcm'.

Time to read the file uploaded in the issue went from 15.9 seconds to 2.8 in python 3.6 and was 2.9 in python 2.7.


#### Any other comments?
The pixel data handlers could use a refactor