### PR TITLE
[MRG] Do not remove the first encoding for multiple encodings

### DIFF
--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -158,10 +158,6 @@ def decode(data_element, dicom_character_set):
                     for value in data_element.value
                 ]
     if data_element.VR in text_VRs:
-        # Remove the first encoding if this is a multi-byte encoding
-        if len(encodings) > 1:
-            del encodings[0]
-
         # You can't re-decode unicode (string literals in py3)
         if data_element.VM == 1:
             if isinstance(data_element.value, compat.text_type):

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """unittest cases for pydicom.charset module"""
 
@@ -26,7 +27,7 @@ class CharsetTests(unittest.TestCase):
         ds = dcmread(latin1_file)
         ds.decode()
         # Make sure don't get unicode encode error on converting to string
-        expected = u'Buc^J\xe9r\xf4me'
+        expected = u'Buc^Jérôme'
         got = ds.PatientName
         self.assertEqual(expected, got,
                          "Expected %r, got %r" % (expected, got))
@@ -120,7 +121,7 @@ class CharsetTests(unittest.TestCase):
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xc3\xa9r\xc3\xb4me')
         pydicom.charset.decode(elem, ['ISO_IR 192'])
         # correct encoding
-        assert u'Buc^J\xe9r\xf4me' == elem.value
+        assert u'Buc^Jérôme' == elem.value
 
         # patched encoding shall behave correctly, but a warning is issued
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xc3\xa9r\xc3\xb4me')
@@ -128,7 +129,7 @@ class CharsetTests(unittest.TestCase):
                           match='Incorrect value for Specific Character Set '
                                 "'ISO IR 192' - assuming 'ISO_IR 192'"):
             pydicom.charset.decode(elem, ['ISO IR 192'])
-            assert u'Buc^J\xe9r\xf4me' == elem.value
+            assert u'Buc^Jérôme' == elem.value
 
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xe9r\xf4me')
         with pytest.warns(UserWarning,
@@ -146,7 +147,18 @@ class CharsetTests(unittest.TestCase):
         # Python encoding also can be used directly
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xc3\xa9r\xc3\xb4me')
         pydicom.charset.decode(elem, ['utf8'])
-        assert u'Buc^J\xe9r\xf4me' == elem.value
+        assert u'Buc^Jérôme' == elem.value
+
+    def test_multi_charset_default_value(self):
+        """Test that the first value is used if no escape code is given"""
+        # regression test for #707
+        elem = DataElement(0x00100010, 'PN', b'Buc^J\xe9r\xf4me')
+        pydicom.charset.decode(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 144'])
+        assert u'Buc^Jérôme' == elem.value
+
+        elem = DataElement(0x00081039, 'LO', b'R\xf6ntgenaufnahme')
+        pydicom.charset.decode(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 144'])
+        assert u'Röntgenaufnahme' == elem.value
 
 
 if __name__ == "__main__":

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -732,9 +732,6 @@ class PersonNameUnicode(PersonNameBase, compat.text_type):
         if len(encodings) == 2:
             encodings.append(encodings[1])
         components = val.split(b"=")
-        # Remove the first encoding if only one component is present
-        if (len(components) == 1):
-            del encodings[0]
 
         comps = [
             clean_escseq(C.decode(enc), encodings)


### PR DESCRIPTION
- fixes #707

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
This fixes only the obvious problem that the first encoding was deleted and thus could not be used as the default value. 

Note that I wanted to add more tests for arbitrary multi-value encodings (such as latin1 and cyrillic mixed as in the test), and I couldn't get them to work correctly. The escape codes (the ones defined in PS3.3, Table C.12-3) seem not to be handled at all. I'm not sure if I did something wrong, or this is just not implemented. Also, in case it is not implemented, I'm not sure if this occurs in the real world (I have never seen it), or we can just ignore these cases.

<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
