### PR TITLE
[MRG+1] Better pixel data handler exceptions

### DIFF
--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -16,7 +16,14 @@ Changes
 * ``uid.JPEG2000Lossy`` deprecated and will be removed in v1.3. Use
   ``uid.JPEG2000`` instead. (:issue:`726`)
 * ``config.image_handlers`` deprecated and will be removed in v1.3. use
-  ``config.pixel_data_handlers`` instead.
+  ``config.pixel_data_handlers`` instead. There is also a change in behaviour
+  in that ``image_handlers`` previously used to only contain the pixel data
+  handlers that had their dependencies met. ``pixel_data_handlers`` contains
+  all handlers no matter whether or not their dependencies are met. To check
+  if a handler is available for use (both support the transfer syntax and
+  has its dependency met) then use the handler's ``is_available`` method.
+  * ``DeferredDataElement`` class deprecated and will be removed in v1.3
+    (:issue:`291`)
 
 
 Enhancements
@@ -24,8 +31,6 @@ Enhancements
 
 * Added possibility to set byte strings as value for VRs that use only the
   default character set (:issue:`624`)
-* ``DeferredDataElement`` class deprecated and will be removed in v1.3
-  (:issue:`291`)
 * Functions for encapsulating frames added to encaps module (:pull_request:`696`)
 * Added ``Dataset.fix_meta_info()`` (:issue:`584`)
 * Add new function for bit packing ``pack_bits`` for use with BitsAllocated
@@ -35,7 +40,7 @@ Enhancements
 * Added ``uid.JPEG2000MultiComponentLossless`` for UID 1.2.840.10008.1.2.4.92
 * Added ``uid.JPEG2000MultiComponent`` for UID 1.2.840.10008.1.2.4.93
 * Added full support for Planar Configuration (:issue:`713`)
-* Added support for single pixel data where BitsAllocated >8 and
+* Added support for single frame pixel data where BitsAllocated >8 and
   SamplesPerPixel > 1 (:issue:`713`)
 * Small improvement in RLE decoding speed (~10%).
 * Add support for non-conformant RLE segment ordering (:pull_request:`729`)

--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -21,8 +21,8 @@ Changes
   in that ``image_handlers`` previously used to only contain the pixel data
   handlers that had their dependencies met. ``pixel_data_handlers`` contains
   all handlers no matter whether or not their dependencies are met. To check
-  if a handler is available for use (it both supports the transfer syntax and
-  has its dependency met) then use the handler's ``is_available`` method.
+  if a handler is available for use (it has its dependency met) then use the
+  handler's ``is_available`` method.
 * ``DeferredDataElement`` class deprecated and will be removed in v1.3
   (:issue:`291`)
 

--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -20,9 +20,9 @@ Changes
   in that ``image_handlers`` previously used to only contain the pixel data
   handlers that had their dependencies met. ``pixel_data_handlers`` contains
   all handlers no matter whether or not their dependencies are met. To check
