### PR TITLE
[MRG+1] Remove UID equality operator overrides

### DIFF
--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -15,6 +15,7 @@ Changes
   ``uid.JPEGExtended`` instead. (:issue:`726`)
 * ``uid.JPEG2000Lossy`` deprecated and will be removed in v1.3. Use
   ``uid.JPEG2000`` instead. (:issue:`726`)
+* Equality and inequality operator overrides removed from ``UID``.
 
 
 Enhancements

--- a/pydicom/tests/test_uid.py
+++ b/pydicom/tests/test_uid.py
@@ -70,49 +70,27 @@ class TestUID(object):
         assert self.uid == UID('1.2.840.10008.1.2')
         assert self.uid == '1.2.840.10008.1.2'
         assert '1.2.840.10008.1.2' == self.uid
-        assert self.uid == 'Implicit VR Little Endian'
-        assert 'Implicit VR Little Endian' == self.uid
+        assert not self.uid == 'Implicit VR Little Endian'
+        assert not 'Implicit VR Little Endian' == self.uid
         assert not self.uid == UID('1.2.840.10008.1.2.1')
         assert not self.uid == '1.2.840.10008.1.2.1'
         assert not '1.2.840.10008.1.2.1' == self.uid
-        assert not self.uid == 'Explicit VR Little Endian'
-        assert not 'Explicit VR Little Endian' == self.uid
         # Issue 96
         assert not self.uid == 3
         assert self.uid is not None
-
-    def test_equality_deprecation_warning(self):
-        """Test the deprecation warning is working"""
-        uid = UID('1.2.840.10008.1.1')
-        assert uid.name == 'Verification SOP Class'
-        assert uid == 'Verification SOP Class'
-        with pytest.deprecated_call():
-            assert uid == 'Verification SOP Class'
-            assert 'Verification SOP Class' == uid
 
     def test_inequality(self):
         """Test that UID.__ne__ works."""
         assert not self.uid != UID('1.2.840.10008.1.2')
         assert not self.uid != '1.2.840.10008.1.2'
         assert not '1.2.840.10008.1.2' != self.uid
-        assert not self.uid != 'Implicit VR Little Endian'
-        assert not 'Implicit VR Little Endian' != self.uid
+        assert self.uid != 'Implicit VR Little Endian'
+        assert 'Implicit VR Little Endian' != self.uid
         assert self.uid != UID('1.2.840.10008.1.2.1')
         assert self.uid != '1.2.840.10008.1.2.1'
         assert '1.2.840.10008.1.2.1' != self.uid
-        assert self.uid != 'Explicit VR Little Endian'
-        assert 'Explicit VR Little Endian' != self.uid
         # Issue 96
         assert self.uid != 3
-
-    def test_inequality_deprecation_warning(self):
-        """Test the deprecation warning is working"""
-        uid = UID('1.2.840.10008.1.1')
-        assert uid.name == 'Verification SOP Class'
-        assert uid != 'Implicit VR Little Endian'
-        with pytest.deprecated_call():
-            assert uid != 'Implicit VR Little Endian'
-            assert 'Implicit VR Little Endian' != uid
 
     def test_hash(self):
         """Test that UID.__hash_- works."""

--- a/pydicom/uid.py
+++ b/pydicom/uid.py
@@ -63,50 +63,6 @@ class UID(str):
 
         raise TypeError("UID must be a string")
 
-    def __eq__(self, other):
-        """Return True if `self` or `self.name` equals `other`."""
-        # TODO: v1.2 - The __ne__ override is deprecated
-        if isinstance(other, str) and other and '.' not in other:
-            msg = "The equality test for \"UID == '{0}'\" is deprecated and " \
-                  "will be removed in pydicom v1.2. In the future use " \
-                  "\"UID.name == '{0}'\"".format(other)
-            warnings.warn(msg, DeprecationWarning)
-
-        if str.__eq__(self, other) is True:  # 'is True' needed (issue 96)
-            return True
-
-        if str.__eq__(self.name, other) is True:  # 'is True' needed (issue 96)
-            return True
-
-        return False
-
-    def __ne__(self, other):
-        """Return True if `self` or `self.name` does not equal `other`."""
-        # TODO: v1.2 - The __ne__ override is deprecated
-        if isinstance(other, str) and other and '.' not in other:
-            msg = "The equality test for \"UID != '{0}'\" is deprecated and " \
-                  "will be removed in pydicom v1.2. In the future use " \
-                  "\"UID.name != '{0}'\"".format(other)
-            warnings.warn(msg, DeprecationWarning)
-
-        if str.__eq__(self, other) is True:
-            return False
-
-        if str.__eq__(self.name, other) is True:
-            return False
-
-        return True
-
-    def __hash__(self):
-        """Return the hash of `self`."""
-        # TODO: v1.2 - The __hash__ override is deprecated
-        # For python 3, any override of __cmp__ or __eq__
-        #   immutable requires explicit redirect of hash
-        #   function to the parent class
-        #   See http://docs.python.org/dev/3.0/
-        #       reference/datamodel.html#object.__hash__
-        return super(UID, self).__hash__()
-
     @property
     def is_implicit_VR(self):
         """Return True if an implicit VR transfer syntax UID."""


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Removes `UID.__eq__`, `UID.__ne__` and `UID.__hash__` as per planned deprecation.