### PR TITLE
[MRG+1] Some changes to correct_ambiguous_vr_element

### DIFF
--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -18,6 +18,98 @@ from pydicom.valuerep import extra_length_VRs
 from pydicom.values import convert_numbers
 
 
+def _correct_ambiguous_vr_element(elem, ds, is_little_endian):
+    """Implementation for `correct_ambiguous_vr_element`.
+    See `correct_ambiguous_vr_element` for description.
+    """
+    # 'OB or OW': 7fe0,0010 PixelData
+    if elem.tag == 0x7fe00010:
+        # Compressed Pixel Data
+        # PS3.5 Annex A.4
+        #   If encapsulated, VR is OB and length is undefined
+        if elem.is_undefined_length:
+            elem.VR = 'OB'
+        # Non-compressed Pixel Data - Implicit Little Endian
+        # PS3.5 Annex A1: VR is always OW
+        elif ds.is_implicit_VR:
+            elem.VR = 'OW'
+        else:
+            # Non-compressed Pixel Data - Explicit VR
+            # PS3.5 Annex A.2:
+            # If BitsAllocated is > 8 then VR shall be OW,
+            # else may be OB or OW.
+            # If we get here, the data has not been written before
+            # or has been converted from Implicit Little Endian,
+            # so we default to OB for BitsAllocated 1 or 8
+            elem.VR = 'OW' if ds.BitsAllocated > 8 else 'OB'
+
+    # 'US or SS' and dependent on PixelRepresentation
+    # (0018,9810) Zero Velocity Pixel Value
+    # (0022,1452) Mapped Pixel Value
+    # (0028,0104)/(0028,0105) Smallest/Largest Valid Pixel Value
+    # (0028,0106)/(0028,0107) Smallest/Largest Image Pixel Value
+    # (0028,0108)/(0028,0109) Smallest/Largest Pixel Value in Series
+    # (0028,0110)/(0028,0111) Smallest/Largest Image Pixel Value in Plane
+    # (0028,0120) Pixel Padding Value
+    # (0028,0121) Pixel Padding Range Limit
+    # (0028,1101-1103) Red/Green/Blue Palette Color Lookup Table Descriptor
+    # (0028,3002) LUT Descriptor
+    # (0040,9216)/(0040,9211) Real World Value First/Last Value Mapped
+    # (0060,3004)/(0060,3006) Histogram First/Last Bin Value
+    elif elem.tag in [
+            0x00189810, 0x00221452, 0x00280104, 0x00280105, 0x00280106,
+            0x00280107, 0x00280108, 0x00280109, 0x00280110, 0x00280111,
+            0x00280120, 0x00280121, 0x00281101, 0x00281102, 0x00281103,
+            0x00283002, 0x00409211, 0x00409216, 0x00603004, 0x00603006
+    ]:
+        # US if PixelRepresentation value is 0x0000, else SS
+        #   For references, see the list at
+        #   https://github.com/darcymason/pydicom/pull/298
+        if ds.PixelRepresentation == 0:
+            elem.VR = 'US'
+            byte_type = 'H'
+        else:
+            elem.VR = 'SS'
+            byte_type = 'h'
+        elem.value = convert_numbers(elem.value, is_little_endian,
+                                     byte_type)
+
+    # 'OB or OW' and dependent on WaveformBitsAllocated
+    # (5400, 0110) Channel Minimum Value
+    # (5400, 0112) Channel Maximum Value
+    # (5400, 100A) Waveform Padding Data
+    # (5400, 1010) Waveform Data
+    elif elem.tag in [0x54000110, 0x54000112, 0x5400100A, 0x54001010]:
+        # If WaveformBitsAllocated is > 8 then OW, otherwise may be
+        #   OB or OW.
+        #   See PS3.3 C.10.9.1.
+        if ds.is_implicit_VR:
+            elem.VR = 'OW'
+        else:
+            elem.VR = 'OW' if ds.WaveformBitsAllocated > 8 else 'OB'
+
+    # 'US or OW': 0028,3006 LUTData
+    elif elem.tag == 0x00283006:
+        # First value in LUT Descriptor is how many values in
+        #   LUTData, if there's only one value then must be US
+        # As per PS3.3 C.11.1.1.1
+        if ds.LUTDescriptor[0] == 1:
+            elem.VR = 'US'
+            elem.value = convert_numbers(elem.value, is_little_endian,
+                                         'H')
+        else:
+            elem.VR = 'OW'
+
+    # 'OB or OW': 60xx,3000 OverlayData and dependent on Transfer Syntax
+    elif (elem.tag.group in range(0x6000, 0x601F, 2)
+          and elem.tag.elem == 0x3000):
+        # Implicit VR must be OW, explicit VR may be OB or OW
+        #   as per PS3.5 Section 8.1.2 and Annex A
+        elem.VR = 'OW'
+
+    return elem
+
+
 def correct_ambiguous_vr_element(elem, ds, is_little_endian):
     """Attempt to correct the ambiguous VR element `elem`.
 
@@ -48,90 +140,12 @@ def correct_ambiguous_vr_element(elem, ds, is_little_endian):
             elem = DataElement_from_raw(elem)
             ds.__setitem__(elem.tag, elem)
 
-        # 'OB or OW': 7fe0,0010 PixelData
-        if elem.tag == 0x7fe00010:
-            # Compressed Pixel Data
-            # PS3.5 Annex A.4
-            #   If encapsulated, VR is OB and length is undefined
-            if elem.is_undefined_length:
-                elem.VR = 'OB'
-            # Non-compressed Pixel Data - Implicit Little Endian
-            # PS3.5 Annex A1: VR is always OW
-            elif ds.is_implicit_VR:
-                elem.VR = 'OW'
-            else:
-                # Non-compressed Pixel Data - Explicit VR
-                # PS3.5 Annex A.2:
-                # If BitsAllocated is > 8 then VR shall be OW,
-                # else may be OB or OW.
-                # If we get here, the data has not been written before
-                # or has been converted from Implicit Little Endian,
-                # so we default to OB for BitsAllocated 1 or 8
-                elem.VR = 'OW' if ds.BitsAllocated > 8 else 'OB'
-
-        # 'US or SS' and dependent on PixelRepresentation
-        # (0018,9810) Zero Velocity Pixel Value
-        # (0022,1452) Mapped Pixel Value
-        # (0028,0104)/(0028,0105) Smallest/Largest Valid Pixel Value
-        # (0028,0106)/(0028,0107) Smallest/Largest Image Pixel Value
-        # (0028,0108)/(0028,0109) Smallest/Largest Pixel Value in Series
-        # (0028,0110)/(0028,0111) Smallest/Largest Image Pixel Value in Plane
-        # (0028,0120) Pixel Padding Value
-        # (0028,0121) Pixel Padding Range Limit
-        # (0028,1101-1103) Red/Green/Blue Palette Color Lookup Table Descriptor
-        # (0028,3002) LUT Descriptor
-        # (0040,9216)/(0040,9211) Real World Value First/Last Value Mapped
-        # (0060,3004)/(0060,3006) Histogram First/Last Bin Value
-        elif elem.tag in [
-                0x00189810, 0x00221452, 0x00280104, 0x00280105, 0x00280106,
-                0x00280107, 0x00280108, 0x00280109, 0x00280110, 0x00280111,
-                0x00280120, 0x00280121, 0x00281101, 0x00281102, 0x00281103,
-                0x00283002, 0x00409211, 0x00409216, 0x00603004, 0x00603006
-        ]:
-            # US if PixelRepresentation value is 0x0000, else SS
-            #   For references, see the list at
-            #   https://github.com/darcymason/pydicom/pull/298
-            if ds.PixelRepresentation == 0:
-                elem.VR = 'US'
-                byte_type = 'H'
-            else:
-                elem.VR = 'SS'
-                byte_type = 'h'
-            elem.value = convert_numbers(elem.value, is_little_endian,
-                                         byte_type)
-
-        # 'OB or OW' and dependent on WaveformBitsAllocated
-        # (5400, 0110) Channel Minimum Value
-        # (5400, 0112) Channel Maximum Value
-        # (5400, 100A) Waveform Padding Data
-        # (5400, 1010) Waveform Data
-        elif elem.tag in [0x54000110, 0x54000112, 0x5400100A, 0x54001010]:
-            # If WaveformBitsAllocated is > 8 then OW, otherwise may be
-            #   OB or OW.
-            #   See PS3.3 C.10.9.1.
-            if ds.is_implicit_VR:
-                elem.VR = 'OW'
-            else:
-                elem.VR = 'OW' if ds.WaveformBitsAllocated > 8 else 'OB'
-
-        # 'US or OW': 0028,3006 LUTData
-        elif elem.tag == 0x00283006:
-            # First value in LUT Descriptor is how many values in
-            #   LUTData, if there's only one value then must be US
-            # As per PS3.3 C.11.1.1.1
-            if ds.LUTDescriptor[0] == 1:
-                elem.VR = 'US'
-                elem.value = convert_numbers(elem.value, is_little_endian,
-                                             'H')
-            else:
-                elem.VR = 'OW'
-
-        # 'OB or OW': 60xx,3000 OverlayData and dependent on Transfer Syntax
-        elif (elem.tag.group in range(0x6000, 0x601F, 2)
-              and elem.tag.elem == 0x3000):
-            # Implicit VR must be OW, explicit VR may be OB or OW
-            #   as per PS3.5 Section 8.1.2 and Annex A
-            elem.VR = 'OW'
+        try:
+            _correct_ambiguous_vr_element(elem, ds, is_little_endian)
+        except AttributeError as e:
+            reason = ('Failed to resolve ambiguous VR for tag'
+                      ' {}: '.format(elem.tag)) + str(e)
+            raise AttributeError(reason)
 
     return elem
 
@@ -157,6 +171,11 @@ def correct_ambiguous_vr(ds, is_little_endian):
     -------
     ds : pydicom.dataset.Dataset
         The corrected dataset
+
+    Raises
+    ------
+    AttributeError
+        If a tag is missing in `ds` that is required to resolve the ambiguity.
     """
     # Iterate through the elements
     for elem in ds:
@@ -377,7 +396,8 @@ def write_TM(fp, data_element, padding=' '):
 
 
 def write_data_element(fp, data_element, encoding=default_encoding):
-    """Write the data_element to file fp according to dicom media storage rules.
+    """Write the data_element to file fp according to
+    dicom media storage rules.
     """
     # Write element's tag
     fp.write_tag(data_element.tag)

--- a/pydicom/tests/test_dicomdir.py
+++ b/pydicom/tests/test_dicomdir.py
@@ -23,8 +23,8 @@ class TestDicomDir(object):
         """Test exception raised if SOP Class is not Media Storage Directory"""
         ds = read_file(get_testdata_files('CT_small.dcm')[0])
         with pytest.raises(InvalidDicomError,
-                           match="SOP Class is not Media Storage "
-                                 "Directory \(DICOMDIR\)"):
+                           match=r"SOP Class is not Media Storage "
+                                 r"Directory \(DICOMDIR\)"):
             DicomDir("some_name", ds, b'\x00' * 128, ds.file_meta, True, True)
 
     def test_invalid_sop_no_file_meta(self):

--- a/pydicom/tests/test_encaps.py
+++ b/pydicom/tests/test_encaps.py
@@ -34,8 +34,8 @@ class TestGetFrameOffsets(object):
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
         with pytest.raises(ValueError,
-                           match="Unexpected tag '\(fffe, e100\)' when "
-                                 "parsing the Basic Table Offset item."):
+                           match=r"Unexpected tag '\(fffe, e100\)' when "
+                                 r"parsing the Basic Table Offset item."):
             get_frame_offsets(fp)
 
     def test_bad_length_multiple(self):
@@ -139,9 +139,10 @@ class TestGeneratePixelDataFragment(object):
         fragments = generate_pixel_data_fragment(fp)
         assert next(fragments) == b'\x01\x00\x00\x00'
         with pytest.raises(ValueError,
-                           match="Unexpected tag '\(0010, 0010\)' at offset "
-                                 "12 when parsing the encapsulated pixel data "
-                                 "fragment items."):
+                           match=r"Unexpected tag '\(0010, 0010\)' at offset "
+                                 r"12 when parsing the encapsulated pixel "
+                                 r"data "
+                                 r"fragment items."):
             next(fragments)
         pytest.raises(StopIteration, next, fragments)
 

--- a/pydicom/tests/test_filebase.py
+++ b/pydicom/tests/test_filebase.py
@@ -227,16 +227,16 @@ class TestDicomFileLike(object):
 
         fp = DicomFileLike(IntPlus)
         with pytest.raises(IOError,
-                           match="This DicomFileLike object has no write\(\) "
-                                 "method"):
+                           match=r"This DicomFileLike object has no write\(\) "
+                                 r"method"):
             fp.write(b'')
         with pytest.raises(IOError,
-                           match="This DicomFileLike object has no read\(\) "
-                                 "method"):
+                           match=r"This DicomFileLike object has no read\(\) "
+                                 r"method"):
             fp.parent_read(b'')
         with pytest.raises(IOError,
-                           match="This DicomFileLike object has no seek\(\) "
-                                 "method"):
+                           match=r"This DicomFileLike object has no seek\(\) "
+                                 r"method"):
             fp.seek(0, 1)
         assert fp.name == '<no filename>'
 

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -888,9 +888,9 @@ class ReadTruncatedFileTests(unittest.TestCase):
         mr.decode()
         # Need to escape brackets
         msg = (
-            "The length of the pixel data in the dataset doesn't match the "
-            "expected amount \(8130 vs. 8192 bytes\). The dataset may be "
-            "corrupted or there may be an issue with the pixel data handler."
+            r"The length of the pixel data in the dataset doesn't match the "
+            r"expected amount \(8130 vs. 8192 bytes\). The dataset may be "
+            r"corrupted or there may be an issue with the pixel data handler."
         )
         with pytest.raises(ValueError, match=msg):
             mr.pixel_array

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -2113,7 +2113,7 @@ class TestWriteNumbers(object):
         elem = DataElement(0x00100010, 'US', b'\x00')
         fmt = 'H'
         with pytest.raises(IOError,
-                           match="for data_element:\n\(0010, 0010\)"):
+                           match=r"for data_element:\n\(0010, 0010\)"):
             write_numbers(fp, elem, fmt)
 
     def test_write_big_endian(self):
@@ -2265,7 +2265,7 @@ class TestWriteNumbers(object):
         elem = DataElement(0x00100010, 'US', b'\x00')
         fmt = 'H'
         with pytest.raises(IOError,
-                           match="for data_element:\n\(0010, 0010\)"):
+                           match=r"for data_element:\n\(0010, 0010\)"):
             write_numbers(fp, elem, fmt)
 
     def test_write_big_endian(self):

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -680,7 +680,8 @@ class TestCorrectAmbiguousVR(unittest.TestCase):
         ref_ds = Dataset()
         ref_ds.SmallestValidPixelValue = b'\x00\x01'  # Big endian 1
         with pytest.raises(AttributeError,
-                           match="has no attribute 'PixelRepresentation'"):
+                           match=r"Failed to resolve ambiguous VR for tag "
+                                 r"\(0028, 0104\):.* 'PixelRepresentation'"):
             correct_ambiguous_vr(deepcopy(ref_ds), True)
 
     def test_pixel_representation_vm_three(self):
@@ -705,7 +706,8 @@ class TestCorrectAmbiguousVR(unittest.TestCase):
         ref_ds = Dataset()
         ref_ds.LUTDescriptor = b'\x01\x00\x00\x01\x00\x10'
         with pytest.raises(AttributeError,
-                           match="has no attribute 'PixelRepresentation'"):
+                           match=r"Failed to resolve ambiguous VR for tag "
+                                 r"\(0028, 3002\):.* 'PixelRepresentation'"):
             correct_ambiguous_vr(deepcopy(ref_ds), False)
 
     def test_pixel_data(self):
@@ -736,7 +738,8 @@ class TestCorrectAmbiguousVR(unittest.TestCase):
         ref_ds = Dataset()
         ref_ds.PixelData = b'\x00\x01'  # Big endian 1
         with pytest.raises(AttributeError,
-                           match="has no attribute 'BitsAllocated'"):
+                           match=r"Failed to resolve ambiguous VR for tag "
+                                 r"\(7fe0, 0010\):.* 'BitsAllocated'"):
             correct_ambiguous_vr(deepcopy(ref_ds), True)
 
     def test_waveform_bits_allocated(self):
@@ -772,7 +775,8 @@ class TestCorrectAmbiguousVR(unittest.TestCase):
         ref_ds = Dataset()
         ref_ds.WaveformData = b'\x00\x01'  # Big endian 1
         with pytest.raises(AttributeError,
-                           match="has no attribute 'WaveformBitsAllocated'"):
+                           match=r"Failed to resolve ambiguous VR for tag "
+                                 r"\(5400, 1010\):.* 'WaveformBitsAllocated'"):
             correct_ambiguous_vr(deepcopy(ref_ds), True)
 
     def test_lut_descriptor(self):
@@ -802,7 +806,8 @@ class TestCorrectAmbiguousVR(unittest.TestCase):
         ref_ds = Dataset()
         ref_ds.LUTData = b'\x00\x01'
         with pytest.raises(AttributeError,
-                           match="has no attribute 'LUTDescriptor'"):
+                           match=r"Failed to resolve ambiguous VR for tag "
+                                 r"\(0028, 3006\):.* 'LUTDescriptor'"):
             correct_ambiguous_vr(deepcopy(ref_ds), True)
 
     def test_overlay(self):
@@ -865,7 +870,8 @@ class TestCorrectAmbiguousVRElement(object):
         ds = Dataset()
         ds.PixelPaddingValue = b'\xfe\xff'
         with pytest.raises(AttributeError,
-                           match="has no attribute 'PixelRepresentation'"):
+                           match=r"Failed to resolve ambiguous VR for tag "
+                                 r"\(0028, 0120\):.* 'PixelRepresentation'"):
             correct_ambiguous_vr_element(ds[0x00280120], ds, True)
 
         ds.PixelRepresentation = 0

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -814,7 +814,7 @@ class TestNumpy_GetPixelData(object):
         ds = dcmread(EXPL_16_1_1F)
         ds.PixelRepresentation = 2
         with pytest.raises(NotImplementedError,
-                           match="value of '2' for '\(0028,0103"):
+                           match=r"value of '2' for '\(0028,0103"):
             get_pixeldata(ds)
 
     def test_unsupported_syntaxes_raises(self):
@@ -915,7 +915,7 @@ class TestNumpy_PackBits(object):
     def test_non_binary_input(self):
         """Test non-binary input raises exception."""
         with pytest.raises(ValueError,
-                           match="Only binary arrays \(containing ones or"):
+                           match=r"Only binary arrays \(containing ones or"):
             pack_bits(np.asarray([0, 0, 2, 0, 0, 0, 0, 0]))
 
     def test_non_array_input(self):
@@ -965,12 +965,12 @@ class TestNumpy_PixelDtype(object):
         self.ds.PixelRepresentation = -1
         # The bracket needs to be escaped
         with pytest.raises(NotImplementedError,
-                           match="value of '-1' for '\(0028,0103"):
+                           match=r"value of '-1' for '\(0028,0103"):
             pixel_dtype(self.ds)
 
         self.ds.PixelRepresentation = 2
         with pytest.raises(NotImplementedError,
-                           match="value of '2' for '\(0028,0103"):
+                           match=r"value of '2' for '\(0028,0103"):
             pixel_dtype(self.ds)
 
     def test_unknown_bits_allocated_raises(self):
@@ -979,17 +979,17 @@ class TestNumpy_PixelDtype(object):
         self.ds.PixelRepresentation = 0
         # The bracket needs to be escaped
         with pytest.raises(NotImplementedError,
-                           match="value of '0' for '\(0028,0100"):
+                           match=r"value of '0' for '\(0028,0100"):
             pixel_dtype(self.ds)
 
         self.ds.BitsAllocated = 2
         with pytest.raises(NotImplementedError,
-                           match="value of '2' for '\(0028,0100"):
+                           match=r"value of '2' for '\(0028,0100"):
             pixel_dtype(self.ds)
 
         self.ds.BitsAllocated = 15
         with pytest.raises(NotImplementedError,
-                           match="value of '15' for '\(0028,0100"):
+                           match=r"value of '15' for '\(0028,0100"):
             pixel_dtype(self.ds)
 
     def test_unsupported_dtypes(self):


### PR DESCRIPTION
- raise AttributeError if a type attribute needed for
  interpretation is missing
- Waveform tags shall always be OW for Implicit Little Endian
- fixed incorrect tag number (5400,0110)
- set OverlayData always to OW

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->
The issue with Overlay Data not converted came up while converting data from Implicit to Explicit Little Endian in a storescp implementation (causing an exception because of ambiguous VR). As far as I understand, we can always use OW in this case.
Raising AttributeError is similar to the change I made for PixelData before and is clearer IMO than the exception raised because of the ambiguous VR in the calling code - if this is not wanted, I can revert this part. 

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