-  if a handler is available for use (both support the transfer syntax and
+  if a handler is available for use (it both supports the transfer syntax and
   has its dependency met) then use the handler's ``is_available`` method.
-  * ``DeferredDataElement`` class deprecated and will be removed in v1.3
+* ``DeferredDataElement`` class deprecated and will be removed in v1.3
     (:issue:`291`)
 
 

--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -15,6 +15,8 @@ Changes
   ``uid.JPEGExtended`` instead. (:issue:`726`)
 * ``uid.JPEG2000Lossy`` deprecated and will be removed in v1.3. Use
   ``uid.JPEG2000`` instead. (:issue:`726`)
+* ``config.image_handlers`` deprecated and will be removed in v1.3. use
+  ``config.pixel_data_handlers`` instead.
 
 
 Enhancements
@@ -32,6 +34,11 @@ Enhancements
 * Added ``uid.JPEGLosslessP14`` for UID 1.2.840.10008.1.2.4.57
 * Added ``uid.JPEG2000MultiComponentLossless`` for UID 1.2.840.10008.1.2.4.92
 * Added ``uid.JPEG2000MultiComponent`` for UID 1.2.840.10008.1.2.4.93
+* Added full support for Planar Configuration (:issue:`713`)
+* Added support for single pixel data where BitsAllocated >8 and
+  SamplesPerPixel > 1 (:issue:`713`)
+* Small improvement in RLE decoding speed (~10%).
+* Add support for non-conformant RLE segment ordering (:pull_request:`729`)
 
 
 Fixes
@@ -44,3 +51,6 @@ Fixes
 * Improve performance of bit unpacking for non-PyPy2 interpreters
   (:pull_request:`715`)
 * First character set no longer removed (:issue:`707`)
+* Fixed RLE decoded data having the wrong byte order (:pull_request:`729`)
+* Fixed RLE decoded data having the wrong planar configuration
+  (:pull_request:`729`)

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -68,11 +68,11 @@ handler.setFormatter(formatter)
 logger.addHandler(handler)
 
 
-import pydicom.pixel_data_handlers.numpy_handler as NP_HANDLER
-import pydicom.pixel_data_handlers.rle_handler as RLE_HANDLER
-import pydicom.pixel_data_handlers.pillow_handler as PILLOW_HANDLER
-import pydicom.pixel_data_handlers.jpeg_ls_handler as JPEGLS_HANDLER
-import pydicom.pixel_data_handlers.gdcm_handler as GDCM_HANDLER
+import pydicom.pixel_data_handlers.numpy_handler as NP_HANDLER  # noqa
+import pydicom.pixel_data_handlers.rle_handler as RLE_HANDLER  # noqa
+import pydicom.pixel_data_handlers.pillow_handler as PILLOW_HANDLER  # noqa
+import pydicom.pixel_data_handlers.jpeg_ls_handler as JPEGLS_HANDLER  # noqa
+import pydicom.pixel_data_handlers.gdcm_handler as GDCM_HANDLER  # noqa
 
 PIXEL_DATA_HANDLERS = [
     NP_HANDLER,
@@ -108,7 +108,6 @@ exception thrown up.
 If no one throws an exception, but they all refuse to support the transfer
 syntax, then this fact is announced in a NotImplementedError exception.
 """
-
 
 
 def debug(debug_on=True):

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -81,7 +81,7 @@ pixel_data_handlers = [
     pillow_handler,
     jpegls_handler,
 ]
-image_handlers = pixel_data_handlers
+image_handlers = [hh for hh in pixel_data_handlers if hh.is_available()]
 """Handlers for converting (7fe0,0010) Pixel Data.
 This is an ordered list that the dataset.convert_pixel_data()
 method will try to extract a correctly sized numpy array from the

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -81,6 +81,7 @@ pixel_data_handlers = [
     pillow_handler,
     jpegls_handler,
 ]
+image_handlers = pixel_data_handlers
 """Handlers for converting (7fe0,0010) Pixel Data.
 This is an ordered list that the dataset.convert_pixel_data()
 method will try to extract a correctly sized numpy array from the

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -70,9 +70,9 @@ logger.addHandler(handler)
 
 import pydicom.pixel_data_handlers.numpy_handler as NP_HANDLER
 import pydicom.pixel_data_handlers.rle_handler as RLE_HANDLER
-import pydicom.pixel_data_handlers.gdcm_handler as GDCM_HANDLER
 import pydicom.pixel_data_handlers.pillow_handler as PILLOW_HANDLER
 import pydicom.pixel_data_handlers.jpeg_ls_handler as JPEGLS_HANDLER
+import pydicom.pixel_data_handlers.gdcm_handler as GDCM_HANDLER
 
 PIXEL_DATA_HANDLERS = [
     NP_HANDLER,

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -68,18 +68,18 @@ handler.setFormatter(formatter)
 logger.addHandler(handler)
 
 
-import pydicom.pixel_data_handlers.numpy_handler as NP_HANDLER  # noqa
-import pydicom.pixel_data_handlers.rle_handler as RLE_HANDLER  # noqa
-import pydicom.pixel_data_handlers.pillow_handler as PILLOW_HANDLER  # noqa
-import pydicom.pixel_data_handlers.jpeg_ls_handler as JPEGLS_HANDLER  # noqa
-import pydicom.pixel_data_handlers.gdcm_handler as GDCM_HANDLER  # noqa
+import pydicom.pixel_data_handlers.numpy_handler as np_handler  # noqa
+import pydicom.pixel_data_handlers.rle_handler as rle_handler  # noqa
+import pydicom.pixel_data_handlers.pillow_handler as pillow_handler  # noqa
+import pydicom.pixel_data_handlers.jpeg_ls_handler as jpegls_handler  # noqa
+import pydicom.pixel_data_handlers.gdcm_handler as gdcm_handler  # noqa
 
-PIXEL_DATA_HANDLERS = [
-    NP_HANDLER,
-    RLE_HANDLER,
-    GDCM_HANDLER,
-    PILLOW_HANDLER,
-    JPEGLS_HANDLER,
+pixel_data_handlers = [
+    np_handler,
+    rle_handler,
+    gdcm_handler,
+    pillow_handler,
+    jpegls_handler,
 ]
 """Handlers for converting (7fe0,0010) Pixel Data.
 This is an ordered list that the dataset.convert_pixel_data()

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -68,20 +68,31 @@ handler.setFormatter(formatter)
 logger.addHandler(handler)
 
 
-image_handlers = []
-"""Image handlers for converting pixel data.
-This is an ordered list that the dataset._get_pixel_array()
+import pydicom.pixel_data_handlers.numpy_handler as NP_HANDLER
+import pydicom.pixel_data_handlers.rle_handler as RLE_HANDLER
+import pydicom.pixel_data_handlers.gdcm_handler as GDCM_HANDLER
+import pydicom.pixel_data_handlers.pillow_handler as PILLOW_HANDLER
+import pydicom.pixel_data_handlers.jpeg_ls_handler as JPEGLS_HANDLER
+
+PIXEL_DATA_HANDLERS = [
+    NP_HANDLER,
+    RLE_HANDLER,
+    GDCM_HANDLER,
+    PILLOW_HANDLER,
+    JPEGLS_HANDLER,
+]
+"""Handlers for converting (7fe0,0010) Pixel Data.
+This is an ordered list that the dataset.convert_pixel_data()
 method will try to extract a correctly sized numpy array from the
-PixelData attribute.
-If a handler lacks required dependencies or can not otherwise be loaded,
-it shall throw an ImportError.
+PixelData element.
+
 Handers shall have two methods:
 
-supports_transfer_syntax(dicom_dataset)
+def supports_transfer_syntax(ds)
   This returns True if the handler might support the transfer syntax
   indicated in the dicom_dataset
 
-def get_pixeldata(dicom_dataset):
+def get_pixeldata(ds):
   This shall either throw an exception or return a correctly sized numpy
   array derived from the PixelData.  Reshaping the array to the correct
   dimensions is handled outside the image handler
@@ -98,41 +109,6 @@ If no one throws an exception, but they all refuse to support the transfer
 syntax, then this fact is announced in a NotImplementedError exception.
 """
 
-have_numpy = True
-try:
-    import pydicom.pixel_data_handlers.numpy_handler as numpy_handler
-    image_handlers.append(numpy_handler)
-
-    import pydicom.pixel_data_handlers.rle_handler as rle_handler
-    image_handlers.append(rle_handler)
-
-except ImportError as e:
-    logger.debug("Could not import numpy")
-    have_numpy = False
-
-have_pillow = True
-try:
-    import pydicom.pixel_data_handlers.pillow_handler as pillow_handler
-    image_handlers.append(pillow_handler)
-except ImportError as e:
-    logger.debug("Could not import pillow")
-    have_pillow = False
-
-have_jpeg_ls = True
-try:
-    import pydicom.pixel_data_handlers.jpeg_ls_handler as jpeg_ls_handler
-    image_handlers.append(jpeg_ls_handler)
-except ImportError as e:
-    logger.debug("Could not import jpeg_ls")
-    have_jpeg_ls = False
-
-have_gdcm = True
-try:
-    import pydicom.pixel_data_handlers.gdcm_handler as gdcm_handler
-    image_handlers.append(gdcm_handler)
-except ImportError as e:
-    logger.debug("Could not import gdcm")
-    have_gdcm = False
 
 
 def debug(debug_on=True):

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -820,8 +820,8 @@ class Dataset(dict):
                 #   convert the color space from YCbCr to RGB
                 if handler.needs_to_convert_to_RGB(self):
                     self._pixel_array = convert_color_space(self._pixel_array,
-                                                             'YBR_FULL',
-                                                             'RGB')
+                                                            'YBR_FULL',
+                                                            'RGB')
 
                 self._pixel_id = id(self.PixelData)
 

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -41,9 +41,9 @@ from pydicom.uid import (ExplicitVRLittleEndian, ImplicitVRLittleEndian,
                          ExplicitVRBigEndian, PYDICOM_IMPLEMENTATION_UID)
 
 if compat.in_py2:
-    from pkgutil import find_loader as HAVE_PACKAGE
+    from pkgutil import find_loader as have_package
 else:
-    from importlib.util import find_spec as HAVE_PACKAGE
+    from importlib.util import find_spec as have_package
 
 have_numpy = True
 try:
@@ -797,7 +797,7 @@ class Dataset(dict):
             for hh in possible_handlers:
                 hh_deps = hh.DEPENDENCIES
                 # Missing packages
-                missing = [dd for dd in hh_deps if HAVE_PACKAGE(dd) is None]
+                missing = [dd for dd in hh_deps if have_package(dd) is None]
                 # Package names
                 names = [hh_deps[name][0] for name in missing]
                 pkg_msg.append(

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -774,9 +774,7 @@ class Dataset(dict):
             raise NotImplementedError(
                 "Unable to decode pixel data with a transfer syntax UID of "
                 "'{0}' ({1}) as there are no pixel data handlers "
-                "available that support it. Please open a new issue on "
-                "pydicom's github repository so that we may work on "
-                "adding support"
+                "available that support it"
                 .format(self.file_meta.TransferSyntaxUID,
                         self.file_meta.TransferSyntaxUID.name)
             )

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -782,7 +782,7 @@ class Dataset(dict):
         # Handlers that both support the transfer syntax and have their
         #   dependencies met
         available_handlers = [hh for hh in possible_handlers if
-                              hh.is_available(transfer_syntax)]
+                              hh.is_available()]
 
         # There are handlers that support the transfer syntax but none of them
         #   can be used as missing dependencies

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -799,10 +799,10 @@ class Dataset(dict):
                 # Missing packages
                 missing = [dd for dd in hh_deps if have_package(dd) is None]
                 # Package names
-                names = [hh_deps[name][0] for name in missing]
+                names = [hh_deps[name][1] for name in missing]
                 pkg_msg.append(
                     "{} (req. {})"
-                    .format(hh.HANDLER_NAME, ', '.join(missing))
+                    .format(hh.HANDLER_NAME, ', '.join(names))
                 )
 
             raise RuntimeError(msg + ', '.join(pkg_msg))

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -766,7 +766,7 @@ class Dataset(dict):
 
         # Find all possible handlers that support the transfer syntax
         transfer_syntax = self.file_meta.TransferSyntaxUID
-        possible_handlers = [hh for hh in pydicom.config.PIXEL_DATA_HANDLERS
+        possible_handlers = [hh for hh in pydicom.config.pixel_data_handlers
                              if hh.supports_transfer_syntax(transfer_syntax)]
 
         # No handlers support the transfer syntax

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -19,7 +19,6 @@ import inspect  # for __dir__
 import io
 import os
 import os.path
-from pkgutil import find_loader
 import sys
 from bisect import bisect_left
 from itertools import takewhile
@@ -40,6 +39,11 @@ from pydicom.pixel_data_handlers.util import (convert_color_space,
 from pydicom.tag import Tag, BaseTag, tag_in_exception
 from pydicom.uid import (ExplicitVRLittleEndian, ImplicitVRLittleEndian,
                          ExplicitVRBigEndian, PYDICOM_IMPLEMENTATION_UID)
+
+if compat.in_py2:
+    from pkgutil import find_loader as HAVE_PACKAGE
+else:
+    from importlib.util import find_spec as HAVE_PACKAGE
 
 have_numpy = True
 try:
@@ -795,7 +799,7 @@ class Dataset(dict):
             for hh in possible_handlers:
                 hh_deps = hh.DEPENDENCIES
                 # Missing packages
-                missing = [dd for dd in hh_deps if find_loader(dd) is None]
+                missing = [dd for dd in hh_deps if HAVE_PACKAGE(dd) is None]
                 # Package names
                 names = [hh_deps[name][0] for name in missing]
                 pkg_msg.append(

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -774,7 +774,8 @@ class Dataset(dict):
             raise NotImplementedError(
                 "Unable to decode pixel data with a transfer syntax UID of "
                 "'{0}' ({1}) as there are no pixel data handlers "
-                "available that support it"
+                "available that support it. Please see the pydicom "
+                "documentation for information on supported transfer syntaxes "
                 .format(self.file_meta.TransferSyntaxUID,
                         self.file_meta.TransferSyntaxUID.name)
             )

--- a/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -53,7 +53,7 @@ def is_available(transfer_syntax):
     if not HAVE_NP or not HAVE_GDCM:
         return False
 
-    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES
+    return supports_transfer_syntax(transfer_syntax)
 
 
 def needs_to_convert_to_RGB(dicom_dataset):

--- a/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -22,8 +22,8 @@ from pydicom import compat
 HANDLER_NAME = 'GDCM'
 
 DEPENDENCIES = {
-    'numpy' : ('http://www.numpy.org/', 'NumPy'),
-    'gdcm' : ('http://gdcm.sourceforge.net/wiki/index.php/Main_Page', 'GDCM'),
+    'numpy': ('http://www.numpy.org/', 'NumPy'),
+    'gdcm': ('http://gdcm.sourceforge.net/wiki/index.php/Main_Page', 'GDCM'),
 }
 
 

--- a/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -41,19 +41,10 @@ should_convert_these_syntaxes_to_RGB = [
     pydicom.uid.JPEGBaseline, ]
 
 
-def is_available(transfer_syntax):
-    """Return True if the handler is available for use.
+def is_available():
+    """Return True if the handler has its dependencies met."""
+    return HAVE_NP and HAVE_GDCM
 
-    Parameters
-    ----------
-    transfer_syntax : UID
-        The Transfer Syntax UID of the Pixel Data that is to be used with
-        the handler.
-    """
-    if not HAVE_NP or not HAVE_GDCM:
-        return False
-
-    return supports_transfer_syntax(transfer_syntax)
 
 
 def needs_to_convert_to_RGB(dicom_dataset):

--- a/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -50,7 +50,10 @@ def is_available(transfer_syntax):
         The Transfer Syntax UID of the Pixel Data that is to be used with
         the handler.
     """
-    return HAVE_NP and HAVE_GDCM
+    if not HAVE_NP or not HAVE_GDCM:
+        return False
+
+    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES
 
 
 def needs_to_convert_to_RGB(dicom_dataset):
@@ -108,7 +111,7 @@ def get_pixeldata(dicom_dataset):
     # FIXME this should just use dicom_dataset.PixelData
     # instead of dicom_dataset.filename
     #       but it is unclear how this should be achieved using GDCM
-    if not can_use_gdcm:
+    if not HAVE_GDCM:
         msg = ("GDCM requires both the gdcm package and numpy "
                "and one or more could not be imported")
         raise ImportError(msg)

--- a/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -2,26 +2,55 @@
 """Use the gdcm python package to decode pixel transfer syntaxes."""
 
 import sys
-from pydicom import compat
-import pydicom
-have_numpy = True
+
 try:
     import numpy
+    HAVE_NP = True
 except ImportError:
-    have_numpy = False
-    raise
+    HAVE_NP = False
 
-have_gdcm = True
 try:
     import gdcm
+    HAVE_GDCM = True
 except ImportError:
-    have_gdcm = False
-    raise
-can_use_gdcm = have_gdcm and have_numpy
+    HAVE_GDCM = False
 
+import pydicom
+from pydicom import compat
+
+
+HANDLER_NAME = 'GDCM'
+
+DEPENDENCIES = {
+    'numpy' : ('http://www.numpy.org/', 'NumPy'),
+    'gdcm' : ('http://gdcm.sourceforge.net/wiki/index.php/Main_Page', 'GDCM'),
+}
+
+
+SUPPORTED_TRANSFER_SYNTAXES = [
+    pydicom.uid.JPEGBaseline,
+    pydicom.uid.JPEGExtended,
+    pydicom.uid.JPEGLossless,
+    pydicom.uid.JPEGLSLossless,
+    pydicom.uid.JPEGLSLossy,
+    pydicom.uid.JPEG2000Lossless,
+    pydicom.uid.JPEG2000,
+]
 
 should_convert_these_syntaxes_to_RGB = [
     pydicom.uid.JPEGBaseline, ]
+
+
+def is_available(transfer_syntax):
+    """Return True if the handler is available for use.
+
+    Parameters
+    ----------
+    transfer_syntax : UID
+        The Transfer Syntax UID of the Pixel Data that is to be used with
+        the handler.
+    """
+    return HAVE_NP and HAVE_GDCM
 
 
 def needs_to_convert_to_RGB(dicom_dataset):
@@ -38,7 +67,7 @@ def should_change_PhotometricInterpretation_to_RGB(dicom_dataset):
     return False
 
 
-def supports_transfer_syntax(dicom_dataset):
+def supports_transfer_syntax(transfer_syntax):
     """
     Returns
     -------
@@ -48,7 +77,7 @@ def supports_transfer_syntax(dicom_dataset):
         False to prevent any attempt to try to use this handler
         to decode the given transfer syntax
     """
-    return True
+    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES
 
 
 def get_pixeldata(dicom_dataset):

--- a/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -26,10 +26,10 @@ DEPENDENCIES = {
     'gdcm': ('http://gdcm.sourceforge.net/wiki/index.php/Main_Page', 'GDCM'),
 }
 
-
 SUPPORTED_TRANSFER_SYNTAXES = [
     pydicom.uid.JPEGBaseline,
     pydicom.uid.JPEGExtended,
+    pydicom.uid.JPEGLosslessP14,
     pydicom.uid.JPEGLossless,
     pydicom.uid.JPEGLSLossless,
     pydicom.uid.JPEGLSLossy,

--- a/pydicom/pixel_data_handlers/jpeg_ls_handler.py
+++ b/pydicom/pixel_data_handlers/jpeg_ls_handler.py
@@ -23,8 +23,8 @@ import pydicom.uid
 HANDLER_NAME = 'JPEG-LS'
 
 DEPENDENCIES = {
-    'numpy' : ('http://www.numpy.org/', 'NumPy'),
-    'jpeg_ls' : ('https://github.com/Who8MyLunch/CharPyLS', 'CharPyLS'),
+    'numpy': ('http://www.numpy.org/', 'NumPy'),
+    'jpeg_ls': ('https://github.com/Who8MyLunch/CharPyLS', 'CharPyLS'),
 }
 
 SUPPORTED_TRANSFER_SYNTAXES = [

--- a/pydicom/pixel_data_handlers/jpeg_ls_handler.py
+++ b/pydicom/pixel_data_handlers/jpeg_ls_handler.py
@@ -33,19 +33,9 @@ SUPPORTED_TRANSFER_SYNTAXES = [
 ]
 
 
-def is_available(transfer_syntax):
-    """Return True if the handler is available for use.
-
-    Parameters
-    ----------
-    transfer_syntax : UID
-        The Transfer Syntax UID of the Pixel Data that is to be used with
-        the handler.
-    """
-    if not HAVE_NP or not HAVE_JPEGLS:
-        return False
-
-    return supports_transfer_syntax(transfer_syntax)
+def is_available():
+    """Return True if the handler has its dependencies met."""
+    return HAVE_NP and HAVE_JPEGLS
 
 
 def needs_to_convert_to_RGB(dicom_dataset):

--- a/pydicom/pixel_data_handlers/jpeg_ls_handler.py
+++ b/pydicom/pixel_data_handlers/jpeg_ls_handler.py
@@ -45,7 +45,7 @@ def is_available(transfer_syntax):
     if not HAVE_NP or not HAVE_JPEGLS:
         return False
 
-    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES
+    return supports_transfer_syntax(transfer_syntax)
 
 
 def needs_to_convert_to_RGB(dicom_dataset):

--- a/pydicom/pixel_data_handlers/jpeg_ls_handler.py
+++ b/pydicom/pixel_data_handlers/jpeg_ls_handler.py
@@ -1,31 +1,51 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """
-Use the jpeg_ls (CharPyLS) python package
-to decode pixel transfer syntaxes.
+Use the jpeg_ls (CharPyLS) python package to decode pixel transfer syntaxes.
 """
 
-import pydicom
-import pydicom.uid
-from pydicom.pixel_data_handlers.util import dtype_corrected_for_endianness
-
-have_numpy = True
 try:
     import numpy
+    HAVE_NP = True
 except ImportError:
-    have_numpy = False
-    raise
+    HAVE_NP = False
 
-have_jpeg_ls = True
 try:
     import jpeg_ls
+    HAVE_JPEGLS = True
 except ImportError:
-    have_jpeg_ls = False
-    raise
+    HAVE_JPEGLS = False
 
-JPEGLSSupportedTransferSyntaxes = [
+import pydicom
+from pydicom.pixel_data_handlers.util import dtype_corrected_for_endianness
+import pydicom.uid
+
+
+HANDLER_NAME = 'JPEG-LS'
+
+DEPENDENCIES = {
+    'numpy' : ('http://www.numpy.org/', 'NumPy'),
+    'jpeg_ls' : ('https://github.com/Who8MyLunch/CharPyLS', 'CharPyLS'),
+}
+
+SUPPORTED_TRANSFER_SYNTAXES = [
     pydicom.uid.JPEGLSLossless,
     pydicom.uid.JPEGLSLossy,
 ]
+
+
+def is_available(transfer_syntax):
+    """Return True if the handler is available for use.
+
+    Parameters
+    ----------
+    transfer_syntax : UID
+        The Transfer Syntax UID of the Pixel Data that is to be used with
+        the handler.
+    """
+    if not HAVE_NP or not HAVE_JPEGLS:
+        return False
+
+    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES
 
 
 def needs_to_convert_to_RGB(dicom_dataset):
@@ -37,7 +57,7 @@ def should_change_PhotometricInterpretation_to_RGB(dicom_dataset):
     return False
 
 
-def supports_transfer_syntax(dicom_dataset):
+def supports_transfer_syntax(transfer_syntax):
     """
     Returns
     -------
@@ -47,8 +67,7 @@ def supports_transfer_syntax(dicom_dataset):
         False to prevent any attempt to try to use this handler
         to decode the given transfer syntax
     """
-    return (dicom_dataset.file_meta.TransferSyntaxUID
-            in JPEGLSSupportedTransferSyntaxes)
+    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES
 
 
 def get_pixeldata(dicom_dataset):
@@ -74,13 +93,13 @@ def get_pixeldata(dicom_dataset):
         if the pixel data type is unsupported
     """
     if (dicom_dataset.file_meta.TransferSyntaxUID
-            not in JPEGLSSupportedTransferSyntaxes):
+            not in SUPPORTED_TRANSFER_SYNTAXES):
         msg = ("The jpeg_ls does not support "
                "this transfer syntax {0}.".format(
                    dicom_dataset.file_meta.TransferSyntaxUID.name))
         raise NotImplementedError(msg)
 
-    if not have_jpeg_ls:
+    if not HAVE_JPEGLS:
         msg = ("The jpeg_ls package is required to use pixel_array "
                "for this transfer syntax {0}, and jpeg_ls could not "
                "be imported.".format(

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -63,16 +63,9 @@ SUPPORTED_TRANSFER_SYNTAXES = [
 ]
 
 
-def is_available(transfer_syntax):
-    """Return True if the handler is available for use.
-
-    Parameters
-    ----------
-    transfer_syntax : UID
-        The Transfer Syntax UID of the Pixel Data that is to be used with
-        the handler.
-    """
-    return supports_transfer_syntax(transfer_syntax) and HAVE_NP
+def is_available():
+    """Return True if the handler has its dependencies met."""
+    return HAVE_NP
 
 
 def supports_transfer_syntax(transfer_syntax):

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -39,29 +39,52 @@ elements have values given in the table below.
 from platform import python_implementation
 from sys import byteorder
 
-import numpy as np
+try:
+    import numpy as np
+    HAVE_NP = True
+except ImportError:
+    HAVE_NP = False
 
 from pydicom.compat import in_py2 as IN_PYTHON2
 from pydicom.pixel_data_handlers.util import pixel_dtype
-from pydicom.uid import (
-    ExplicitVRLittleEndian,
-    ImplicitVRLittleEndian,
-    DeflatedExplicitVRLittleEndian,
-    ExplicitVRBigEndian,
-)
+import pydicom.uid
 
+HANDLER_NAME = 'Numpy'
+
+DEPENDENCIES = {
+    'numpy' : ('http://www.numpy.org/', 'NumPy'),
+}
 
 SUPPORTED_TRANSFER_SYNTAXES = [
-    ExplicitVRLittleEndian,
-    ImplicitVRLittleEndian,
-    DeflatedExplicitVRLittleEndian,
-    ExplicitVRBigEndian,
+    pydicom.uid.ExplicitVRLittleEndian,
+    pydicom.uid.ImplicitVRLittleEndian,
+    pydicom.uid.DeflatedExplicitVRLittleEndian,
+    pydicom.uid.ExplicitVRBigEndian,
 ]
 
 
-def supports_transfer_syntax(ds):
-    """Return True if the handler supports the transfer syntax used in `ds`."""
-    return ds.file_meta.TransferSyntaxUID in SUPPORTED_TRANSFER_SYNTAXES
+def is_available(transfer_syntax):
+    """Return True if the handler is available for use.
+
+    Parameters
+    ----------
+    transfer_syntax : UID
+        The Transfer Syntax UID of the Pixel Data that is to be used with
+        the handler.
+    """
+    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES and HAVE_NP
+
+
+def supports_transfer_syntax(transfer_syntax):
+    """Return True if the handler supports the `transfer_syntax`.
+
+    Parameters
+    ----------
+    transfer_syntax : UID
+        The Transfer Syntax UID of the Pixel Data that is to be used with
+        the handler.
+    """
+    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES
 
 
 def needs_to_convert_to_RGB(ds):

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -52,7 +52,7 @@ import pydicom.uid
 HANDLER_NAME = 'Numpy'
 
 DEPENDENCIES = {
-    'numpy' : ('http://www.numpy.org/', 'NumPy'),
+    'numpy': ('http://www.numpy.org/', 'NumPy'),
 }
 
 SUPPORTED_TRANSFER_SYNTAXES = [

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -72,7 +72,7 @@ def is_available(transfer_syntax):
         The Transfer Syntax UID of the Pixel Data that is to be used with
         the handler.
     """
-    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES and HAVE_NP
+    return supports_transfer_syntax(transfer_syntax) and HAVE_NP
 
 
 def supports_transfer_syntax(transfer_syntax):

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -53,23 +53,9 @@ DEPENDENCIES = {
 }
 
 
-def is_available(transfer_syntax):
-    """Return True if the handler is available for use.
-
-    Parameters
-    ----------
-    transfer_syntax : UID
-        The Transfer Syntax UID of the Pixel Data that is to be used with
-        the handler.
-    """
-    if HAVE_NP and HAVE_PIL:
-        if transfer_syntax in PillowJPEG2000TransferSyntaxes and HAVE_JPEG2K:
-            return True
-
-        if transfer_syntax in PillowJPEGTransferSyntaxes and HAVE_JPEG:
-            return True
-
-    return False
+def is_available():
+    """Return True if the handler has its dependencies met."""
+    return HAVE_NP and HAVE_PIL
 
 
 def supports_transfer_syntax(transfer_syntax):

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -48,8 +48,8 @@ PillowJPEGTransferSyntaxes = [
 HANDLER_NAME = 'Pillow'
 
 DEPENDENCIES = {
-    'numpy' : ('http://www.numpy.org/', 'NumPy'),
-    'pillow' : ('https://python-pillow.org/', 'Pillow'),
+    'numpy': ('http://www.numpy.org/', 'NumPy'),
+    'pillow': ('https://python-pillow.org/', 'Pillow'),
 }
 
 

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -49,7 +49,7 @@ HANDLER_NAME = 'Pillow'
 
 DEPENDENCIES = {
     'numpy': ('http://www.numpy.org/', 'NumPy'),
-    'pillow': ('https://python-pillow.org/', 'Pillow'),
+    'PIL': ('https://python-pillow.org/', 'Pillow'),
 }
 
 

--- a/pydicom/pixel_data_handlers/rle_handler.py
+++ b/pydicom/pixel_data_handlers/rle_handler.py
@@ -66,7 +66,7 @@ def is_available(transfer_syntax):
         The Transfer Syntax UID of the Pixel Data that is to be used with
         the handler.
     """
-    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES and HAVE_RLE
+    return supports_transfer_syntax(transfer_syntax) and HAVE_RLE
 
 
 def supports_transfer_syntax(transfer_syntax):

--- a/pydicom/pixel_data_handlers/rle_handler.py
+++ b/pydicom/pixel_data_handlers/rle_handler.py
@@ -35,21 +35,43 @@ elements have values given in the table below.
 
 from struct import unpack
 
-import numpy as np
+try:
+    import numpy as np
+    HAVE_NP = True
+except ImportError:
+    HAVE_NP = False
 
 from pydicom.encaps import decode_data_sequence, defragment_data
 from pydicom.pixel_data_handlers.util import pixel_dtype
-from pydicom.uid import RLELossless
+import pydicom.uid
 
+
+HANDLER_NAME = 'RLE Lossless'
+
+DEPENDENCIES = {
+    'numpy' : ('http://www.numpy.org/', 'NumPy'),
+}
 
 SUPPORTED_TRANSFER_SYNTAXES = [
-    RLELossless
+    pydicom.uid.RLELossless
 ]
 
 
-def supports_transfer_syntax(ds):
-    """Return True if the handler supports the transfer syntax used in `ds`."""
-    return ds.file_meta.TransferSyntaxUID in SUPPORTED_TRANSFER_SYNTAXES
+def is_available(transfer_syntax):
+    """Return True if the handler is available for use.
+
+    Parameters
+    ----------
+    transfer_syntax : UID
+        The Transfer Syntax UID of the Pixel Data that is to be used with
+        the handler.
+    """
+    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES and HAVE_NP
+
+
+def supports_transfer_syntax(transfer_syntax):
+    """Return True if the handler supports the `transfer_syntax`."""
+    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES
 
 
 def needs_to_convert_to_RGB(ds):

--- a/pydicom/pixel_data_handlers/rle_handler.py
+++ b/pydicom/pixel_data_handlers/rle_handler.py
@@ -49,7 +49,7 @@ import pydicom.uid
 HANDLER_NAME = 'RLE Lossless'
 
 DEPENDENCIES = {
-    'numpy' : ('http://www.numpy.org/', 'NumPy'),
+    'numpy': ('http://www.numpy.org/', 'NumPy'),
 }
 
 SUPPORTED_TRANSFER_SYNTAXES = [

--- a/pydicom/pixel_data_handlers/rle_handler.py
+++ b/pydicom/pixel_data_handlers/rle_handler.py
@@ -66,7 +66,7 @@ def is_available(transfer_syntax):
         The Transfer Syntax UID of the Pixel Data that is to be used with
         the handler.
     """
-    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES and HAVE_NP
+    return transfer_syntax in SUPPORTED_TRANSFER_SYNTAXES and HAVE_RLE
 
 
 def supports_transfer_syntax(transfer_syntax):

--- a/pydicom/pixel_data_handlers/rle_handler.py
+++ b/pydicom/pixel_data_handlers/rle_handler.py
@@ -37,9 +37,9 @@ from struct import unpack
 
 try:
     import numpy as np
-    HAVE_NP = True
+    HAVE_RLE = True
 except ImportError:
-    HAVE_NP = False
+    HAVE_RLE = False
 
 from pydicom.encaps import decode_data_sequence, defragment_data
 from pydicom.pixel_data_handlers.util import pixel_dtype

--- a/pydicom/pixel_data_handlers/rle_handler.py
+++ b/pydicom/pixel_data_handlers/rle_handler.py
@@ -57,16 +57,9 @@ SUPPORTED_TRANSFER_SYNTAXES = [
 ]
 
 
-def is_available(transfer_syntax):
-    """Return True if the handler is available for use.
-
-    Parameters
-    ----------
-    transfer_syntax : UID
-        The Transfer Syntax UID of the Pixel Data that is to be used with
-        the handler.
-    """
-    return supports_transfer_syntax(transfer_syntax) and HAVE_RLE
+def is_available():
+    """Return True if the handler has its dependencies met."""
+    return HAVE_RLE
 
 
 def supports_transfer_syntax(transfer_syntax):

--- a/pydicom/tests/test_JPEG_LS_transfer_syntax.py
+++ b/pydicom/tests/test_JPEG_LS_transfer_syntax.py
@@ -98,7 +98,7 @@ class Test_JPEG_LS_Lossless_transfer_syntax():
         msg = (
             r"Unable to decode pixel data with a transfer syntax UID of "
             r"'1.2.840.10008.1.2.4.80' \(JPEG-LS Lossless Image Compression\) "
-            r"as there are no suitable pixel data handlers available."
+            r"as there are no pixel data handlers available."
         )
         with pytest.raises(NotImplementedError, match=msg):
             self.jpeg_ls_lossless.pixel_array
@@ -109,7 +109,7 @@ class Test_JPEG_LS_Lossless_transfer_syntax():
         msg = (
             r"Unable to decode pixel data with a transfer syntax UID of "
             r"'1.2.840.10008.1.2.4.80' \(JPEG-LS Lossless Image Compression\) "
-            r"as there are no suitable pixel data handlers available."
+            r"as there are no pixel data handlers available."
         )
         with pytest.raises(NotImplementedError, match=msg):
             self.emri_jpeg_ls_lossless.pixel_array

--- a/pydicom/tests/test_JPEG_LS_transfer_syntax.py
+++ b/pydicom/tests/test_JPEG_LS_transfer_syntax.py
@@ -65,14 +65,14 @@ class Test_JPEG_LS_Lossless_transfer_syntax():
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        self.original_handlers = pydicom.config.pixel_data_handlers
 
     def teardown_method(self, method):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     @pytest.mark.skipif(not HAVE_NP, reason=numpy_missing_message)
     def test_read_mr_with_numpy(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
+        pydicom.config.pixel_data_handlers = [numpy_handler]
         msg = (
             r"Unable to decode pixel data with a transfer syntax UID of "
             r"'1.2.840.10008.1.2.4.80' \(JPEG-LS Lossless Image Compression\) "
@@ -83,7 +83,7 @@ class Test_JPEG_LS_Lossless_transfer_syntax():
 
     @pytest.mark.skipif(not HAVE_NP, reason=numpy_missing_message)
     def test_read_emri_with_numpy(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
+        pydicom.config.pixel_data_handlers = [numpy_handler]
         msg = (
             r"Unable to decode pixel data with a transfer syntax UID of "
             r"'1.2.840.10008.1.2.4.80' \(JPEG-LS Lossless Image Compression\) "
@@ -94,7 +94,7 @@ class Test_JPEG_LS_Lossless_transfer_syntax():
 
     @pytest.mark.skipif(not HAVE_PIL, reason=pillow_missing_message)
     def test_read_mr_with_pillow(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = [pillow_handler]
+        pydicom.config.pixel_data_handlers = [pillow_handler]
         msg = (
             r"Unable to decode pixel data with a transfer syntax UID of "
             r"'1.2.840.10008.1.2.4.80' \(JPEG-LS Lossless Image Compression\) "
@@ -105,7 +105,7 @@ class Test_JPEG_LS_Lossless_transfer_syntax():
 
     @pytest.mark.skipif(not HAVE_PIL, reason=pillow_missing_message)
     def test_read_emri_with_pillow(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = [pillow_handler]
+        pydicom.config.pixel_data_handlers = [pillow_handler]
         msg = (
             r"Unable to decode pixel data with a transfer syntax UID of "
             r"'1.2.840.10008.1.2.4.80' \(JPEG-LS Lossless Image Compression\) "
@@ -116,7 +116,7 @@ class Test_JPEG_LS_Lossless_transfer_syntax():
 
     @pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
     def test_read_mr_with_gdcm(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, gdcm_handler]
+        pydicom.config.pixel_data_handlers = [numpy_handler, gdcm_handler]
         a = self.jpeg_ls_lossless.pixel_array
         b = self.mr_small.pixel_array
         assert a.mean() == b.mean(), \
@@ -125,7 +125,7 @@ class Test_JPEG_LS_Lossless_transfer_syntax():
 
     @pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
     def test_read_emri_with_gdcm(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, gdcm_handler]
+        pydicom.config.pixel_data_handlers = [numpy_handler, gdcm_handler]
         a = self.emri_jpeg_ls_lossless.pixel_array
         b = self.emri_small.pixel_array
         assert a.mean() == b.mean(), \
@@ -134,7 +134,7 @@ class Test_JPEG_LS_Lossless_transfer_syntax():
 
     @pytest.mark.skipif(not HAVE_JPEGLS, reason=jpeg_ls_missing_message)
     def test_read_mr_with_jpeg_ls(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, jpeg_ls_handler]
+        pydicom.config.pixel_data_handlers = [numpy_handler, jpeg_ls_handler]
         a = self.jpeg_ls_lossless.pixel_array
         b = self.mr_small.pixel_array
         assert a.mean() == b.mean(), \
@@ -143,7 +143,7 @@ class Test_JPEG_LS_Lossless_transfer_syntax():
 
     @pytest.mark.skipif(not HAVE_JPEGLS, reason=jpeg_ls_missing_message)
     def test_read_emri_with_jpeg_ls(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, jpeg_ls_handler]
+        pydicom.config.pixel_data_handlers = [numpy_handler, jpeg_ls_handler]
         a = self.emri_jpeg_ls_lossless.pixel_array
         b = self.emri_small.pixel_array
         assert a.mean() == b.mean(), \
@@ -151,7 +151,7 @@ class Test_JPEG_LS_Lossless_transfer_syntax():
             "(mean == {1})".format(b.mean(), a.mean())
 
     def test_read_mr_without_any_handler(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = []
+        pydicom.config.pixel_data_handlers = []
         msg = (
             r"Unable to decode pixel data with a transfer syntax UID of "
             r"'1.2.840.10008.1.2.4.80' \(JPEG-LS Lossless Image Compression\) "
@@ -161,7 +161,7 @@ class Test_JPEG_LS_Lossless_transfer_syntax():
             self.jpeg_ls_lossless.pixel_array
 
     def test_read_emri_without_any_handler(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = []
+        pydicom.config.pixel_data_handlers = []
         msg = (
             r"Unable to decode pixel data with a transfer syntax UID of "
             r"'1.2.840.10008.1.2.4.80' \(JPEG-LS Lossless Image Compression\) "

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1018,16 +1018,31 @@ class DatasetTests(unittest.TestCase):
         """Test that we try to get new pixel data if the id has changed."""
         fpath = get_testdata_files("CT_small.dcm")[0]
         ds = dcmread(fpath)
+        ds.file_meta.TransferSyntaxUID = '1.2.3.4'
         ds._pixel_id = 1234
         assert ds._pixel_id != id(ds.PixelData)
         ds._pixel_array = 'Test Value'
         # If _pixel_id doesn't match then attempt to get new pixel data
-        orig_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = []
+        orig_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = []
         with pytest.raises(NotImplementedError):
             ds.convert_pixel_data()
 
-        pydicom.config.image_handlers = orig_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = orig_handlers
+
+    def test_pixel_array_unknown_syntax(self):
+        """Test that pixel_array for an unknown syntax raises exception."""
+        ds = dcmread(get_testdata_files("CT_small.dcm")[0])
+        ds.file_meta.TransferSyntaxUID = '1.2.3.4'
+        msg = (
+            r"Unable to decode pixel data with a transfer syntax UID of "
+            r"'1.2.3.4' \(1.2.3.4\) as there are no pixel data handlers "
+            r"available that support it. Please open a new issue on "
+            r"pydicom's github repository so that we may work on "
+            r"adding support"
+        )
+        with pytest.raises(NotImplementedError, match=msg):
+            ds.pixel_array
 
     def test_formatted_lines(self):
         """Test Dataset.formatted_lines"""

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1037,9 +1037,7 @@ class DatasetTests(unittest.TestCase):
         msg = (
             r"Unable to decode pixel data with a transfer syntax UID of "
             r"'1.2.3.4' \(1.2.3.4\) as there are no pixel data handlers "
-            r"available that support it. Please open a new issue on "
-            r"pydicom's github repository so that we may work on "
-            r"adding support"
+            r"available that support it"
         )
         with pytest.raises(NotImplementedError, match=msg):
             ds.pixel_array

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1023,12 +1023,12 @@ class DatasetTests(unittest.TestCase):
         assert ds._pixel_id != id(ds.PixelData)
         ds._pixel_array = 'Test Value'
         # If _pixel_id doesn't match then attempt to get new pixel data
-        orig_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = []
+        orig_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = []
         with pytest.raises(NotImplementedError):
             ds.convert_pixel_data()
 
-        pydicom.config.PIXEL_DATA_HANDLERS = orig_handlers
+        pydicom.config.pixel_data_handlers = orig_handlers
 
     def test_pixel_array_unknown_syntax(self):
         """Test that pixel_array for an unknown syntax raises exception."""

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -42,7 +42,6 @@ except ImportError:
     HAVE_NP = False
     numpy_handler = None
 
-TEST_GDCM = HAVE_GDCM
 
 empty_number_tags_name = get_testdata_files(
     "reportsi_with_empty_number_tags.dcm")[0]
@@ -119,11 +118,11 @@ class GDCM_JPEG_LS_Tests_no_gdcm(unittest.TestCase):
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = []
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = []
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
         os.remove(self.unicode_filename)
 
     def test_JPEG_LS_PixelArray(self):
@@ -143,11 +142,11 @@ class GDCM_JPEG2000Tests_no_gdcm(unittest.TestCase):
         self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
         self.emri_small = dcmread(emri_name)
         self.sc_rgb_jpeg2k_gdcm_KY = dcmread(sc_rgb_jpeg2k_gdcm_KY)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = []
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = []
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEG2000(self):
         """JPEG2000: Returns correct values for sample data elements"""
@@ -186,11 +185,11 @@ class GDCM_JPEGlossyTests_no_gdcm(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = []
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = []
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEGlossy(self):
         """JPEG-lossy: Returns correct values for sample data elements"""
@@ -214,11 +213,11 @@ class GDCM_JPEGlossyTests_no_gdcm(unittest.TestCase):
 class GDCM_JPEGlosslessTests_no_gdcm(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = []
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = []
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossless(self):
         """JPEGlossless: Returns correct values for sample data elements"""
@@ -239,7 +238,7 @@ class GDCM_JPEGlosslessTests_no_gdcm(unittest.TestCase):
             _ = self.jpeg_lossless.pixel_array
 
 
-@pytest.mark.skipif(not TEST_GDCM, reason=gdcm_missing_message)
+@pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
 class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
     def setUp(self):
         if compat.in_py2:
@@ -256,11 +255,11 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, gdcm_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [numpy_handler, gdcm_handler]
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
         os.remove(self.unicode_filename)
 
     def test_JPEG_LS_PixelArray(self):
@@ -282,7 +281,7 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
             "(mean == {1})".format(b.mean(), a.mean()))
 
 
-@pytest.mark.skipif(not TEST_GDCM, reason=gdcm_missing_message)
+@pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
 class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
     def setUp(self):
         self.jpeg_2k = dcmread(jpeg2000_name)
@@ -293,11 +292,11 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
         self.sc_rgb_jpeg2k_gdcm_KY = dcmread(sc_rgb_jpeg2k_gdcm_KY)
         self.ground_truth_sc_rgb_jpeg2k_gdcm_KY_gdcm = dcmread(
             ground_truth_sc_rgb_jpeg2k_gdcm_KY_gdcm)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, gdcm_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [numpy_handler, gdcm_handler]
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEG2000(self):
         """JPEG2000: Returns correct values for sample data elements"""
@@ -349,17 +348,17 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
                 "(mean == {1})".format(b.mean(), a.mean()))
 
 
-@pytest.mark.skipif(not TEST_GDCM, reason=gdcm_missing_message)
+@pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
 class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
 
     def setUp(self):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, gdcm_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [numpy_handler, gdcm_handler]
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossless_odd_data_size(self):
         test_file = get_testdata_files('SC_rgb_small_odd_jpeg.dcm')[0]
@@ -402,10 +401,10 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
 
 @pytest.fixture(scope="module")
 def test_with_gdcm():
-    original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-    pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, gdcm_handler]
+    original_handlers = pydicom.config.pixel_data_handlers
+    pydicom.config.pixel_data_handlers = [numpy_handler, gdcm_handler]
     yield original_handlers
-    pydicom.config.PIXEL_DATA_HANDLERS = original_handlers
+    pydicom.config.pixel_data_handlers = original_handlers
 
 
 if have_pytest_param:
@@ -554,7 +553,7 @@ else:
 
 
 @pytest.mark.skipif(
-    not TEST_GDCM,
+    not HAVE_GDCM,
     reason=gdcm_missing_message)
 @pytest.mark.parametrize(
     "image,PhotometricInterpretation,results,convert_yuv_to_rgb",
@@ -585,15 +584,15 @@ def test_PI_RGB(test_with_gdcm,
     assert t.PhotometricInterpretation == PhotometricInterpretation
 
 
-@pytest.mark.skipif(not TEST_GDCM, reason=gdcm_missing_message)
+@pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
 class GDCM_JPEGlosslessTests_with_gdcm(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, gdcm_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [numpy_handler, gdcm_handler]
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossless(self):
         """JPEGlossless: Returns correct values for sample data elements"""

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -28,19 +28,21 @@ try:
 except AttributeError:
     have_pytest_param = False
 
-gdcm_handler = None
-have_gdcm_handler = True
 try:
     import pydicom.pixel_data_handlers.gdcm_handler as gdcm_handler
+    HAVE_GDCM = gdcm_handler.HAVE_GDCM
 except ImportError as e:
-    have_gdcm_handler = False
-numpy_handler = None
-have_numpy_handler = True
+    HAVE_GDCM = False
+    gdcm_handler = None
+
 try:
     import pydicom.pixel_data_handlers.numpy_handler as numpy_handler
+    HAVE_NP = numpy_handler.HAVE_NP
 except ImportError:
-    have_numpy_handler = False
-test_gdcm_decoder = have_gdcm_handler
+    HAVE_NP = False
+    numpy_handler = None
+
+test_gdcm_decoder = HAVE_GDCM
 
 empty_number_tags_name = get_testdata_files(
     "reportsi_with_empty_number_tags.dcm")[0]
@@ -117,11 +119,11 @@ class GDCM_JPEG_LS_Tests_no_gdcm(unittest.TestCase):
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [None]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = []
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
         os.remove(self.unicode_filename)
 
     def test_JPEG_LS_PixelArray(self):
@@ -141,11 +143,11 @@ class GDCM_JPEG2000Tests_no_gdcm(unittest.TestCase):
         self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
         self.emri_small = dcmread(emri_name)
         self.sc_rgb_jpeg2k_gdcm_KY = dcmread(sc_rgb_jpeg2k_gdcm_KY)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [None]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = []
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_JPEG2000(self):
         """JPEG2000: Returns correct values for sample data elements"""
@@ -184,11 +186,11 @@ class GDCM_JPEGlossyTests_no_gdcm(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [None]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = []
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_JPEGlossy(self):
         """JPEG-lossy: Returns correct values for sample data elements"""
@@ -212,11 +214,11 @@ class GDCM_JPEGlossyTests_no_gdcm(unittest.TestCase):
 class GDCM_JPEGlosslessTests_no_gdcm(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [None]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = []
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def testJPEGlossless(self):
         """JPEGlossless: Returns correct values for sample data elements"""
@@ -254,11 +256,11 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [numpy_handler, gdcm_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, gdcm_handler]
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
         os.remove(self.unicode_filename)
 
     def test_JPEG_LS_PixelArray(self):
@@ -291,11 +293,11 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
         self.sc_rgb_jpeg2k_gdcm_KY = dcmread(sc_rgb_jpeg2k_gdcm_KY)
         self.ground_truth_sc_rgb_jpeg2k_gdcm_KY_gdcm = dcmread(
             ground_truth_sc_rgb_jpeg2k_gdcm_KY_gdcm)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [numpy_handler, gdcm_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, gdcm_handler]
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_JPEG2000(self):
         """JPEG2000: Returns correct values for sample data elements"""
@@ -353,11 +355,11 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [numpy_handler, gdcm_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, gdcm_handler]
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def testJPEGlossless_odd_data_size(self):
         test_file = get_testdata_files('SC_rgb_small_odd_jpeg.dcm')[0]
@@ -400,10 +402,10 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
 
 @pytest.fixture(scope="module")
 def test_with_gdcm():
-    original_handlers = pydicom.config.image_handlers
-    pydicom.config.image_handlers = [numpy_handler, gdcm_handler]
+    original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+    pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, gdcm_handler]
     yield original_handlers
-    pydicom.config.image_handlers = original_handlers
+    pydicom.config.PIXEL_DATA_HANDLERS = original_handlers
 
 
 if have_pytest_param:
@@ -587,11 +589,11 @@ def test_PI_RGB(test_with_gdcm,
 class GDCM_JPEGlosslessTests_with_gdcm(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [numpy_handler, gdcm_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler, gdcm_handler]
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def testJPEGlossless(self):
         """JPEGlossless: Returns correct values for sample data elements"""

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -42,7 +42,7 @@ except ImportError:
     HAVE_NP = False
     numpy_handler = None
 
-test_gdcm_decoder = HAVE_GDCM
+TEST_GDCM = HAVE_GDCM
 
 empty_number_tags_name = get_testdata_files(
     "reportsi_with_empty_number_tags.dcm")[0]
@@ -239,7 +239,7 @@ class GDCM_JPEGlosslessTests_no_gdcm(unittest.TestCase):
             _ = self.jpeg_lossless.pixel_array
 
 
-@pytest.mark.skipif(not test_gdcm_decoder, reason=gdcm_missing_message)
+@pytest.mark.skipif(not TEST_GDCM, reason=gdcm_missing_message)
 class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
     def setUp(self):
         if compat.in_py2:
@@ -282,7 +282,7 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
             "(mean == {1})".format(b.mean(), a.mean()))
 
 
-@pytest.mark.skipif(not test_gdcm_decoder, reason=gdcm_missing_message)
+@pytest.mark.skipif(not TEST_GDCM, reason=gdcm_missing_message)
 class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
     def setUp(self):
         self.jpeg_2k = dcmread(jpeg2000_name)
@@ -349,7 +349,7 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
                 "(mean == {1})".format(b.mean(), a.mean()))
 
 
-@pytest.mark.skipif(not test_gdcm_decoder, reason=gdcm_missing_message)
+@pytest.mark.skipif(not TEST_GDCM, reason=gdcm_missing_message)
 class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
 
     def setUp(self):
@@ -554,7 +554,7 @@ else:
 
 
 @pytest.mark.skipif(
-    not test_gdcm_decoder,
+    not TEST_GDCM,
     reason=gdcm_missing_message)
 @pytest.mark.parametrize(
     "image,PhotometricInterpretation,results,convert_yuv_to_rgb",
@@ -585,7 +585,7 @@ def test_PI_RGB(test_with_gdcm,
     assert t.PhotometricInterpretation == PhotometricInterpretation
 
 
-@pytest.mark.skipif(not test_gdcm_decoder, reason=gdcm_missing_message)
+@pytest.mark.skipif(not TEST_GDCM, reason=gdcm_missing_message)
 class GDCM_JPEGlosslessTests_with_gdcm(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -75,11 +75,11 @@ class jpeg_ls_JPEG_LS_Tests_no_jpeg_ls(unittest.TestCase):
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [numpy_handler]
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEG_LS_PixelArray(self):
         with self.assertRaises((RuntimeError, NotImplementedError)):
@@ -93,11 +93,11 @@ class jpeg_ls_JPEG2000Tests_no_jpeg_ls(unittest.TestCase):
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [numpy_handler]
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEG2000PixelArray(self):
         """JPEG2000: Now works"""
@@ -115,11 +115,11 @@ class jpeg_ls_JPEGlossyTests_no_jpeg_ls(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [numpy_handler]
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossy(self):
         """JPEG-lossy: Returns correct values for sample data elements"""
@@ -144,11 +144,11 @@ class jpeg_ls_JPEGlossyTests_no_jpeg_ls(unittest.TestCase):
 class jpeg_ls_JPEGlosslessTests_no_jpeg_ls(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [numpy_handler]
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossless(self):
         """JPEGlossless: Returns correct values for sample data elements"""
@@ -178,11 +178,11 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [jpeg_ls_handler, numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [jpeg_ls_handler, numpy_handler]
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_raises_if_endianess_not_set(self):
         self.jpeg_ls_lossless.is_little_endian = None
@@ -218,11 +218,11 @@ class jpeg_ls_JPEG2000Tests_with_jpeg_ls(unittest.TestCase):
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [jpeg_ls_handler, numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [jpeg_ls_handler, numpy_handler]
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEG2000PixelArray(self):
         with self.assertRaises((NotImplementedError, )):
@@ -241,11 +241,11 @@ class jpeg_ls_JPEGlossyTests_with_jpeg_ls(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [jpeg_ls_handler, numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [jpeg_ls_handler, numpy_handler]
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossy(self):
         """JPEG-lossy: Returns correct values for sample data elements"""
@@ -272,11 +272,11 @@ class jpeg_ls_JPEGlossyTests_with_jpeg_ls(unittest.TestCase):
 class jpeg_ls_JPEGlosslessTests_with_jpeg_ls(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [jpeg_ls_handler, numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [jpeg_ls_handler, numpy_handler]
 
     def tearDown(self):
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossless(self):
         """JPEGlossless: Returns correct values for sample data elements"""

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -10,18 +10,20 @@ from pydicom.data import get_testdata_files
 jpeg_ls_missing_message = ("jpeg_ls is not available "
                            "in this test environment")
 jpeg_ls_present_message = "jpeg_ls is being tested"
-jpeg_ls_handler = None
-have_jpeg_ls_handler = True
-numpy_handler = None
-have_numpy_handler = True
+
 try:
     import pydicom.pixel_data_handlers.numpy_handler as numpy_handler
+    have_numpy_handler = numpy_handler.HAVE_NP
 except ImportError:
     have_numpy_handler = False
+    numpy_handler = None
+
 try:
     import pydicom.pixel_data_handlers.jpeg_ls_handler as jpeg_ls_handler
+    have_jpeg_ls_handler = jpeg_ls_handler.HAVE_JPEGLS
 except ImportError:
     have_jpeg_ls_handler = False
+    jpeg_ls_handler = None
 
 test_jpeg_ls_decoder = have_numpy_handler and have_jpeg_ls_handler
 
@@ -73,14 +75,14 @@ class jpeg_ls_JPEG_LS_Tests_no_jpeg_ls(unittest.TestCase):
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [None, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_JPEG_LS_PixelArray(self):
-        with self.assertRaises((NotImplementedError, )):
+        with self.assertRaises((RuntimeError, NotImplementedError)):
             _ = self.jpeg_ls_lossless.pixel_array
 
 
@@ -91,11 +93,11 @@ class jpeg_ls_JPEG2000Tests_no_jpeg_ls(unittest.TestCase):
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [None, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_JPEG2000PixelArray(self):
         """JPEG2000: Now works"""
@@ -113,11 +115,11 @@ class jpeg_ls_JPEGlossyTests_no_jpeg_ls(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [None, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def testJPEGlossy(self):
         """JPEG-lossy: Returns correct values for sample data elements"""
@@ -142,11 +144,11 @@ class jpeg_ls_JPEGlossyTests_no_jpeg_ls(unittest.TestCase):
 class jpeg_ls_JPEGlosslessTests_no_jpeg_ls(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [None, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def testJPEGlossless(self):
         """JPEGlossless: Returns correct values for sample data elements"""
@@ -176,11 +178,11 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [jpeg_ls_handler, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [jpeg_ls_handler, numpy_handler]
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_raises_if_endianess_not_set(self):
         self.jpeg_ls_lossless.is_little_endian = None
@@ -216,11 +218,11 @@ class jpeg_ls_JPEG2000Tests_with_jpeg_ls(unittest.TestCase):
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [jpeg_ls_handler, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [jpeg_ls_handler, numpy_handler]
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_JPEG2000PixelArray(self):
         with self.assertRaises((NotImplementedError, )):
@@ -239,11 +241,11 @@ class jpeg_ls_JPEGlossyTests_with_jpeg_ls(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [jpeg_ls_handler, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [jpeg_ls_handler, numpy_handler]
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def testJPEGlossy(self):
         """JPEG-lossy: Returns correct values for sample data elements"""
@@ -270,11 +272,11 @@ class jpeg_ls_JPEGlossyTests_with_jpeg_ls(unittest.TestCase):
 class jpeg_ls_JPEGlosslessTests_with_jpeg_ls(unittest.TestCase):
     def setUp(self):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [jpeg_ls_handler, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [jpeg_ls_handler, numpy_handler]
 
     def tearDown(self):
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def testJPEGlossless(self):
         """JPEGlossless: Returns correct values for sample data elements"""

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -178,12 +178,12 @@ class TestNoNumpy_NoNumpyHandler(object):
     """Tests for handling datasets without numpy and the handler."""
     def setup(self):
         """Setup the environment."""
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = []
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = []
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""
@@ -235,12 +235,12 @@ class TestNoNumpy_NumpyHandler(object):
     """Tests for handling datasets without numpy and the handler."""
     def setup(self):
         """Setup the environment."""
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [NP_HANDLER]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [NP_HANDLER]
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""
@@ -305,12 +305,12 @@ class TestNumpy_NoNumpyHandler(object):
     """Tests for handling datasets without the handler."""
     def setup(self):
         """Setup the environment."""
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = []
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = []
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""
@@ -401,12 +401,12 @@ class TestNumpy_NumpyHandler(object):
     """Tests for handling Pixel Data with the handler."""
     def setup(self):
         """Setup the test datasets and the environment."""
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [NP_HANDLER]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [NP_HANDLER]
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -174,12 +174,12 @@ class TestNoNumpy_NoNumpyHandler(object):
     """Tests for handling datasets without numpy and the handler."""
     def setup(self):
         """Setup the environment."""
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = []
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = []
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""
@@ -231,12 +231,12 @@ class TestNumpy_NoNumpyHandler(object):
     """Tests for handling datasets without the handler."""
     def setup(self):
         """Setup the environment."""
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = []
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = []
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""
@@ -278,8 +278,7 @@ class TestNumpy_NoNumpyHandler(object):
         ds = dcmread(EXPL_16_1_1F)
         for uid in ALL_TRANSFER_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
-            with pytest.raises(NotImplementedError,
-                               match="UID of '{}'".format(uid)):
+            with pytest.raises((NotImplementedError, RuntimeError)):
                 ds.pixel_array
 
 
@@ -328,12 +327,12 @@ class TestNumpy_NumpyHandler(object):
     """Tests for handling Pixel Data with the handler."""
     def setup(self):
         """Setup the test datasets and the environment."""
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [NP_HANDLER]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [NP_HANDLER]
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""
@@ -346,8 +345,7 @@ class TestNumpy_NumpyHandler(object):
 
         for uid in UNSUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
-            with pytest.raises(NotImplementedError,
-                               match="UID of '{0}' ".format(uid)):
+            with pytest.raises((NotImplementedError, RuntimeError)):
                 ds.pixel_array
 
     def test_dataset_pixel_array_handler_needs_convert(self):

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -5,7 +5,7 @@ There are the following possibilities:
 
 * numpy is not available and
   * the numpy handler is not available
-  * the numpy handler is not available
+  * the numpy handler is available
 * numpy is available and
   * the numpy handler is not available
   * the numpy handler is available
@@ -293,7 +293,7 @@ class TestNoNumpy_NumpyHandler(object):
             exc_msg = (
                 r"The following handlers are available to decode the pixel "
                 r"data however they are missing required dependencies: "
-                r"Numpy \(req. numpy\)"
+                r"Numpy \(req. NumPy\)"
             )
             with pytest.raises(RuntimeError, match=exc_msg):
                 ds.pixel_array

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -15,20 +15,20 @@ have_pytest_param = hasattr(pytest, 'param')
 
 try:
     from pydicom.pixel_data_handlers import numpy_handler
-    have_numpy_handler = True
+    HAVE_NP = numpy_handler.HAVE_NP
 except ImportError:
-    have_numpy_handler = False
+    HAVE_NP = False
     numpy_handler = None
 
 try:
     from pydicom.pixel_data_handlers import pillow_handler
-    have_pillow_handler = True
+    HAVE_PIL = pillow_handler.HAVE_PIL
     HAVE_JPEG = pillow_handler.HAVE_JPEG
     HAVE_JPEG2K = pillow_handler.HAVE_JPEG2K
     import numpy as np
 except ImportError:
     pillow_handler = None
-    have_pillow_handler = False
+    HAVE_PIL = False
     HAVE_JPEG = False
     HAVE_JPEG2K = False
 
@@ -36,11 +36,9 @@ except ImportError:
 pillow_missing_message = ("pillow is not available "
                           "in this test environment")
 
-test_pillow_decoder = have_numpy_handler and have_pillow_handler
-test_pillow_jpeg_decoder = (test_pillow_decoder and
-                            HAVE_JPEG)
-test_pillow_jpeg2000_decoder = (test_pillow_decoder and
-                                HAVE_JPEG2K)
+TEST_PIL = HAVE_NP and HAVE_PIL
+TEST_JPEG = TEST_PIL and HAVE_JPEG
+TEST_JPEG2K = TEST_PIL and HAVE_JPEG2K
 
 empty_number_tags_name = get_testdata_files(
     "reportsi_with_empty_number_tags.dcm")[0]
@@ -241,7 +239,7 @@ class Test_JPEGlosslessTests_no_pillow(object):
 
 
 @pytest.mark.skipif(
-    not test_pillow_decoder,
+    not TEST_PIL,
     reason=pillow_missing_message)
 class Test_JPEG_LS_with_pillow(object):
     """Tests for decoding JPEG LS if pillow pixel handler is available."""
@@ -268,7 +266,7 @@ class Test_JPEG_LS_with_pillow(object):
 
 
 @pytest.mark.skipif(
-    not test_pillow_jpeg2000_decoder,
+    not TEST_JPEG2K,
     reason=pillow_missing_message)
 class Test_JPEG2000Tests_with_pillow(object):
     """Test decoding JPEG2K if pillow JPEG2K plugin is available."""
@@ -322,7 +320,7 @@ class Test_JPEG2000Tests_with_pillow(object):
 
 
 @pytest.mark.skipif(
-    not test_pillow_jpeg_decoder,
+    not TEST_JPEG,
     reason=pillow_missing_message)
 class Test_JPEGlossyTests_with_pillow(object):
     """Test decoding JPEG if pillow JPEG plugin is available."""
@@ -539,7 +537,7 @@ else:
 
 
 @pytest.mark.skipif(
-    not test_pillow_jpeg_decoder,
+    not TEST_JPEG,
     reason=pillow_missing_message)
 @pytest.mark.parametrize(
     "image,PhotometricInterpretation,results,ground_truth",
@@ -579,7 +577,7 @@ def test_PI_RGB(test_with_pillow,
 
 
 @pytest.mark.skipif(
-    not test_pillow_jpeg_decoder,
+    not TEST_JPEG,
     reason=pillow_missing_message)
 class Test_JPEGlosslessTests_with_pillow(object):
     """Test decoding JPEG lossless if pillow JPEG plugin is available."""
@@ -601,5 +599,5 @@ class Test_JPEGlosslessTests_with_pillow(object):
 
     def testJPEGlosslessPixelArray(self):
         """Test decoding JPEG lossless with pillow handler fails."""
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(RuntimeError):
             self.jpeg_lossless.pixel_array

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -23,14 +23,14 @@ except ImportError:
 try:
     from pydicom.pixel_data_handlers import pillow_handler
     have_pillow_handler = True
-    have_pillow_jpeg_plugin = pillow_handler.have_pillow_jpeg_plugin
-    have_pillow_jpeg2000_plugin = pillow_handler.have_pillow_jpeg2000_plugin
+    HAVE_JPEG = pillow_handler.HAVE_JPEG
+    HAVE_JPEG2K = pillow_handler.HAVE_JPEG2K
     import numpy as np
 except ImportError:
     pillow_handler = None
     have_pillow_handler = False
-    have_pillow_jpeg_plugin = False
-    have_pillow_jpeg2000_plugin = False
+    HAVE_JPEG = False
+    HAVE_JPEG2K = False
 
 
 pillow_missing_message = ("pillow is not available "
@@ -38,9 +38,9 @@ pillow_missing_message = ("pillow is not available "
 
 test_pillow_decoder = have_numpy_handler and have_pillow_handler
 test_pillow_jpeg_decoder = (test_pillow_decoder and
-                            have_pillow_jpeg_plugin)
+                            HAVE_JPEG)
 test_pillow_jpeg2000_decoder = (test_pillow_decoder and
-                                have_pillow_jpeg2000_plugin)
+                                HAVE_JPEG2K)
 
 empty_number_tags_name = get_testdata_files(
     "reportsi_with_empty_number_tags.dcm")[0]
@@ -129,12 +129,12 @@ class Test_JPEGLS_no_pillow(object):
         """Setup the test datasets."""
         self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [None, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_JPEG_LS_PixelArray(self):
         """Test decoding JPEG LS with only numpy fails."""
@@ -155,12 +155,12 @@ class Test_JPEG2000Tests_no_pillow(object):
         self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
         self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
         self.sc_rgb_jpeg2k_gdcm_KY = dcmread(sc_rgb_jpeg2k_gdcm_KY)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [None, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def testJPEG2000(self):
         """Test reading element values works OK without Pillow."""
@@ -193,12 +193,12 @@ class Test_JPEGlossyTests_no_pillow(object):
         """Setup the test datasets."""
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [None, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def testJPEGlossy(self):
         """Test reading element values works OK without Pillow."""
@@ -221,12 +221,12 @@ class Test_JPEGlosslessTests_no_pillow(object):
     def setup(self):
         """Setup the test datasets."""
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [None, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def testJPEGlossless(self):
         """Test reading element values works OK without Pillow."""
@@ -249,12 +249,12 @@ class Test_JPEG_LS_with_pillow(object):
         """Setup the test datasets."""
         self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [pillow_handler, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [pillow_handler, numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_JPEG_LS_PixelArray(self):
         """Test decoding JPEG LS with pillow handler fails."""
@@ -282,12 +282,12 @@ class Test_JPEG2000Tests_with_pillow(object):
         self.sc_rgb_jpeg2k_gdcm_KY = dcmread(sc_rgb_jpeg2k_gdcm_KY)
         self.ground_truth_sc_rgb_jpeg2k_gdcm_KY_gdcm = dcmread(
             ground_truth_sc_rgb_jpeg2k_gdcm_KY_gdcm)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [pillow_handler, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [pillow_handler, numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_raises_if_endianess_not_set(self):
         self.jpeg_2k_lossless.is_little_endian = None
@@ -330,12 +330,12 @@ class Test_JPEGlossyTests_with_pillow(object):
         """Setup the test datasets."""
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [pillow_handler, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [pillow_handler, numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def testJPEGlossless_odd_data_size(self):
         """Test decoding JPEG with pillow handler succeeds."""
@@ -370,10 +370,10 @@ class Test_JPEGlossyTests_with_pillow(object):
 
 @pytest.fixture(scope="module")
 def test_with_pillow():
-    original_handlers = pydicom.config.image_handlers
-    pydicom.config.image_handlers = [pillow_handler, numpy_handler]
+    original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+    pydicom.config.PIXEL_DATA_HANDLERS = [pillow_handler, numpy_handler]
     yield original_handlers
-    pydicom.config.image_handlers = original_handlers
+    pydicom.config.PIXEL_DATA_HANDLERS = original_handlers
 
 
 if have_pytest_param:
@@ -586,12 +586,12 @@ class Test_JPEGlosslessTests_with_pillow(object):
     def setup(self):
         """Setup the test datasets."""
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [pillow_handler, numpy_handler]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [pillow_handler, numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def testJPEGlossless(self):
         """Test reading element values works OK with pillow pixel handler."""

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -127,12 +127,12 @@ class Test_JPEGLS_no_pillow(object):
         """Setup the test datasets."""
         self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEG_LS_PixelArray(self):
         """Test decoding JPEG LS with only numpy fails."""
@@ -153,12 +153,12 @@ class Test_JPEG2000Tests_no_pillow(object):
         self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
         self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
         self.sc_rgb_jpeg2k_gdcm_KY = dcmread(sc_rgb_jpeg2k_gdcm_KY)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEG2000(self):
         """Test reading element values works OK without Pillow."""
@@ -191,12 +191,12 @@ class Test_JPEGlossyTests_no_pillow(object):
         """Setup the test datasets."""
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossy(self):
         """Test reading element values works OK without Pillow."""
@@ -219,12 +219,12 @@ class Test_JPEGlosslessTests_no_pillow(object):
     def setup(self):
         """Setup the test datasets."""
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossless(self):
         """Test reading element values works OK without Pillow."""
@@ -247,12 +247,12 @@ class Test_JPEG_LS_with_pillow(object):
         """Setup the test datasets."""
         self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [pillow_handler, numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [pillow_handler, numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEG_LS_PixelArray(self):
         """Test decoding JPEG LS with pillow handler fails."""
@@ -280,12 +280,12 @@ class Test_JPEG2000Tests_with_pillow(object):
         self.sc_rgb_jpeg2k_gdcm_KY = dcmread(sc_rgb_jpeg2k_gdcm_KY)
         self.ground_truth_sc_rgb_jpeg2k_gdcm_KY_gdcm = dcmread(
             ground_truth_sc_rgb_jpeg2k_gdcm_KY_gdcm)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [pillow_handler, numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [pillow_handler, numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_raises_if_endianess_not_set(self):
         self.jpeg_2k_lossless.is_little_endian = None
@@ -328,12 +328,12 @@ class Test_JPEGlossyTests_with_pillow(object):
         """Setup the test datasets."""
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [pillow_handler, numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [pillow_handler, numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossless_odd_data_size(self):
         """Test decoding JPEG with pillow handler succeeds."""
@@ -368,10 +368,10 @@ class Test_JPEGlossyTests_with_pillow(object):
 
 @pytest.fixture(scope="module")
 def test_with_pillow():
-    original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-    pydicom.config.PIXEL_DATA_HANDLERS = [pillow_handler, numpy_handler]
+    original_handlers = pydicom.config.pixel_data_handlers
+    pydicom.config.pixel_data_handlers = [pillow_handler, numpy_handler]
     yield original_handlers
-    pydicom.config.PIXEL_DATA_HANDLERS = original_handlers
+    pydicom.config.pixel_data_handlers = original_handlers
 
 
 if have_pytest_param:
@@ -584,12 +584,12 @@ class Test_JPEGlosslessTests_with_pillow(object):
     def setup(self):
         """Setup the test datasets."""
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [pillow_handler, numpy_handler]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [pillow_handler, numpy_handler]
 
     def teardown(self):
         """Reset the pixel data handlers."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossless(self):
         """Test reading element values works OK with pillow pixel handler."""

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -152,13 +152,13 @@ def _get_pixel_array(fpath):
             'Function only usable if the numpy handler is available'
         )
 
-    original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-    pydicom.config.PIXEL_DATA_HANDLERS = [NP_HANDLER]
+    original_handlers = pydicom.config.pixel_data_handlers
+    pydicom.config.pixel_data_handlers = [NP_HANDLER]
 
     ds = dcmread(fpath)
     arr = ds.pixel_array
 
-    pydicom.config.PIXEL_DATA_HANDLERS = original_handlers
+    pydicom.config.pixel_data_handlers = original_handlers
 
     return arr
 
@@ -185,12 +185,12 @@ class TestNoNumpy_NoRLEHandler(object):
     """Tests for handling datasets without numpy and the handler."""
     def setup(self):
         """Setup the environment."""
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = []
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = []
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""
@@ -230,12 +230,12 @@ class TestNoNumpy_RLEHandler(object):
     """Tests for handling datasets without numpy and the handler."""
     def setup(self):
         """Setup the environment."""
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [RLE_HANDLER]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [RLE_HANDLER]
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""
@@ -288,12 +288,12 @@ class TestNumpy_NoRLEHandler(object):
     """Tests for handling datasets with no handler."""
     def setup(self):
         """Setup the environment."""
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = []
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = []
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""
@@ -333,12 +333,12 @@ class TestNumpy_RLEHandler(object):
     """Tests for handling datasets with the handler."""
     def setup(self):
         """Setup the environment."""
-        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
-        pydicom.config.PIXEL_DATA_HANDLERS = [RLE_HANDLER]
+        self.original_handlers = pydicom.config.pixel_data_handlers
+        pydicom.config.pixel_data_handlers = [RLE_HANDLER]
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
+        pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -36,7 +36,7 @@ try:
     import numpy as np
     from pydicom.pixel_data_handlers import numpy_handler as NP_HANDLER
     from pydicom.pixel_data_handlers.util import reshape_pixel_array
-    HAVE_NP = True
+    HAVE_NP = NP_HANDLER.HAVE_NP
 except ImportError:
     NP_HANDLER = None
     HAVE_NP = False
@@ -49,7 +49,9 @@ try:
         _rle_decode_segment,
         _parse_rle_header,
     )
+    HAVE_RLE = RLE_HANDLER.HAVE_RLE
 except ImportError:
+    HAVE_RLE = False
     RLE_HANDLER = None
 
 
@@ -144,7 +146,7 @@ def _get_pixel_array(fpath):
     -------
     numpy.ndarray
     """
-    if NP_HANDLER is None:
+    if not HAVE_NP:
         raise RuntimeError(
             'Function only usable if the numpy handler is available'
         )
@@ -192,7 +194,8 @@ class TestNoNumpy_NoRLEHandler(object):
     def test_environment(self):
         """Check that the testing environment is as expected."""
         assert not HAVE_NP
-        assert RLE_HANDLER is None
+        # The RLE handler should still be available
+        assert RLE_HANDLER is not None
 
     def test_can_access_supported_dataset(self):
         """Test that we can read and access elements in an RLE dataset."""

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -276,7 +276,7 @@ class TestNoNumpy_RLEHandler(object):
             exc_msg = (
                 r"The following handlers are available to decode the pixel "
                 r"data however they are missing required dependencies: "
-                r"RLE Lossless \(req. numpy\)"
+                r"RLE Lossless \(req. NumPy\)"
             )
             with pytest.raises(RuntimeError, match=exc_msg):
                 ds.pixel_array

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -149,13 +149,13 @@ def _get_pixel_array(fpath):
             'Function only usable if the numpy handler is available'
         )
 
-    original_handlers = pydicom.config.image_handlers
-    pydicom.config.image_handlers = [NP_HANDLER]
+    original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+    pydicom.config.PIXEL_DATA_HANDLERS = [NP_HANDLER]
 
     ds = dcmread(fpath)
     arr = ds.pixel_array
 
-    pydicom.config.image_handlers = original_handlers
+    pydicom.config.PIXEL_DATA_HANDLERS = original_handlers
 
     return arr
 
@@ -182,12 +182,12 @@ class TestNoNumpy_NoRLEHandler(object):
     """Tests for handling datasets without numpy and the handler."""
     def setup(self):
         """Setup the environment."""
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = []
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = []
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""
@@ -226,12 +226,12 @@ class TestNumpy_NoRLEHandler(object):
     """Tests for handling datasets with no handler."""
     def setup(self):
         """Setup the environment."""
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = []
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = []
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""
@@ -271,12 +271,12 @@ class TestNumpy_RLEHandler(object):
     """Tests for handling datasets with the handler."""
     def setup(self):
         """Setup the environment."""
-        self.original_handlers = pydicom.config.image_handlers
-        pydicom.config.image_handlers = [RLE_HANDLER]
+        self.original_handlers = pydicom.config.PIXEL_DATA_HANDLERS
+        pydicom.config.PIXEL_DATA_HANDLERS = [RLE_HANDLER]
 
     def teardown(self):
         """Restore the environment."""
-        pydicom.config.image_handlers = self.original_handlers
+        pydicom.config.PIXEL_DATA_HANDLERS = self.original_handlers
 
     def test_environment(self):
         """Check that the testing environment is as expected."""


### PR DESCRIPTION
#### Reference Issue
Closes #578

#### What does this implement/fix? Explain your changes.
Better exception messages for the handlers
* If no handlers support the transfer syntax, `NotImplementedError`
* If handlers support syntax but dependencies not met, `RuntimeError` and msg with handler name and required (unmet) dependencies.
