### PR TITLE
[MRG+1] Use PersonNameUnicode to decode PN in Python 2

### DIFF
--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -19,19 +19,12 @@ from pydicom import config
 from pydicom import valuerep
 from pydicom.util.fixes import timezone
 from pydicom.data import get_testdata_files
-import unittest
+from pydicom.valuerep import DS, IS
 import pytest
-
-try:
-    unittest.skipIf
-except AttributeError:
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        print("unittest2 is required for testing in python2.6")
 
 if not in_py2:
     from pydicom.valuerep import PersonName3 as PersonNameUnicode
+
     PersonName = PersonNameUnicode
 else:
     from pydicom.valuerep import (
@@ -48,70 +41,85 @@ badvr_name = get_testdata_files("badVR.dcm")[0]
 default_encoding = 'iso8859'
 
 
-@unittest.skipIf(platform.python_implementation() == 'PyPy',
-                 "PyPy has trouble with this pickle")
-class TMPickleTest(unittest.TestCase):
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy',
+                    reason="PyPy has trouble with this pickle")
+class TestTM(object):
     """Unit tests for pickling TM"""
-    def testPickling(self):
+
+    def test_pickling(self):
         # Check that a pickled TM is read back properly
         x = pydicom.valuerep.TM("212223")
         x.original_string = 'hello'
-        self.assertEqual(x.original_string, 'hello')
-        self.assertEqual(x, time(21, 22, 23))
+        assert 'hello' == x.original_string
+        assert time(21, 22, 23) == x
         data1_string = pickle.dumps(x)
         x2 = pickle.loads(data1_string)
-        self.assertEqual(x, x2)
-        self.assertEqual(x.original_string,
-                         x2.original_string)
-        self.assertEqual(str(x), str(x2))
+        assert x == x2
+        assert x.original_string == x2.original_string
+        assert str(x) == str(x2)
 
 
-class DTPickleTest(unittest.TestCase):
+class TestDT(object):
     """Unit tests for pickling DT"""
-    def testPickling(self):
+
+    def test_pickling(self):
         # Check that a pickled DT is read back properly
         x = pydicom.valuerep.DT("19111213212123")
         x.original_string = 'hello'
         data1_string = pickle.dumps(x)
         x2 = pickle.loads(data1_string)
-        self.assertEqual(x, x2)
-        self.assertEqual(x.original_string,
-                         x2.original_string)
-        self.assertEqual(str(x), str(x2))
+        assert x == x2
+        assert x.original_string == x2.original_string
+        assert str(x) == str(x2)
 
 
-class DAPickleTest(unittest.TestCase):
+class TestDA(object):
     """Unit tests for pickling DA"""
-    def testPickling(self):
+
+    def test_pickling(self):
         # Check that a pickled DA is read back properly
         x = pydicom.valuerep.DA("19111213")
         x.original_string = 'hello'
         data1_string = pickle.dumps(x)
         x2 = pickle.loads(data1_string)
-        self.assertEqual(x, x2)
-        self.assertEqual(x.original_string,
-                         x2.original_string)
-        self.assertEqual(str(x), str(x2))
+        assert x == x2
+        assert x.original_string == x2.original_string
+        assert str(x) == str(x2)
 
 
-class DSfloatPickleTest(unittest.TestCase):
+class TestDS(object):
+    """Unit tests for DS values"""
+
+    def test_empty_value(self):
+        assert '' == DS(None)
+        assert '' == DS('')
+
+    def test_float_values(self):
+        val = DS(0.9)
+        assert isinstance(val, pydicom.valuerep.DSfloat)
+        assert 0.9 == val
+        val = DS('0.9')
+        assert isinstance(val, pydicom.valuerep.DSfloat)
+        assert 0.9 == val
+
+
+class TestDSfloat(object):
     """Unit tests for pickling DSfloat"""
 
-    def testPickling(self):
+    def test_pickling(self):
         # Check that a pickled DSFloat is read back properly
         x = pydicom.valuerep.DSfloat(9.0)
         x.original_string = 'hello'
         data1_string = pickle.dumps(x)
         x2 = pickle.loads(data1_string)
