### PR TITLE
Added support for some common misspelled character set values

### DIFF
--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -1,5 +1,6 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Handle alternate character sets for character strings."""
+import warnings
 
 from pydicom import compat
 from pydicom.valuerep import PersonNameUnicode, text_VRs
@@ -93,7 +94,25 @@ def convert_encodings(encodings):
     # Assume that it is already the python encoding
     # (is there a way to check this?)
     except KeyError:
-        pass
+        # check for some common mistakes in encodings
+        patched_encodings = []
+        patched = {}
+        for x in encodings:
+            if x.startswith('ISO-IR') or x.startswith('ISO IR'):
+                patched[x] = 'ISO_IR' + x[6:]
+                patched_encodings.append(patched[x])
+            else:
+                patched_encodings.append(x)
+        if patched:
+            try:
+                encodings = [python_encoding[x] for x in patched_encodings]
+                for old, new in patched.items():
+                    warnings.warn("Incorrect value for Specific Character "
+                                  "Set '{}' - assuming '{}'".format(old, new))
+            except KeyError:
+                # Assume that it is already the python encoding
+                # (is there a way to check this?)
+                pass
 
     if len(encodings) == 1:
         encodings = [encodings[0]] * 3


### PR DESCRIPTION
- patches "ISO IR XXX" and "ISO-IR XXX" to "ISO_IR XXX" while reading
- issues a warning for each patch
Note: I met both of these in the wild (the second form just recently)

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
I have been reminded of this by [this issue](https://github.com/pydicom/pynetdicom3/issues/201). We have been using a similar fix in another library (based on dcmtk) some time ago, as this kind of data pops up every now and then.

<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
