### PR TITLE
[MRG+1] Do not handle private tags in repeater range as repeater tags

### DIFF
--- a/pydicom/datadict.py
+++ b/pydicom/datadict.py
@@ -254,9 +254,11 @@ def get_private_entry(tag, private_creator):
         elem_str = "%04x" % tag.elem
         key = "%sxx%s" % (group_str, elem_str[-2:])
         if key not in private_dict:
-            msg = ("Tag {0} not in private dictionary "
-                   "for private creator {1}".format(key, private_creator))
-            raise KeyError(msg)
+            key = "%sxxxx%s" % (group_str[:2], elem_str[-2:])
+            if key not in private_dict:
+                msg = ("Tag {0} not in private dictionary "
+                       "for private creator {1}".format(key, private_creator))
+                raise KeyError(msg)
         dict_entry = private_dict[key]
     return dict_entry
 

--- a/pydicom/datadict.py
+++ b/pydicom/datadict.py
@@ -135,11 +135,11 @@ def get_entry(tag):
     try:
         return DicomDictionary[tag]
     except KeyError:
-        mask_x = mask_match(tag)
-        if mask_x:
-            return RepeatersDictionary[mask_x]
-        else:
-            raise KeyError("Tag {0} not found in DICOM dictionary".format(tag))
+        if not tag.is_private:
+            mask_x = mask_match(tag)
+            if mask_x:
+                return RepeatersDictionary[mask_x]
+        raise KeyError("Tag {0} not found in DICOM dictionary".format(tag))
 
 
 def dictionary_is_retired(tag):

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -348,9 +348,7 @@ class DataElement(object):
 
     def description(self):
         """Return the DICOM dictionary name for the element."""
-        if dictionary_has_tag(self.tag) or repeater_has_tag(self.tag):
-            name = dictionary_description(self.tag)
-        elif self.tag.is_private:
+        if self.tag.is_private:
             name = "Private tag data"  # default
             if hasattr(self, 'private_creator'):
                 try:
@@ -364,6 +362,8 @@ class DataElement(object):
                     pass
             elif self.tag.elem >> 8 == 0:
                 name = "Private Creator"
