### PR TITLE
Write original transfer syntax/encoding in filereader.read_dataset()

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -646,11 +646,11 @@ class Dataset(dict):
         """
         tags = self._slice_dataset(slice.start, slice.stop, slice.step)
         dataset = Dataset({tag: self.get_item(tag) for tag in tags})
-        dataset.read_implicit_vr = self.read_implicit_vr
-        dataset.read_little_endian = self.read_little_endian
         dataset.is_little_endian = self.is_little_endian
         dataset.is_implicit_VR = self.is_implicit_VR
-        dataset.read_encoding = self.read_encoding
+        dataset.set_original_encoding(self.read_implicit_vr,
+                                      self.read_little_endian,
+                                      self.read_encoding)
         return dataset
 
     @property
@@ -665,6 +665,16 @@ class Dataset(dict):
                 self.read_implicit_vr == self.is_implicit_VR and
                 self.read_little_endian == self.is_little_endian and
                 self.read_encoding == self._character_set)
+
+    def set_original_encoding(self, is_implicit_vr, is_little_endian,
+                              character_encoding):
+        """Set the values for the original transfer syntax and encoding.
+        Can be used for a dataset with raw data elements to enable
+        optimized writing (e.g. without decoding the data elements).
+        """
+        self.read_implicit_vr = is_implicit_vr
+        self.read_little_endian = is_little_endian
+        self.read_encoding = character_encoding
 
     def group_dataset(self, group):
         """Return a Dataset containing only DataElements of a certain group.

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -889,9 +889,7 @@ class DatasetTests(unittest.TestCase):
 
         # simulate reading
         ds.SpecificCharacterSet = 'ISO_IR 100'
-        ds.read_little_endian = True
-        ds.read_implicit_vr = True
-        ds.read_encoding = ['latin_1', 'latin_1', 'latin_1']
+        ds.set_original_encoding(True, True, ['latin_1', 'latin_1', 'latin_1'])
         assert not ds.is_original_encoding
 
         ds.is_little_endian = True


### PR DESCRIPTION
- was only done in filreader.read_partial(), which does not cover all cases
- added convenience method Dataset.set_original_encoding:
  can be used after creating a dataset with raw data elements
  (as is done in pynetdicom3)

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->
I noticed that in the 'storescp` implementation in `pynetdicom3` the files are not written using the raw data element optimization, even if the encoding did not change. To allow this, we need to adapt the orginal values in `filereader.read_dataset()' as done in this PR, and also update the newly created dataset in `storescp` - thus the convenience function to set all three values.  

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
