### PR TITLE
[MRG+1] Remove PIL as a fallback

### DIFF
--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -17,8 +17,8 @@ Enhancements
   (:issue:`291`)
 * Functions for encapsulating frames added to encaps module (:pull_request:`696`)
 * Added ``Dataset.fix_meta_info()`` (:issue:`584`)
-* Add new function for bit packing ``pack_bits`` (:pull_request:`715`) for use
-  with BitsAllocated = 1.
+* Add new function for bit packing ``pack_bits`` for use
+  with BitsAllocated = 1 (:pull_request:`715`) 
 * Added handling of single-byte character set extensions (:pull_request:`718`)
 
 

--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -13,8 +13,10 @@ Enhancements
 * ``DeferredDataElement`` class deprecated and will be removed in v1.3
   (:issue:`291`)
 * Functions for encapsulating frames added to encaps module (:pull_request:`696`)
-
 * Added ``Dataset.fix_meta_info()`` (:issue:`584`)
+* Add new function for bit packing ``pack_bits`` (:pull_request:`715`) for use
+  with BitsAllocated = 1.
+* Added handling of single-byte character set extensions (:pull_request:`718`)
 
 
 Fixes
@@ -24,3 +26,6 @@ Fixes
   (:pull_request:`660`)
 * Improve performance for Python 3 when dealing with compressed multi-frame
   Pixel Data with pillow and jpeg-ls (:issue:`682`).
+* Improve performance of bit unpacking for non-PyPy2 interpreters
+  (:pull_request:`715`)
+* First character set no longer removed (:issue:`707`)

--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -4,6 +4,9 @@ Version 1.2.0
 Changelog
 ---------
 
+* PIL removed as a fallback if Pillow is not available in the pillow pixel data
+  handler (:issue:`722`)
+
 
 Enhancements
 ............

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -20,13 +20,7 @@ have_pillow = True
 try:
     from PIL import Image as PILImg
 except ImportError:
-    # If that failed, try the alternate import syntax for PIL.
-    try:
-        import Image as PILImg
-    except ImportError:
-        # Neither worked, so it's likely not installed.
-        have_pillow = False
-        raise
+    have_pillow = False
 
 PillowSupportedTransferSyntaxes = [
     pydicom.uid.JPEGBaseLineLossy8bit,


### PR DESCRIPTION
#### Reference Issue
Closes #722


#### What does this implement/fix? Explain your changes.
Removes PIL as a fallback in the pillow pixel data handler