-        self.assertEqual(x.real, x2.real)
-        self.assertEqual(x.original_string,
-                         x2.original_string)
+        assert x.real == x2.real
+        assert x.original_string == x2.original_string
 
 
-class DSdecimalPickleTest(unittest.TestCase):
+class TestDSdecimal(object):
     """Unit tests for pickling DSdecimal"""
 
-    def testPickling(self):
+    def test_pickling(self):
         # Check that a pickled DSdecimal is read back properly
         # DSdecimal actually prefers original_string when
         # reading back
@@ -119,33 +127,54 @@ class DSdecimalPickleTest(unittest.TestCase):
         x.original_string = '19'
         data1_string = pickle.dumps(x)
         x2 = pickle.loads(data1_string)
-        self.assertEqual(x.real, x2.real)
-        self.assertEqual(x.original_string,
-                         x2.original_string)
+        assert x.real == x2.real
+        assert x.original_string == x2.original_string
+
+    def test_float_value(self):
+        config.allow_DS_float = False
+        with pytest.raises(TypeError,
+                           match='cannot be instantiated with a float value'):
+            pydicom.valuerep.DSdecimal(9.0)
+        config.allow_DS_float = True
+        assert 9 == pydicom.valuerep.DSdecimal(9.0)
 
 
-class ISPickleTest(unittest.TestCase):
-    """Unit tests for pickling IS"""
+class TestIS(object):
+    """Unit tests for IS"""
 
-    def testPickling(self):
+    def test_empty_value(self):
+        assert '' == IS(None)
+        assert '' == IS('')
+
+    def test_valid_value(self):
+        assert 42 == IS(42)
+        assert 42 == IS('42')
+        assert 42 == IS(42.0)
+
+    def test_invalid_value(self):
+        with pytest.raises(TypeError, match='Could not convert value'):
+            IS(0.9)
+        with pytest.raises(ValueError, match='invalid literal for int()'):
+            IS('0.9')
+
+    def test_pickling(self):
         # Check that a pickled IS is read back properly
         x = pydicom.valuerep.IS(921)
         x.original_string = 'hello'
         data1_string = pickle.dumps(x)
         x2 = pickle.loads(data1_string)
-        self.assertEqual(x.real, x2.real)
-        self.assertEqual(x.original_string,
-                         x2.original_string)
+        assert x.real == x2.real
+        assert x.original_string == x2.original_string
 
-    def testLongInt(self):
+    def test_longint(self):
         # Check that a long int is read properly
         # Will not work with enforce_valid_values
         x = pydicom.valuerep.IS(3103050000)
         data1_string = pickle.dumps(x)
         x2 = pickle.loads(data1_string)
-        self.assertEqual(x.real, x2.real)
+        assert x.real == x2.real
 
-    def testOverflow(self):
+    def test_overflow(self):
         original_flag = config.enforce_valid_values
         config.enforce_valid_values = True
         with pytest.raises(OverflowError, match="Value exceeds DICOM limits*"):
@@ -153,11 +182,11 @@ class ISPickleTest(unittest.TestCase):
         config.enforce_valid_values = original_flag
 
 
-class BadValueReadtests(unittest.TestCase):
+class TestBadValueRead(object):
     """Unit tests for handling a bad value for a VR
        (a string in a number VR here)"""
 
-    def setUp(self):
+    def setup(self):
         class TagLike(object):
             pass
 
@@ -167,88 +196,67 @@ class BadValueReadtests(unittest.TestCase):
         self.tag.is_implicit_VR = False
         self.tag.tag = Tag(0x0010, 0x0020)
 
-    def testReadBadValueInVRDefault(self):
+    def test_read_bad_value_in_VR_default(self):
         # found a conversion
-        self.assertEqual('1A', convert_value('SH', self.tag))
+        assert '1A' == convert_value('SH', self.tag)
         # converted with fallback vr "SH"
-        self.assertEqual('1A', convert_value('IS', self.tag))
+        assert '1A' == convert_value('IS', self.tag)
 
         pydicom.values.convert_retry_VR_order = ['FL', 'UL']
         # no fallback VR succeeded, returned original value untranslated
