### PR TITLE
[MRG+1] Support resetting delimiters in single-value encodings

### DIFF
--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -320,6 +320,31 @@ class TestPersonName(object):
         assert u'山田^太郎' == pn.ideographic
         assert u'やまだ^たろう' == pn.phonetic
 
+    def test_unicode_jp_from_bytes_comp_delimiter(self):
+        """The example encoding without the escape sequence before '='"""
+        pn = PersonNameUnicode(b'Yamada^Tarou='
+                               b'\033$B;3ED\033(B^\033$BB@O:='
+                               b'\033$B$d$^$@\033(B^\033$B$?$m$&\033(B',
+                               [default_encoding, 'iso2022_jp'])
+        if not in_py2:
+            pn = pn.decode()
+        assert (u'Yamada', u'Tarou') == (pn.family_name, pn.given_name)
+        assert u'山田^太郎' == pn.ideographic
+        assert u'やまだ^たろう' == pn.phonetic
+
+    def test_unicode_jp_from_bytes_caret_delimiter(self):
+        """PN: 3component in unicode works (Japanese)..."""
+        # Example name from PS3.5-2008 section H  p. 98
+        pn = PersonNameUnicode(b'Yamada^Tarou='
+                               b'\033$B;3ED\033(B^\033$BB@O:\033(B='
+                               b'\033$B$d$^$@\033(B^\033$B$?$m$&\033(B',
+                               [default_encoding, 'iso2022_jp'])
+        if not in_py2:
+            pn = pn.decode()
+        assert (u'Yamada', u'Tarou') == (pn.family_name, pn.given_name)
+        assert u'山田^太郎' == pn.ideographic
+        assert u'やまだ^たろう' == pn.phonetic
+
     def test_unicode_jp_from_unicode(self):
         """A person name initialized from unicode is already decoded"""
         pn = PersonNameUnicode(u'Yamada^Tarou=山田^太郎=やまだ^たろう',

--- a/pydicom/tests/test_values.py
+++ b/pydicom/tests/test_values.py
@@ -45,14 +45,17 @@ class TestConvertAE(object):
         bytestring = b'  AE_TITLE '
         assert u'AE_TITLE' == convert_AE_string(bytestring, True)
 
+
 class TestConvertText(object):
     def test_single_value(self):
+        """Test that encoding can change inside a text string"""
         bytestring = (b'Dionysios is \x1b\x2d\x46'
                       b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
         encodings = ('latin_1', 'iso_ir_126')
         assert u'Dionysios is Διονυσιος' == convert_text(bytestring, encodings)
 
     def test_multi_value(self):
+        """Test that backslash is handled as value separator"""
         bytestring = (b'Buc^J\xe9r\xf4me\\\x1b\x2d\x46'
                       b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2\\'
                       b'\x1b\x2d\x4C'
@@ -62,6 +65,7 @@ class TestConvertText(object):
             bytestring, encodings)
 
     def test_single_value_with_backslash(self):
+        """Test that backslash is handled as character"""
         bytestring = (b'Buc^J\xe9r\xf4me\\\x1b\x2d\x46'
                       b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2\\'
                       b'\x1b\x2d\x4C'
@@ -69,6 +73,18 @@ class TestConvertText(object):
         encodings = ('latin_1', 'iso_ir_144', 'iso_ir_126')
         assert u'Buc^Jérôme\\Διονυσιος\\Люкceмбypг' == convert_single_string(
             bytestring, encodings)
+
+    def test_single_value_with_delimiters(self):
+        """Test that delimiters reset the encoding"""
+        bytestring = (b'\x1b\x2d\x46'
+                      b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2'
+                      b'\r\nJ\xe9r\xf4me/'
+                      b'\x1b\x2d\x4C'
+                      b'\xbb\xee\xda\x63\x65\xdc\xd1\x79\x70\xd3'
+                      b'\tJ\xe9r\xf4me')
+        encodings = ('latin_1', 'iso_ir_144', 'iso_ir_126')
+        expected = u'Διονυσιος\r\nJérôme/Люкceмбypг\tJérôme'
+        assert expected == convert_single_string(bytestring, encodings)
 
 
 class TestConvertAT(object):

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -31,12 +31,12 @@ text_VRs = ('SH', 'LO', 'ST', 'LT', 'UC', 'UT')
 # The delimiters are collected in a byte string suitable for use in a regex.
 # See PS3.5, Section 6.1.2.5.3
 
-# Delimiters for text VRs: LF, CR, TAB, FF, ESC
-TEXT_VR_DELIMS = b'\n\r\t\f\x1b'
+# Character codes for text VR delimiters: LF, CR, TAB, FF
+TEXT_VR_DELIMS = {0x0d, 0x0a, 0x09, 0x0c}
 
-# Delimiters for VR PN : name part separator '^' (escaped for regex), ESC
+# Character code for PN delimiter: name part separator '^'
 # (the component separator '=' is handled separately)
-PN_DELIMS = b'\\^\x1b'
+PN_DELIMS = {0x5e}
 
 match_string = b''.join([
     b'(?P<single_byte>', br'(?P<family_name>[^=\^]*)',

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -27,6 +27,11 @@ extra_length_VRs = ('OB', 'OD', 'OF', 'OL', 'OW', 'SQ', 'UC', 'UN', 'UR', 'UT')
 # and PN, but it is handled separately.
 text_VRs = ('SH', 'LO', 'ST', 'LT', 'UC', 'UT')
 
+# Delimiters for text strings and person name that reset the encoding.
+# See PS3.5, Section 6.1.2.5.3
+TEXT_VR_DELIMS = (b'\n', b'\r', b'\t', b'\f')
+PN_DELIMS = (b'^', )
+
 match_string = b''.join([
     b'(?P<single_byte>', br'(?P<family_name>[^=\^]*)',
     br'\^?(?P<given_name>[^=\^]*)', br'\^?(?P<middle_name>[^=\^]*)',
@@ -542,7 +547,7 @@ def _decode_personname(components, encodings):
     if isinstance(components[0], compat.text_type):
         comps = components
     else:
-        comps = [decode_string(comp, encodings)
+        comps = [decode_string(comp, encodings, PN_DELIMS)
                  for comp in components]
     # Remove empty elements from the end to avoid trailing '='
     while len(comps) and not comps[-1]:

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -29,8 +29,8 @@ text_VRs = ('SH', 'LO', 'ST', 'LT', 'UC', 'UT')
 
 # Delimiters for text strings and person name that reset the encoding.
 # See PS3.5, Section 6.1.2.5.3
-TEXT_VR_DELIMS = (b'\n', b'\r', b'\t', b'\f')
-PN_DELIMS = (b'^', )
+TEXT_VR_DELIMS = b'\n\r\t\f\x1b'
+PN_DELIMS = b'\\^\x1b'
 
 match_string = b''.join([
     b'(?P<single_byte>', br'(?P<family_name>[^=\^]*)',

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -31,12 +31,13 @@ text_VRs = ('SH', 'LO', 'ST', 'LT', 'UC', 'UT')
 # The delimiters are collected in a byte string suitable for use in a regex.
 # See PS3.5, Section 6.1.2.5.3
 
-# Character codes for text VR delimiters: LF, CR, TAB, FF
-TEXT_VR_DELIMS = {0x0d, 0x0a, 0x09, 0x0c}
+# Characters/Character codes for text VR delimiters: LF, CR, TAB, FF
+TEXT_VR_DELIMS = ({'\n', '\r', '\t', '\f'} if compat.in_py2
+                  else {0x0d, 0x0a, 0x09, 0x0c})
 
-# Character code for PN delimiter: name part separator '^'
+# Character/Character code for PN delimiter: name part separator '^'
 # (the component separator '=' is handled separately)
-PN_DELIMS = {0x5e}
+PN_DELIMS = {'^'} if compat.in_py2 else {0xe5}
 
 match_string = b''.join([
     b'(?P<single_byte>', br'(?P<family_name>[^=\^]*)',

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -28,8 +28,9 @@ extra_length_VRs = ('OB', 'OD', 'OF', 'OL', 'OW', 'SQ', 'UC', 'UN', 'UR', 'UT')
 text_VRs = ('SH', 'LO', 'ST', 'LT', 'UC', 'UT')
 
 # Delimiters for text strings and person name that reset the encoding.
-# The delimiters are collected in a byte string suitable for use in a regex.
 # See PS3.5, Section 6.1.2.5.3
+# Note: We use characters for Python 2 and character codes for Python 3
+# because these are the types yielded if iterating over a byte string.
 
 # Characters/Character codes for text VR delimiters: LF, CR, TAB, FF
 TEXT_VR_DELIMS = ({'\n', '\r', '\t', '\f'} if compat.in_py2

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -28,8 +28,14 @@ extra_length_VRs = ('OB', 'OD', 'OF', 'OL', 'OW', 'SQ', 'UC', 'UN', 'UR', 'UT')
 text_VRs = ('SH', 'LO', 'ST', 'LT', 'UC', 'UT')
 
 # Delimiters for text strings and person name that reset the encoding.
+# The delimiters are collected in a byte string suitable for use in a regex.
 # See PS3.5, Section 6.1.2.5.3
+
+# Delimiters for text VRs: LF, CR, TAB, FF, ESC
 TEXT_VR_DELIMS = b'\n\r\t\f\x1b'
+
+# Delimiters for VR PN : name part separator '^' (escaped for regex), ESC
+# (the component separator '=' is handled separately)
 PN_DELIMS = b'\\^\x1b'
 
 match_string = b''.join([

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -17,7 +17,7 @@ from pydicom.multival import MultiValue
 from pydicom.tag import (Tag, TupleTag)
 import pydicom.uid
 import pydicom.valuerep  # don't import DS directly as can be changed by config
-from pydicom.valuerep import (MultiString, DA, DT, TM)
+from pydicom.valuerep import (MultiString, DA, DT, TM, TEXT_VR_DELIMS)
 
 if not in_py2:
     from pydicom.valuerep import PersonName3 as PersonName
@@ -240,7 +240,7 @@ def convert_single_string(byte_string, encodings=None):
     """Read and return a single string
        (backslash character does not split)"""
     encodings = encodings or [default_encoding]
-    value = decode_string(byte_string, encodings)
+    value = decode_string(byte_string, encodings, TEXT_VR_DELIMS)
     if value and value.endswith(' '):
         value = value[:-1]
     return value


### PR DESCRIPTION
- support delimiters as defined in PS3.5, section 6.1.2.5.3
- extended tests for PersonNameUnicode

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->
This was missing from the implementation of reading single-value encodings.

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
