### PR TITLE
[MRG] Ignore gh-pages branch in Circle builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
       DOC_URL: ""
       # The email is to be used for commits in the Github Page
       EMAIL: g.lemaitre58@gmail.com
+    branches:
+      - ignore:
+        - gh-pages
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       # The email is to be used for commits in the Github Page
       EMAIL: g.lemaitre58@gmail.com
     branches:
-      - ignore:
+      ignore:
         - gh-pages
     steps:
       - checkout


### PR DESCRIPTION
#### Reference Issue
Fixes #702


#### What does this implement/fix? Explain your changes.
gh-pages branch ignored in Circle

#### Any other comments?
I've switched the 'Only build pull requests' option back to 'off'.