-        self.assertEqual(b'1A', convert_value('IS', self.tag))
+        assert b'1A' == convert_value('IS', self.tag)
 
-    def testReadBadValueInVREnforceValidValue(self):
+    def test_read_bad_value_in_VR_enforce_valid_value(self):
         pydicom.config.enforce_valid_values = True
         # found a conversion
-        self.assertEqual('1A', convert_value('SH', self.tag))
+        assert '1A' == convert_value('SH', self.tag)
         # invalid literal for base 10
-        self.assertRaises(ValueError, convert_value, 'IS', self.tag)
+        with pytest.raises(ValueError):
+            convert_value('IS', self.tag)
 
 
-class DecimalStringtests(unittest.TestCase):
+class TestDecimalString(object):
     """Unit tests unique to the use of DS class
        derived from python Decimal"""
 
-    def setUp(self):
+    def setup(self):
         config.DS_decimal(True)
         config.enforce_valid_values = True
 
-    def tearDown(self):
+    def teardown(self):
         config.DS_decimal(False)
         config.enforce_valid_values = False
 
-    def testValidDecimalStrings(self):
+    def test_valid_decimal_strings(self):
         # Ensures that decimal.Decimal doesn't cause a valid string to become
         # invalid
         valid_str = '-9.81338674e-006'
         ds = valuerep.DS(valid_str)
-        L = len(str(ds))
-        self.assertTrue(L <= 16, "DS: expected a string of length 16 but got %d" % (L,))  # noqa
+        assert len(str(ds)) <= 16
 
         # Now the input string is too long but decimal.Decimal can convert it
         # to a valid 16-character string
         long_str = '-0.000000981338674'
         ds = valuerep.DS(long_str)
-        L = len(str(ds))
-        self.assertTrue(L <= 16, "DS: expected a string of length 16 but got %d" % (L,))  # noqa
+        assert len(str(ds)) <= 16
 
-    def testInvalidDecimalStrings(self):
+    def test_invalid_decimal_strings(self):
         # Now the input string truly is invalid
         invalid_string = '-9.813386743e-006'
-        self.assertRaises(OverflowError,
-                          valuerep.DS,
-                          invalid_string)
+        with pytest.raises(OverflowError):
+            valuerep.DS(invalid_string)
 
 
-class PersonNametests(unittest.TestCase):
-    def testLastFirst(self):
+class TestPersonName(object):
+    def test_last_first(self):
         """PN: Simple Family-name^Given-name works..."""
         pn = PersonName("Family^Given")
-        expected = "Family"
-        got = pn.family_name
-        self.assertEqual(got, expected,
-                         "PN: expected '%s', got '%s' for family name"
-                         % (expected, got))
+        assert "Family" == pn.family_name
+        assert 'Given' == pn.given_name
+        assert '' == pn.name_suffix
+        assert '' == pn.phonetic
 
-        expected = 'Given'
-        got = pn.given_name
-        self.assertEqual(got, expected,
-                         "PN: expected '%s', got '%s' for given name"
-                         % (expected, got))
-
-        expected = ''
-        got = pn.name_suffix
-        self.assertEqual(got, expected,
-                         "PN: expected '%s', got '%s' for name_suffix"
-                         % (expected, got))
-
-        expected = ''
-        got = pn.phonetic
-        self.assertEqual(got, expected,
-                         "PN: expected '%s', got '%s' for phonetic component"
-                         % (expected, got))
-
-    def testCopy(self):
+    def test_copy(self):
         """PN: Copy and deepcopy works..."""
         pn = PersonNameUnicode(
             'Hong^Gildong='
@@ -256,72 +264,57 @@ class PersonNametests(unittest.TestCase):
             '\033$)C\310\253^\033$)C\261\346\265\277',
             [default_encoding, 'euc_kr'])
         pn_copy = copy.copy(pn)
-        self.assertEqual(pn_copy, pn)
-        self.assertEqual(pn_copy.components, pn.components)
+        assert pn == pn_copy
+        assert pn.components == pn_copy.components
         # the copied object references the original components