+        elif dictionary_has_tag(self.tag) or repeater_has_tag(self.tag):
+            name = dictionary_description(self.tag)
 
         # implied Group Length dicom versions < 3
         elif self.tag.element == 0:

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -330,7 +330,7 @@ class DataElementTests(unittest.TestCase):
 
     def test_private_tag_in_repeater_range(self):
         """Test that a private tag in the repeater range is not handled as
-        repeater tag"""
+        repeater tag using Implicit Little Endian transfer syntax."""
         # regression test for #689
         ds = Dataset()
         ds[0x50f10010] = RawDataElement(
@@ -338,12 +338,28 @@ class DataElementTests(unittest.TestCase):
         ds[0x50f1100a] = RawDataElement(
             Tag(0x50f1100a), None, 6, b'ACC0.6', 0, True, True)
         private_creator_tag = ds[0x50f10010]
-        assert private_creator_tag.name == 'Private Creator'
-        assert private_creator_tag.VR == 'LO'
+        assert 'Private Creator' == private_creator_tag.name
+        assert 'LO' == private_creator_tag.VR
 
         private_tag = ds[0x50f1100a]
-        assert private_tag.name == '[FNC Parameters]'
-        assert private_tag.VR == 'UN'
+        assert '[FNC Parameters]' == private_tag.name
+        assert 'UN' == private_tag.VR
+
+    def test_private_repeater_tag(self):
+        """Test that a known private tag in the repeater range is correctly
+        handled using Implicit Little Endian transfer syntax."""
+        ds = Dataset()
+        ds[0x60210012] = RawDataElement(
+            Tag(0x60210012), None, 12, b'PAPYRUS 3.0 ', 0, True, True)
+        ds[0x60211200] = RawDataElement(
+            Tag(0x60211200), None, 6, b'123456', 0, True, True)
+        private_creator_tag = ds[0x60210012]
+        assert 'Private Creator' == private_creator_tag.name
+        assert 'LO' == private_creator_tag.VR
+
+        private_tag = ds[0x60211200]
+        assert '[Overlay ID]' == private_tag.name
+        assert 'UN' == private_tag.VR
 
 
 class RawDataElementTests(unittest.TestCase):

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -328,6 +328,23 @@ class DataElementTests(unittest.TestCase):
         with pytest.raises(TypeError):
             elem[0]
 
+    def test_private_tag_in_repeater_range(self):
+        """Test that a private tag in the repeater range is not handled as
+        repeater tag"""
+        # regression test for #689
+        ds = Dataset()
+        ds[0x50f10010] = RawDataElement(
+            Tag(0x50f10010), None, 8, b'FDMS 1.0', 0, True, True)
+        ds[0x50f1100a] = RawDataElement(
+            Tag(0x50f1100a), None, 6, b'ACC0.6', 0, True, True)
+        private_creator_tag = ds[0x50f10010]
+        assert private_creator_tag.name == 'Private Creator'
+        assert private_creator_tag.VR == 'LO'
+
+        private_tag = ds[0x50f1100a]
+        assert private_tag.name == '[FNC Parameters]'
+        assert private_tag.VR == 'UN'
+
 
 class RawDataElementTests(unittest.TestCase):
     def testKeyError(self):

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -329,21 +329,22 @@ class DataElementTests(unittest.TestCase):
             elem[0]
 
     def test_private_tag_in_repeater_range(self):
-        """Test that a private tag in the repeater range is not handled as
-        repeater tag using Implicit Little Endian transfer syntax."""
+        """Test that an unknown private tag (e.g. a tag not in the private
+        dictionary) in the repeater range is not handled as a repeater tag
+        if using Implicit Little Endian transfer syntax."""
         # regression test for #689
         ds = Dataset()
         ds[0x50f10010] = RawDataElement(
             Tag(0x50f10010), None, 8, b'FDMS 1.0', 0, True, True)
         ds[0x50f1100a] = RawDataElement(
             Tag(0x50f1100a), None, 6, b'ACC0.6', 0, True, True)
-        private_creator_tag = ds[0x50f10010]
-        assert 'Private Creator' == private_creator_tag.name
-        assert 'LO' == private_creator_tag.VR
+        private_creator_data_elem = ds[0x50f10010]
+        assert 'Private Creator' == private_creator_data_elem.name
+        assert 'LO' == private_creator_data_elem.VR
 
-        private_tag = ds[0x50f1100a]
-        assert '[FNC Parameters]' == private_tag.name
-        assert 'UN' == private_tag.VR
+        private_data_elem = ds[0x50f1100a]
+        assert '[FNC Parameters]' == private_data_elem.name
+        assert 'UN' == private_data_elem.VR
 
     def test_private_repeater_tag(self):
         """Test that a known private tag in the repeater range is correctly
@@ -353,13 +354,13 @@ class DataElementTests(unittest.TestCase):
             Tag(0x60210012), None, 12, b'PAPYRUS 3.0 ', 0, True, True)
         ds[0x60211200] = RawDataElement(
             Tag(0x60211200), None, 6, b'123456', 0, True, True)
-        private_creator_tag = ds[0x60210012]
-        assert 'Private Creator' == private_creator_tag.name
-        assert 'LO' == private_creator_tag.VR
+        private_creator_data_elem = ds[0x60210012]
+        assert 'Private Creator' == private_creator_data_elem.name
+        assert 'LO' == private_creator_data_elem.VR
 
-        private_tag = ds[0x60211200]
-        assert '[Overlay ID]' == private_tag.name
-        assert 'UN' == private_tag.VR
+        private_data_elem = ds[0x60211200]
+        assert '[Overlay ID]' == private_data_elem.name
+        assert 'UN' == private_data_elem.VR
 
 
 class RawDataElementTests(unittest.TestCase):


### PR DESCRIPTION
- happened for Implicit Little Endian transfer syntax:
  incorrect VR was taken from the repeater tags
- fixes #689

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
