### PR TITLE
[MRG] Changed handling of Pixel Data with undefined VR

### DIFF
--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -57,22 +57,18 @@ def correct_ambiguous_vr_element(elem, ds, is_little_endian):
                 #   If encapsulated, VR is OB and length is undefined
                 if elem.is_undefined_length:
                     elem.VR = 'OB'
+                # Non-compressed Pixel Data - Implicit Little Endian
+                # PS3.5 Annex A1: VR is always OW
+                elif ds.is_implicit_VR:
+                    elem.VR = 'OW'
                 else:
-                    # Non-compressed Pixel Data
-                    # If BitsAllocated is > 8 then OW, else may be OB or OW
-                    #   as per PS3.5 Annex A.2. For BitsAllocated < 8 test the
-                    #    size of each pixel to see if its written in OW or OB
-                    if ds.BitsAllocated > 8:
-                        elem.VR = 'OW'
-                    else:
-                        nr_pixels = ds.Rows * ds.Columns
-                        if 'SamplesPerPixel' in ds:
-                            nr_pixels *= ds.SamplesPerPixel
-                        pixel_size = len(ds.PixelData) / nr_pixels
-                        if pixel_size == 2:
-                            elem.VR = 'OW'
-                        elif pixel_size == 1:
-                            elem.VR = 'OB'
+                    # Non-compressed Pixel Data - Explicit VR
+                    # PS3.5 Annex A.2:
+                    # If BitsAllocated is > 8 then VR shall be OW,
+                    # else may be OB or OW.
+                    # If we get here, the data has not been written before,
+                    # so we default to OB for BitsAllocated 1 or 8
+                    elem.VR = 'OW' if ds.BitsAllocated > 8 else 'OB'
             except AttributeError:
                 pass
 

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -50,27 +50,23 @@ def correct_ambiguous_vr_element(elem, ds, is_little_endian):
 
         # 'OB or OW': 7fe0,0010 PixelData
         if elem.tag == 0x7fe00010:
-
-            try:
-                # Compressed Pixel Data
-                # PS3.5 Annex A.4
-                #   If encapsulated, VR is OB and length is undefined
-                if elem.is_undefined_length:
-                    elem.VR = 'OB'
-                # Non-compressed Pixel Data - Implicit Little Endian
-                # PS3.5 Annex A1: VR is always OW
-                elif ds.is_implicit_VR:
-                    elem.VR = 'OW'
-                else:
-                    # Non-compressed Pixel Data - Explicit VR
-                    # PS3.5 Annex A.2:
-                    # If BitsAllocated is > 8 then VR shall be OW,
-                    # else may be OB or OW.
-                    # If we get here, the data has not been written before,
-                    # so we default to OB for BitsAllocated 1 or 8
-                    elem.VR = 'OW' if ds.BitsAllocated > 8 else 'OB'
-            except AttributeError:
-                pass
+            # Compressed Pixel Data
+            # PS3.5 Annex A.4
+            #   If encapsulated, VR is OB and length is undefined
+            if elem.is_undefined_length:
+                elem.VR = 'OB'
+            # Non-compressed Pixel Data - Implicit Little Endian
+            # PS3.5 Annex A1: VR is always OW
+            elif ds.is_implicit_VR:
+                elem.VR = 'OW'
+            else:
+                # Non-compressed Pixel Data - Explicit VR
+                # PS3.5 Annex A.2:
+                # If BitsAllocated is > 8 then VR shall be OW,
+                # else may be OB or OW.
+                # If we get here, the data has not been written before,
+                # so we default to OB for BitsAllocated 1 or 8
+                elem.VR = 'OW' if ds.BitsAllocated > 8 else 'OB'
 
         # 'US or SS' and dependent on PixelRepresentation
         elif elem.tag in [

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -716,47 +716,28 @@ class TestCorrectAmbiguousVR(unittest.TestCase):
         ref_ds.BitsAllocated = 16
         ref_ds.PixelData = b'\x00\x01'  # Little endian 256
         ds = correct_ambiguous_vr(deepcopy(ref_ds), True)  # Little endian
-        self.assertEqual(ds.PixelData, b'\x00\x01')
-        self.assertEqual(ds[0x7fe00010].VR, 'OW')
+        assert b'\x00\x01' == ds.PixelData
+        assert 'OW' == ds[0x7fe00010].VR
         ds = correct_ambiguous_vr(deepcopy(ref_ds), False)  # Big endian
-        self.assertEqual(ds.PixelData, b'\x00\x01')
-        self.assertEqual(ds[0x7fe00010].VR, 'OW')
+        assert b'\x00\x01' == ds.PixelData
+        assert 'OW' == ds[0x7fe00010].VR
 
-        # If BitsAllocated <= 8 then VR can be OB or OW: OW
+        # If BitsAllocated <= 8 then VR can be OB or OW: we set it to OB
         ref_ds = Dataset()
         ref_ds.BitsAllocated = 8
         ref_ds.Rows = 2
         ref_ds.Columns = 2
         ref_ds.PixelData = b'\x01\x00\x02\x00\x03\x00\x04\x00'
         ds = correct_ambiguous_vr(deepcopy(ref_ds), True)
-        self.assertEqual(ds.PixelData, b'\x01\x00\x02\x00\x03\x00\x04\x00')
-        self.assertEqual(ds[0x7fe00010].VR, 'OW')
-
-        # If BitsAllocated <= 8 then VR can be OB or OW: OB
-        ref_ds = Dataset()
-        ref_ds.BitsAllocated = 8
-        ref_ds.Rows = 2
-        ref_ds.Columns = 2
-        ref_ds.PixelData = b'\x01\x02\x03\x04'
-        ds = correct_ambiguous_vr(deepcopy(ref_ds), True)
-        self.assertEqual(ds.PixelData, b'\x01\x02\x03\x04')
-        self.assertEqual(ds[0x7fe00010].VR, 'OB')
+        assert b'\x01\x00\x02\x00\x03\x00\x04\x00' == ds.PixelData
+        assert 'OB' == ds[0x7fe00010].VR
 
         # If no BitsAllocated then VR should be unchanged
         ref_ds = Dataset()
         ref_ds.PixelData = b'\x00\x01'  # Big endian 1
         ds = correct_ambiguous_vr(deepcopy(ref_ds), True)
-        self.assertEqual(ds.PixelData, b'\x00\x01')
-        self.assertEqual(ds[0x7fe00010].VR, 'OB or OW')
-
-        # If required elements missing then VR should be unchanged
-        ref_ds = Dataset()
-        ref_ds.BitsAllocated = 8
-        ref_ds.Rows = 2
-        ref_ds.PixelData = b'\x01\x02\x03\x04'
-        ds = correct_ambiguous_vr(deepcopy(ref_ds), True)
-        self.assertEqual(ds.PixelData, b'\x01\x02\x03\x04')
-        self.assertEqual(ds[0x7fe00010].VR, 'OB or OW')
+        assert b'\x00\x01' == ds.PixelData
+        assert 'OB or OW' == ds[0x7fe00010].VR
 
     def test_waveform_bits_allocated(self):
         """Test correcting elements which require WaveformBitsAllocated."""
@@ -1340,7 +1321,8 @@ class TestWriteToStandard(object):
         fp.seek(0)
         ds_impl = dcmread(fp)
         for elem_orig, elem_conv in zip(ds_orig, ds_impl):
-            assert elem_orig == elem_conv
+            assert elem_orig.value == elem_conv.value
+        assert 'OW' == ds_impl[0x7fe00010].VR
 
         ds_impl.is_implicit_VR = False
         ds_impl.is_little_endian = True
@@ -1351,7 +1333,7 @@ class TestWriteToStandard(object):
         # used to raise, see #620
         ds_expl = dcmread(fp)
         for elem_orig, elem_conv in zip(ds_orig, ds_expl):
-            assert elem_orig == elem_conv
+            assert elem_orig.value == elem_conv.value
 
     def test_transfer_syntax_not_added(self):
         """Test TransferSyntaxUID is not added if ExplVRLE."""

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -732,12 +732,11 @@ class TestCorrectAmbiguousVR(unittest.TestCase):
         assert b'\x01\x00\x02\x00\x03\x00\x04\x00' == ds.PixelData
         assert 'OB' == ds[0x7fe00010].VR
 
-        # If no BitsAllocated then VR should be unchanged
+        # If no BitsAllocated set then AttributesError is raised
         ref_ds = Dataset()
         ref_ds.PixelData = b'\x00\x01'  # Big endian 1
-        ds = correct_ambiguous_vr(deepcopy(ref_ds), True)
-        assert b'\x00\x01' == ds.PixelData
-        assert 'OB or OW' == ds[0x7fe00010].VR
+        with pytest.raises(AttributeError):
+            correct_ambiguous_vr(deepcopy(ref_ds), True)
 
     def test_waveform_bits_allocated(self):
         """Test correcting elements which require WaveformBitsAllocated."""
@@ -884,18 +883,6 @@ class TestCorrectAmbiguousVRElement(object):
         assert type(out) == DataElement
         assert out.VR == 'US'
         assert out.value == 0xfffe
-
-    def test_pixel_data_not_ow_or_ob(self):
-        """Test no change if can't figure out bit depth"""
-        ds = Dataset()
-        ds.Rows = 1
-        ds.Columns = 1
-        ds.PixelData = b'\x00\x01\x02'
-        ds[0x7fe00010].VR = 'OB or OW'
-        out = correct_ambiguous_vr_element(ds[0x7fe00010], ds, True)
-        assert out.VR == 'OB or OW'
-        assert out.tag == 0x7fe00010
-        assert out.value == b'\x00\x01\x02'
 
 
 class WriteAmbiguousVRTests(unittest.TestCase):


### PR DESCRIPTION
- always set to OW for Implicit Little Endian (as per standard)
- always set to OB for BitsAllocated <= 8

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
I got a crash report from a former collegue using pynetdicom3 for multi-frame files with implicit VR, so I checked this code again, and also noticed that it didn't handle data with BitsAllocated = 1 (additionally to multi-frame data). 
Note that the behavior has slightly changed, as described in the commit comment. Additionally, the absence of some tags is not handled as before. The handling (e.g. the attribute error is caught, and the program will crash because of the invalid VR later) has remained for BitsAllocated, though I would find it more logical to not catch that error at all, e.g. raise an attribute error because of the missing tag instead of a later error due to an unhandled VR. What do you think?


<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