-        self.assertTrue(pn_copy.components is pn.components)
-        self.assertEqual(pn_copy.encodings, pn.encodings)
+        assert pn_copy.components is pn.components
+        assert pn.encodings == pn_copy.encodings
 
         pn_copy = copy.deepcopy(pn)
-        self.assertEqual(pn_copy, pn)
-        self.assertEqual(pn_copy.components, pn.components)
+        assert pn == pn_copy
+        assert pn.components == pn_copy.components
         # deepcopy() shall have made a copy of components
-        self.assertFalse(pn_copy.components is pn.components)
-        self.assertEqual(pn_copy.encodings, pn.encodings)
+        assert pn_copy.components is not pn.components
+        assert pn.encodings == pn_copy.encodings
 
-    def testThreeComponent(self):
+    def test_three_component(self):
         """PN: 3component (single-byte, ideographic,
         phonetic characters) works..."""
         # Example name from PS3.5-2008 section I.2 p. 108
         pn = PersonName('Hong^Gildong='
                         '\033$)C\373\363^\033$)C\321\316\324\327='
                         '\033$)C\310\253^\033$)C\261\346\265\277')
-        expected = ("Hong", "Gildong")
-        got = (pn.family_name, pn.given_name)
-        msg = "PN: Expected single_byte name '%s', got '%s'" % (expected, got)
-        self.assertEqual(got, expected, msg)
+        assert ("Hong", "Gildong") == (pn.family_name, pn.given_name)
 
-    def testFormatting(self):
+    def test_formatting(self):
         """PN: Formatting works..."""
         pn = PersonName("Family^Given")
-        expected = "Family, Given"
-        got = pn.family_comma_given()
-        msg = ("PN: expected '%s', got '%s' for formatted Family, Given"
-               % (expected, got))
-        self.assertEqual(got, expected, msg)
+        assert "Family, Given" == pn.family_comma_given()
 
-    def testUnicodeKr(self):
+    def test_unicode_kr(self):
         """PN: 3component in unicode works (Korean)..."""
         # Example name from PS3.5-2008 section I.2 p. 101
         pn = PersonNameUnicode('Hong^Gildong='
                                '\033$)C\373\363^\033$)C\321\316\324\327='
                                '\033$)C\310\253^\033$)C\261\346\265\277',
                                [default_encoding, 'euc_kr'])
-        expected = ("Hong", "Gildong")
-        got = (pn.family_name, pn.given_name)
-        msg = "PN: Expected single_byte name '{0!s}', got '{1!s}'".format(expected, got)  # noqa
-        self.assertEqual(got, expected, msg)
+        assert ("Hong", "Gildong") == (pn.family_name, pn.given_name)
 
-    def testUnicodeJp(self):
+    def test_unicode_jp(self):
         """PN: 3component in unicode works (Japanese)..."""
         # Example name from PS3.5-2008 section H  p. 98
         pn = PersonNameUnicode('Yamada^Tarou='
                                '\033$B;3ED\033(B^\033$BB@O:\033(B='
                                '\033$B$d$^$@\033(B^\033$B$?$m$&\033(B',
                                [default_encoding, 'iso2022_jp'])
-        expected = ("Yamada", "Tarou")
-        got = (pn.family_name, pn.given_name)
-        msg = ("PN: Expected single_byte name '{0!s}', got '{1!s}'"
-               .format(expected, got))
-        self.assertEqual(got, expected, msg)
+        assert ("Yamada", "Tarou") == (pn.family_name, pn.given_name)
 
-    def testNotEqual(self):
+    def test_not_equal(self):
         """PN3: Not equal works correctly (issue 121)..."""
         # Meant to only be used in python 3 but doing simple check here
         from pydicom.valuerep import PersonName3
         pn = PersonName3("John^Doe")
-        msg = "PersonName3 not equal comparison did not work correctly"
-        self.assertFalse(pn != "John^Doe", msg)
+        assert not pn != "John^Doe"
 
     def test_encoding_carried(self):
         """Test encoding is carried over to a new PN3 object"""
@@ -333,143 +326,87 @@ class PersonNametests(unittest.TestCase):
         assert pn2.encodings == ['iso_ir_126']
 
 
