### PR TITLE
[MRG+1] Raise ValueError if endianess is not set in dataset

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -44,8 +44,6 @@ try:
 except ImportError:
     have_numpy = False
 
-sys_is_little_endian = (sys.byteorder == 'little')
-
 
 class PropertyError(Exception):
     """For AttributeErrors caught in a property, so do not go to __getattr__"""

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -32,9 +32,6 @@ from pydicom.util.hexutil import bytes2hex
 from pydicom.valuerep import extra_length_VRs
 
 
-sys_is_little_endian = (byteorder == 'little')
-
-
 class DicomIter(object):
     """Iterator over DICOM data elements created from a file-like object"""
 

--- a/pydicom/pixel_data_handlers/jpeg_ls_handler.py
+++ b/pydicom/pixel_data_handlers/jpeg_ls_handler.py
@@ -4,9 +4,9 @@ Use the jpeg_ls (CharPyLS) python package
 to decode pixel transfer syntaxes.
 """
 
-import sys
 import pydicom
 import pydicom.uid
+from pydicom.pixel_data_handlers.util import dtype_corrected_for_endianess
 
 have_numpy = True
 try:
@@ -21,7 +21,6 @@ try:
 except ImportError:
     have_jpeg_ls = False
     raise
-sys_is_little_endian = (sys.byteorder == 'little')
 
 JPEGLSSupportedTransferSyntaxes = [
     pydicom.uid.JPEGLSLossless,
@@ -108,9 +107,8 @@ def get_pixeldata(dicom_dataset):
                    dicom_dataset.BitsAllocated))
         raise TypeError(msg)
 
-    if (dicom_dataset.is_little_endian !=
-            sys_is_little_endian):
-        numpy_format = numpy_format.newbyteorder('S')
+    numpy_format = dtype_corrected_for_endianess(
+        dicom_dataset.is_little_endian, numpy_format)
 
     # decompress here
     UncompressedPixelData = bytearray()

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -1,17 +1,16 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Use the numpy package to decode pixel transfer syntaxes."""
 
-import sys
 import pydicom.uid
 from pydicom import compat
+from pydicom.pixel_data_handlers.util import dtype_corrected_for_endianess
+
 have_numpy = True
 try:
     import numpy
 except ImportError:
     have_numpy = False
     raise
-
-sys_is_little_endian = (sys.byteorder == 'little')
 
 NumpySupportedTransferSyntaxes = [
     pydicom.uid.ExplicitVRLittleEndian,
@@ -102,8 +101,8 @@ def get_pixeldata(dicom_dataset):
                    dicom_dataset.BitsAllocated))
         raise TypeError(msg)
 
-    if dicom_dataset.is_little_endian != sys_is_little_endian:
-        numpy_dtype = numpy_dtype.newbyteorder('S')
+    numpy_dtype = dtype_corrected_for_endianess(
+        dicom_dataset.is_little_endian, numpy_dtype)
 
     pixel_bytearray = dicom_dataset.PixelData
 

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -1,11 +1,13 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Use the pillow python package to decode pixel transfer syntaxes."""
 
-import sys
 import io
 import pydicom.encaps
 import pydicom.uid
 import logging
+
+from pydicom.pixel_data_handlers.util import dtype_corrected_for_endianess
+
 have_numpy = True
 logger = logging.getLogger('pydicom')
 try:
@@ -40,7 +42,6 @@ PillowJPEGTransferSyntaxes = [
     pydicom.uid.JPEGBaseLineLossy12bit,
 ]
 
-sys_is_little_endian = (sys.byteorder == 'little')
 have_pillow_jpeg_plugin = False
 have_pillow_jpeg2000_plugin = False
 try:
@@ -150,8 +151,8 @@ def get_pixeldata(dicom_dataset):
                    dicom_dataset.BitsAllocated))
         raise TypeError(msg)
 
-    if dicom_dataset.is_little_endian != sys_is_little_endian:
-        numpy_format = numpy_format.newbyteorder('S')
+    numpy_format = dtype_corrected_for_endianess(
+        dicom_dataset.is_little_endian, numpy_format)
 
     # decompress here
     if (dicom_dataset.file_meta.TransferSyntaxUID in

--- a/pydicom/pixel_data_handlers/rle_handler.py
+++ b/pydicom/pixel_data_handlers/rle_handler.py
@@ -1,6 +1,5 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 
-import sys
 import pydicom.uid
 import pydicom.encaps
 from struct import unpack
@@ -10,8 +9,6 @@ try:
 except ImportError:
     have_numpy = False
     raise
-
-sys_is_little_endian = (sys.byteorder == 'little')
 
 RLESupportedTransferSyntaxes = [
     pydicom.uid.RLELossless,

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -1,0 +1,39 @@
+# Copyright 2008-2018 pydicom authors. See LICENSE file for details.
+"""Utility functions used in the pixel data handlers."""
+
+import sys
+
+sys_is_little_endian = (sys.byteorder == 'little')
+
+
+def dtype_corrected_for_endianess(is_little_endian, numpy_dtype):
+    """Adapts the given numpy data type for changing the endianess of the
+    dataset, if needed.
+
+        Parameters
+        ----------
+        is_little_endian : bool
+            The endianess of the affected dataset.
+        numpy_dtype : numpy.dtype
+            The numpy data type used for the pixel data without considering
+            endianess.
+
+        Raises
+        ------
+        ValueError
+            If `is_little_endian` id None, e.g. not initialized.
+
+        Returns
+        -------
+        numpy.dtype
+            The numpy data type to be used for the pixel data, considering
+            the endianess.
+    """
+    if is_little_endian is None:
+        raise ValueError("Dataset attribute 'is_little_endian' "
+                         "has to be set before writing the dataset")
+
+    if is_little_endian != sys_is_little_endian:
+        return numpy_dtype.newbyteorder('S')
+
+    return numpy_dtype

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -182,6 +182,11 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
     def tearDown(self):
         pydicom.config.image_handlers = self.original_handlers
 
+    def test_raises_if_endianess_not_set(self):
+        self.jpeg_ls_lossless.is_little_endian = None
+        with pytest.raises(ValueError):
+            _ = self.jpeg_ls_lossless.pixel_array
+
     def test_JPEG_LS_PixelArray(self):
         a = self.jpeg_ls_lossless.pixel_array
         b = self.mr_small.pixel_array

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -301,6 +301,11 @@ class numpy_LittleEndian_Tests(unittest.TestCase):
     def tearDown(self):
         pydicom.config.image_handlers = self.original_handlers
 
+    def test_raises_if_endianess_not_set(self):
+        self.odd_size_image.is_little_endian = None
+        with pytest.raises(ValueError):
+            _ = self.odd_size_image.pixel_array
+
     def test_little_endian_PixelArray_odd_data_size(self):
         pixel_data = self.odd_size_image.pixel_array
         assert pixel_data.nbytes == 27

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -289,6 +289,11 @@ class Test_JPEG2000Tests_with_pillow(object):
         """Reset the pixel data handlers."""
         pydicom.config.image_handlers = self.original_handlers
 
+    def test_raises_if_endianess_not_set(self):
+        self.jpeg_2k_lossless.is_little_endian = None
+        with pytest.raises(ValueError):
+            _ = self.jpeg_2k_lossless.pixel_array
+
     def testJPEG2000(self):
         """Test reading element values works OK with pillow pixel handler."""
         # XX also tests multiple-valued AT data element


### PR DESCRIPTION
- adapted pixel handlers where endianess is explicitely adapted
- fixes #704

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
