### PR TITLE
[MRG] Fix Pillow pixel data handler for non-JPEG2k transfer syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=true
 
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=jpeg  JPEG2000=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=jpeg  JPEG2000=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=jpeg  JPEG2000=false JPEG_LS=false GDCM=false
 
     - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=false
     - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,37 +14,39 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=true
 
     - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=false PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=true
 
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=true
 
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=false PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=true
 
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=false PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=true  JPEG2000=false JPEG_LS=true  GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=true
+
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=jpeg  JPEG2000=false JPEG_LS=false GDCM=false
 
     - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=false
     - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -45,8 +45,11 @@ if [[ "$DISTRIB" == "conda" ]]; then
     if [[ "$JPEG2000" == "true" ]]; then
         sudo apt-get install libopenjp2-7 libopenjp2-7-dev
     fi
-    if [[ "$PILLOW" == "true" ]]; then
+    if [[ "$PILLOW" == "both" ]]; then
         conda install --yes pillow jpeg
+    elif [[ "$PILLOW" == "jpeg" ]]; then
+        conda install --yes jpeg
+        pip install pillow --global-option="build_ext" --global-option="--disable-jpeg2000"
     fi
     if [[ "$JPEG_LS" == "true" ]]; then
         conda install --yes cython

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -47,9 +47,12 @@ if [[ "$DISTRIB" == "conda" ]]; then
     fi
     if [[ "$PILLOW" == "both" ]]; then
         conda install --yes pillow jpeg
+        python -c "from PIL import _imaging; print('JPEG plugin:', hasattr(_imaging, 'jpeg_decoder'))"
+        python -c "from PIL import _imaging; print('JPEG2k plugin:', hasattr(_imaging, 'jpeg2k_decoder'))"
     elif [[ "$PILLOW" == "jpeg" ]]; then
-        conda install --yes jpeg
         pip install pillow --global-option="build_ext" --global-option="--disable-jpeg2000"
+        python -c "from PIL import _imaging; print('JPEG plugin:', hasattr(_imaging, 'jpeg_decoder'))"
+        python -c "from PIL import _imaging; print('JPEG2k plugin:', hasattr(_imaging, 'jpeg2k_decoder'))"
     fi
     if [[ "$JPEG_LS" == "true" ]]; then
         conda install --yes cython

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -160,10 +160,8 @@ def get_pixeldata(dicom_dataset):
         if dicom_dataset.BitsAllocated > 8:
             raise NotImplementedError("JPEG Lossy only supported if "
                                       "Bits Allocated = 8")
-        generic_jpeg_file_header = (
-            b'\xff\xd8\xff\xe0\x00\x10'
-            b'JFIF\x00\x01\x01\x01\x00\x01\x00\x01\x00\x00')
-        frame_start_from = 2
+        generic_jpeg_file_header = b''
+        frame_start_from = 0
     elif (dicom_dataset.file_meta.TransferSyntaxUID in
           PillowJPEG2000TransferSyntaxes):
         logger.debug("This is a JPEG 2000 format")
@@ -175,6 +173,7 @@ def get_pixeldata(dicom_dataset):
         logger.debug("This is a another pillow supported format")
         generic_jpeg_file_header = b''
         frame_start_from = 0
+
     try:
         UncompressedPixelData = bytearray()
         if ('NumberOfFrames' in dicom_dataset and


### PR DESCRIPTION
#### Reference Issue
Fixes #663


#### What does this implement/fix? Explain your changes.

* Adds travis builds for pillow without JP2k to reproduce the issue
* Removes the addition of an APP marker with JFIF to the pixel data when handling JPEG Baseline transfer syntaxes with the pillow handler.