-class DateTimeTests(unittest.TestCase):
+class TestDateTime(object):
     """Unit tests for DA, DT, TM conversion to datetime objects"""
 
-    def setUp(self):
+    def setup(self):
         config.datetime_conversion = True
 
-    def tearDown(self):
+    def teardown(self):
         config.datetime_conversion = False
 
-    def testDate(self):
+    def test_date(self):
         """DA conversion to datetime.date ..."""
         dicom_date = "19610804"
         da = valuerep.DA(dicom_date)
         # Assert `da` equals to correct `date`
-        datetime_date = date(1961, 8, 4)
-        self.assertEqual(da, datetime_date,
-                         ("DA {0} not equal to date {1}"
-                          .format(dicom_date, datetime_date)))
+        assert date(1961, 8, 4) == da
         # Assert `da.__repr__` holds original string
-        self.assertEqual(repr(da), '"{0}"'.format(dicom_date),
-                         ('DA {0} string representation is not equal to '
-                          'original DICOM string: {1}').format(da, dicom_date))
+        assert '"{0}"'.format(dicom_date) == repr(da)
 
         dicom_date = "1961.08.04"  # ACR-NEMA Standard 300
         da = valuerep.DA(dicom_date)
         # Assert `da` equals to correct `date`
         datetime_date = date(1961, 8, 4)
-        self.assertEqual(da, datetime_date,
-                         ("DA {0} not equal to date {1}"
-                          .format(dicom_date, datetime_date)))
+        assert date(1961, 8, 4) == da
         # Assert `da.__repr__` holds original string
-        self.assertEqual(repr(da), '"{0}"'.format(dicom_date),
-                         ('DA {0} string representation is not equal to '
-                          'original DICOM string: {1}').format(da, dicom_date))
+        assert '"{0}"'.format(dicom_date) == repr(da)
 
         dicom_date = ""
         da = valuerep.DA(dicom_date)
         # Assert `da` equals to no date
-        self.assertEqual(da, None,
-                         "DA {0} not None".format(dicom_date))
+        assert da is None
 
-    def testDateTime(self):
+    def test_date_time(self):
         """DT conversion to datetime.datetime ..."""
         dicom_datetime = "1961"
         dt = valuerep.DT(dicom_datetime)
         # Assert `dt` equals to correct `datetime`
-        datetime_datetime = datetime(1961, 1, 1)
-        self.assertEqual(dt, datetime_datetime,
-                         ("DT {0} not equal to datetime {1}"
-                          .format(dicom_datetime,
-                                  datetime_datetime)))
+        assert datetime(1961, 1, 1) == dt
         # Assert `dt.__repr__` holds original string
-        self.assertEqual(repr(dt), '"{0}"'.format(dicom_datetime),
-                         ('DT {0} string representation is not equal to '
-                          'original DICOM string: {1}'
-                          .format(dt, dicom_datetime)))
+        assert '"{0}"'.format(dicom_datetime) == repr(dt)
 
         dicom_datetime = "19610804"
         dt = valuerep.DT(dicom_datetime)
         # Assert `dt` equals to correct `datetime`
-        datetime_datetime = datetime(1961, 8, 4)
-        self.assertEqual(dt, datetime_datetime,
-                         ("DT {0} not equal to datetime {1}"
-                          .format(dicom_datetime,
-                                  datetime_datetime)))
+        assert datetime(1961, 8, 4) == dt
         # Assert `dt.__repr__` holds original string
-        self.assertEqual(repr(dt), '"{0}"'.format(dicom_datetime),
-                         ('DT {0} string representation is not equal to '
-                          'original DICOM string: {1}'
-                          .format(dt, dicom_datetime)))
+        assert '"{0}"'.format(dicom_datetime) == repr(dt)
 
         dicom_datetime = "19610804192430.123"
         dt = valuerep.DT(dicom_datetime)
         # Assert `dt` equals to correct `datetime`
