### PR TITLE
[MRG] Fix the regex for char set values to not include correct values

### DIFF
--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -97,7 +97,7 @@ def convert_encodings(encodings):
         patched_encodings = []
         patched = {}
         for x in encodings:
-            if re.match('^ISO.IR', x):
+            if re.match('^ISO[^_]IR', x):
                 patched[x] = 'ISO_IR' + x[6:]
                 patched_encodings.append(patched[x])
             else:
@@ -106,8 +106,9 @@ def convert_encodings(encodings):
             try:
                 encodings = [python_encoding[x] for x in patched_encodings]
                 for old, new in patched.items():
-                    warnings.warn("Incorrect value for Specific Character "
-                                  "Set '{}' - assuming '{}'".format(old, new))
+                    warnings.warn("Incorrect value for Specific Character Set "
+                                  "'{}' - assuming '{}'".format(old, new),
+                                  stacklevel=2)
             except KeyError:
                 # assume that it is already a python encoding
                 # otherwise, a LookupError will be raised in the using code

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -130,12 +130,13 @@ class CharsetTests(unittest.TestCase):
             pydicom.charset.decode(elem, ['ISO IR 192'])
             assert u'Buc^J\xe9r\xf4me' == elem.value
 
-        elem = DataElement(0x00100010, 'PN', b'Buc^J\xc3\xa9r\xc3\xb4me')
+        elem = DataElement(0x00100010, 'PN', b'Buc^J\xe9r\xf4me')
         with pytest.warns(UserWarning,
                           match='Incorrect value for Specific Character Set '
-                                "'ISO-IR 192' - assuming 'ISO_IR 192'"):
-            pydicom.charset.decode(elem, ['ISO-IR 192'])
-            assert u'Buc^J\xe9r\xf4me' == elem.value
+                                "'ISO-IR 144' - assuming 'ISO_IR 144'") as w:
+            pydicom.charset.decode(elem, ['ISO_IR 100', 'ISO-IR 144'])
+            # make sure no warning is issued for the correct value
+            assert 1 == len(w)
 
         # not patched incorrect encoding raises
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xc3\xa9r\xc3\xb4me')


### PR DESCRIPTION
- this avoids warnings on correct values, if not all of multiple values
  have to be patched
- use stacktrace=2 for the warning for the stacktrace line to make a bit more sense
- removed code that deleted the first encoding for PN if only one component is present

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
This is a minor cosmetic change to #695. This came up in the related [pynetdicom3 issue](https://github.com/pydicom/pynetdicom3/issues/201#issuecomment-411740471).

<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