-        datetime_datetime = datetime(1961, 8, 4, 19, 24, 30, 123000)
-        self.assertEqual(dt, datetime_datetime,
-                         ("DT {0} not equal to datetime {1}"
-                          .format(dicom_datetime,
-                                  datetime_datetime)))
+        assert datetime(1961, 8, 4, 19, 24, 30, 123000) == dt
         # Assert `dt.__repr__` holds original string
-        self.assertEqual(repr(dt), '"{0}"'.format(dicom_datetime),
-                         ('DT {0} string representation is not equal to '
-                          'original DICOM string: {1}'
-                          .format(dt, dicom_datetime)))
+        assert '"{0}"'.format(dicom_datetime) == repr(dt)
 
         dicom_datetime = "196108041924-1000"
         dt = valuerep.DT(dicom_datetime)
         # Assert `dt` equals to correct `datetime`
         datetime_datetime = datetime(1961, 8, 4, 19, 24, 0, 0,
                                      timezone(timedelta(seconds=-10 * 3600)))
-        self.assertEqual(dt, datetime_datetime,
-                         ("DT {0} not equal to datetime {1}"
-                          .format(dicom_datetime,
-                                  datetime_datetime)))
-        self.assertEqual(dt.utcoffset(),
-                         timedelta(0, 0, 0, 0, 0, -10),
-                         "DT offset did not compare correctly to timedelta")
-        # Assert `dt.__repr__` holds original string
-        self.assertEqual(repr(dt), '"{0}"'.format(dicom_datetime),
-                         ('DT {0} string representation is not equal to '
-                          'original DICOM string: {1}'
-                          .format(dt, dicom_datetime)))
+        assert datetime_datetime == dt
+        assert timedelta(0, 0, 0, 0, 0, -10) == dt.utcoffset()
 
-    def testTime(self):
+        # Assert `dt.__repr__` holds original string
+        assert '"{0}"'.format(dicom_datetime) == repr(dt)
+
+    def test_time(self):
         """TM conversion to datetime.time..."""
         dicom_time = "2359"
         tm = valuerep.TM(dicom_time)
         # Assert `tm` equals to correct `time`
-        datetime_time = time(23, 59)
-        self.assertEqual(tm, datetime_time,
-                         ("TM {0} not equal to time {1}"
-                          .format(dicom_time, datetime_time)))
+        assert time(23, 59) == tm
         # Assert `tm.__repr__` holds original string
-        self.assertEqual(repr(tm), '"{0}"'.format(dicom_time),
-                         ('TM {0} string representation is not equal to '
-                          'original DICOM string: {1}'
-                          .format(tm, dicom_time)))
+        assert '"{0}"'.format(dicom_time) == repr(tm)
 
         dicom_time = "235900.123"
         tm = valuerep.TM(dicom_time)
         # Assert `tm` equals to correct `time`
-        datetime_time = time(23, 59, 00, 123000)
-        self.assertEqual(tm, datetime_time,
-                         ("TM {0} not equal to time {1}"
-                          .format(dicom_time, datetime_time)))
+        assert time(23, 59, 00, 123000) == tm
         # Assert `tm.__repr__` holds original string
-        self.assertEqual(repr(tm), '"{0}"'.format(dicom_time),
-                         ('TM {0} string representation is not equal to '
-                          'original DICOM string: {1}'
-                          .format(tm, dicom_time)))
+        assert '"{0}"'.format(dicom_time) == repr(tm)
 
-        dicom_time = ""
         # Assert `tm` equals to no `time`
-        tm = valuerep.TM(dicom_time)
-        self.assertEqual(tm, None,
-                         "TM {0} not None".format(dicom_time))
-
-
-if __name__ == "__main__":
-    unittest.main()
+        tm = valuerep.TM("")
+        assert tm is None

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -55,10 +55,10 @@ class DA(date):
             setattr(self, slot, value)
 
     def __reduce__(self):
-        return super(DA, self).__reduce__() + (self.__getstate__(), )
+        return super(DA, self).__reduce__() + (self.__getstate__(),)
 
     def __reduce_ex__(self, protocol):
-        return super(DA, self).__reduce__() + (self.__getstate__(), )
+        return super(DA, self).__reduce__() + (self.__getstate__(),)
 
     def __new__(cls, val):
         """Create an instance of DA object.
@@ -130,10 +130,10 @@ class DT(datetime):
             setattr(self, slot, value)
 
     def __reduce__(self):
-        return super(DT, self).__reduce__() + (self.__getstate__(), )
+        return super(DT, self).__reduce__() + (self.__getstate__(),)
 
     def __reduce_ex__(self, protocol):
-        return super(DT, self).__reduce__() + (self.__getstate__(), )
+        return super(DT, self).__reduce__() + (self.__getstate__(),)
 
     @staticmethod
     def _utc_offset(offset, name):
@@ -240,10 +240,10 @@ class TM(time):
             setattr(self, slot, value)
 
     def __reduce__(self):
-        return super(TM, self).__reduce__() + (self.__getstate__(), )
+        return super(TM, self).__reduce__() + (self.__getstate__(),)
 
     def __reduce_ex__(self, protocol):
-        return super(TM, self).__reduce__() + (self.__getstate__(), )
+        return super(TM, self).__reduce__() + (self.__getstate__(),)
 
     def __new__(cls, val):
         """Create an instance of TM object from a string.
@@ -484,7 +484,7 @@ class IS(int):
         if isinstance(val, (float, Decimal)) and newval != val:
             raise TypeError("Could not convert value to integer without loss")
         # Checks in case underlying int is >32 bits, DICOM does not allow this
-        check_newval = (newval < -2**31 or newval >= 2**31)
+        check_newval = (newval < -2 ** 31 or newval >= 2 ** 31)
         if check_newval and config.enforce_valid_values:
             dcm_limit = "-2**31 to (2**31 - 1) for IS"
             message = "Value exceeds DICOM limits of %s" % (dcm_limit)
@@ -527,6 +527,14 @@ def MultiString(val, valtype=str):
         return MultiValue(valtype, splitup)
 
 
+def _verify_encodings(encodings):
+    """Checks the encoding to ensure proper format"""
+    if encodings is not None and not isinstance(encodings, list):
+        return [encodings]
+
+    return encodings
+
+
 def _decode_personname(components, encodings):
     """Return a list of decoded person name components."""
     from pydicom.charset import decode_string
@@ -542,15 +550,30 @@ def _decode_personname(components, encodings):
     return comps
 
 
+def _encode_personname(components, encodings):
+    if not compat.in_py2 and isinstance(components[0], bytes):
+        comps = components
+    else:
+        comps = [
+            C.encode(enc) for C, enc in zip(components, encodings)
+        ]
+
+    # Remove empty elements from the end
+    while len(comps) and not comps[-1]:
+        comps.pop()
+
+    return b'='.join(comps)
+
+
 class PersonName3(object):
-    def __init__(self, val, encodings=default_encoding):
+    def __init__(self, val, encodings=None):
         if isinstance(val, PersonName3):
             encodings = val.encodings
             val = val.original_string
 
         self.original_string = val
 
-        self.encodings = self._verify_encodings(encodings)
+        self.encodings = _verify_encodings(encodings) or [default_encoding]
         self.parse(val)
 
     def parse(self, val):
@@ -586,25 +609,13 @@ class PersonName3(object):
     __hash__ = object.__hash__
 
     def decode(self, encodings=None):
-        encodings = self._verify_encodings(encodings)
+        encodings = _verify_encodings(encodings) or self.encodings
         comps = _decode_personname(self.components, encodings)
         return PersonName3(u'='.join(comps), encodings)
 
     def encode(self, encodings=None):
-        encodings = self._verify_encodings(encodings)
-
-        if isinstance(self.components[0], bytes):
-            comps = self.components
-        else:
-            comps = [
-                C.encode(enc) for C, enc in zip(self.components, encodings)
-            ]
-
-        # Remove empty elements from the end
-        while len(comps) and not comps[-1]:
-            comps.pop()
-
-        return b'='.join(comps)
+        encodings = _verify_encodings(encodings) or self.encodings
+        return _encode_personname(self.components, encodings)
 
     def family_comma_given(self):
         return self.formatted('%(family_name)s, %(given_name)s')
@@ -614,15 +625,6 @@ class PersonName3(object):
             return format_str % self.decode(default_encoding).__dict__
         else:
             return format_str % self.__dict__
-
-    def _verify_encodings(self, encodings):
-        if encodings is None:
-            return self.encodings
-
-        if not isinstance(encodings, list):
-            encodings = [encodings]
-
-        return encodings
 
 
 class PersonNameBase(object):
@@ -723,19 +725,14 @@ class PersonNameUnicode(PersonNameBase, compat.text_type):
                  from pydicom.charset.python_encodings mapping
                  of values in DICOM data element (0008,0005).
         """
-        # in here to avoid circular import
-        from pydicom.charset import decode_string
-
-        if not isinstance(encodings, list):
-            encodings = [encodings]
-        components = val.split(b"=")
-        comps = _decode_personname(components, encodings)
+        encodings = _verify_encodings(encodings)
+        comps = _decode_personname(val.split(b"="), encodings)
         new_val = u"=".join(comps)
 
         return compat.text_type.__new__(cls, new_val)
 
     def __init__(self, val, encodings):
-        self.encodings = self._verify_encodings(encodings)
+        self.encodings = _verify_encodings(encodings)
         PersonNameBase.__init__(self, val)
 
     def __copy__(self):
@@ -760,29 +757,10 @@ class PersonNameUnicode(PersonNameBase, compat.text_type):
             setattr(new_person, k, deepcopy(v, memo))
         return new_person
 
-    def _verify_encodings(self, encodings):
-        """Checks the encoding to ensure proper format"""
-        if encodings is None:
-            return self.encodings
-
-        if not isinstance(encodings, list):
-            encodings = [encodings]
-
-        return encodings
-
     def encode(self, encodings):
         """Encode the unicode using the specified encoding"""
-        encodings = self._verify_encodings(encodings)
-
-        components = self.split('=')
-
-        comps = [C.encode(enc) for C, enc in zip(components, encodings)]
-
-        # Remove empty elements from the end
-        while len(comps) and not comps[-1]:
-            comps.pop()
-
-        return '='.join(comps)
+        encodings = _verify_encodings(encodings) or self.encodings
+        return _encode_personname(self.split('='), encodings)
 
     def family_comma_given(self):
         """Return name as 'Family-name, Given-name'"""

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -22,7 +22,7 @@ from pydicom.valuerep import (MultiString, DA, DT, TM)
 if not in_py2:
     from pydicom.valuerep import PersonName3 as PersonName
 else:
-    from pydicom.valuerep import PersonName  # NOQA
+    from pydicom.valuerep import PersonNameUnicode as PersonName
 
 
 def convert_tag(byte_string, is_little_endian, offset=0):
@@ -199,17 +199,13 @@ def convert_PN(byte_string,
 
     def get_valtype(x):
         if not in_py2:
-            if encodings:
-                return PersonName(x, encodings).decode()
-            return PersonName(x).decode()
-        return PersonName(x)
+            return PersonName(x, encodings).decode()
+        return PersonName(x, encodings)
 
     # XXX - We have to replicate MultiString functionality
     # here because we can't decode easily here since that
     # is performed in PersonNameUnicode
-    ends_with1 = byte_string.endswith(b' ')
-    ends_with2 = byte_string.endswith(b'\x00')
-    if byte_string and (ends_with1 or ends_with2):
+    if byte_string.endswith((b' ', b'\x00')):
         byte_string = byte_string[:-1]
 
     splitup = byte_string.split(b"\\")
@@ -425,5 +421,3 @@ converters = {
     'DT': convert_DT_string,
     'UT': convert_single_string,
 }
-if __name__ == "__main__":
-    pass


### PR DESCRIPTION
- fixes #629
- minor consolidation of person name code to avoid duplicate code
- converted valuerep tests to pytest, added some tests

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->
I was doing some minor refactoring to prepare further changes and noticed the change to `PersonNameUnicode` in Python 2 is now very easy (after the latest changes), and does not break any tests and current behavior (hopefully). So this is a bit of a mix of the fix and the refactoring - if wanted, I can separate these into 2 commits.

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
