### PR TITLE
[MRG+2] Added correct writing of PN values with multiple encodings

### DIFF
--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -37,7 +37,11 @@ Enhancements
 * Added ``Dataset.fix_meta_info()`` (:issue:`584`)
 * Add new function for bit packing ``pack_bits`` for use with BitsAllocated
   = 1 (:pull_request:`715`)
-* Added handling of single-byte character set extensions (:pull_request:`718`)
+* Added/corrected encoding and decoding of text and person name VRs using
+  character sets with code extensions, added handling of encoding/decoding
+  errors (:issue:`716`)
+* Handle common spelling errors in Specific Character Set values
+  (:pull_request:`695`, :pull_request:`737`)
 * Added ``uid.JPEGLosslessP14`` for UID 1.2.840.10008.1.2.4.57
 * Added ``uid.JPEG2000MultiComponentLossless`` for UID 1.2.840.10008.1.2.4.92
 * Added ``uid.JPEG2000MultiComponent`` for UID 1.2.840.10008.1.2.4.93
@@ -55,6 +59,9 @@ Fixes
   (:pull_request:`660`)
 * Improve performance for Python 3 when dealing with compressed multi-frame
   Pixel Data with pillow and jpeg-ls (:issue:`682`).
+* Fixed handling of private tags in repeater range (:issue:`689`)
+* Fixed handling of elements with ambiguous VR (:pull_request:`700`,
+  :pull_request:`728`)
 * Improve performance of bit unpacking (:pull_request:`715`)
 * First character set no longer removed (:issue:`707`)
 * Fixed RLE decoded data having the wrong byte order (:pull_request:`729`)

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -55,7 +55,8 @@ python_encoding = {
 }
 
 # these encodings cannot be used with code extensions
-# see PS3.5, Section 6.1.2.5.4, item d
+# see DICOM Standard, Part 3, Table C.12-5
+# and DICOM Standard, Part 5, Section 6.1.2.5.4, item d
 STAND_ALONE_ENCODINGS = ('ISO_IR 192', 'GBK', 'GB18030')
 
 # the escape character used to mark the start of escape sequences

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -397,7 +397,7 @@ def convert_encodings(encodings):
             except KeyError:
                 pass
         # if patching failed at this point, the original encodings
-        # will be returned, assumimg that they are already Python encodings;
+        # will be returned, assuming that they are already Python encodings;
         # otherwise, a LookupError will be raised in the using code
 
     # handle illegal stand-alone encodings

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -55,6 +55,7 @@ python_encoding = {
 }
 
 # these encodings cannot be used with code extensions
+# see PS3.5, Section 6.1.2.5.4, item d
 STAND_ALONE_ENCODINGS = ('ISO_IR 192', 'GBK', 'GB18030')
 
 # the escape character used to mark the start of escape sequences
@@ -323,7 +324,7 @@ def _encode_string_parts(value, encodings):
         If `value` could not be encoded with the given encodings.
 
     """
-    encoded = b''
+    encoded = bytearray()
     unencoded_part = value
     while unencoded_part:
         # find the encoding that can encode the longest part of the rest

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1344,8 +1344,9 @@ class FileDataset(Dataset):
 
         Parameters
         ----------
-        filename_or_obj : str or None
-            Full path and filename to the file. Use None if is a BytesIO.
+        filename_or_obj : str or BytesIO or None
+            Full path and filename to the file, memory buffer object, or None
+            if is a BytesIO.
         dataset : Dataset or dict
             Some form of dictionary, usually a Dataset from read_dataset().
         preamble : bytes or str, optional

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -299,7 +299,7 @@ def write_text(fp, data_element, encoding=None):
                 val = encode_string(val, encoding)
 
         if len(val) % 2 != 0:
-            val = val + b' ' # pad to even length
+            val = val + b' '  # pad to even length
         fp.write(val)
 
 

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -6,8 +6,9 @@ from struct import pack
 
 from pydicom import compat
 from pydicom.compat import in_py2
-from pydicom.charset import default_encoding, text_VRs, convert_encodings, \
-    encode_string
+from pydicom.charset import (
+    default_encoding, text_VRs, convert_encodings, encode_string
+)
 from pydicom.dataelem import DataElement_from_raw
 from pydicom.dataset import Dataset, validate_file_meta
 from pydicom.filebase import DicomFile, DicomFileLike, DicomBytesIO
@@ -249,9 +250,9 @@ def multi_string(val):
         return val
 
 
-def write_PN(fp, data_element, encoding=None):
-    if not encoding:
-        encoding = [default_encoding]
+def write_PN(fp, data_element, encodings=None):
+    if not encodings:
+        encodings = [default_encoding]
 
     if data_element.VM == 1:
         val = [data_element.value, ]
@@ -260,11 +261,11 @@ def write_PN(fp, data_element, encoding=None):
 
     if isinstance(val[0], compat.text_type) or not in_py2:
         try:
-            val = [elem.encode(encoding) for elem in val]
+            val = [elem.encode(encodings) for elem in val]
         except TypeError:
             # we get here in Python 2 if val is a unicode string
-            val = [PersonNameUnicode(elem, encoding) for elem in val]
-            val = [elem.encode(encoding) for elem in val]
+            val = [PersonNameUnicode(elem, encodings) for elem in val]
+            val = [elem.encode(encodings) for elem in val]
 
     val = b'\\'.join(val)
 
@@ -285,20 +286,20 @@ def write_string(fp, data_element, padding=' '):
         fp.write(val)
 
 
-def write_text(fp, data_element, encoding=None):
+def write_text(fp, data_element, encodings=None):
     """Write a single or multivalued text string."""
     val = data_element.value
     if val is not None:
-        encoding = encoding or [default_encoding]
+        encodings = encodings or [default_encoding]
         if _is_multi_value(val):
             if val and isinstance(val[0], compat.text_type):
-                val = b'\\'.join([encode_string(val, encoding)
+                val = b'\\'.join([encode_string(val, encodings)
                                   for val in val])
             else:
                 val = b'\\'.join([val for val in val])
         else:
             if isinstance(val, compat.text_type):
-                val = encode_string(val, encoding)
+                val = encode_string(val, encodings)
 
         if len(val) % 2 != 0:
             val = val + b' '  # pad to even length
@@ -417,7 +418,7 @@ def write_TM(fp, data_element):
         fp.write(val)
 
 
-def write_data_element(fp, data_element, encoding=default_encoding):
+def write_data_element(fp, data_element, encodings=None):
     """Write the data_element to file fp according to
     dicom media storage rules.
     """
@@ -455,13 +456,14 @@ def write_data_element(fp, data_element, encoding=default_encoding):
                 "write_data_element: unknown Value Representation "
                 "'{0}'".format(VR))
 
-        encoding = convert_encodings(encoding)
+        encodings = encodings or [default_encoding]
+        encodings = convert_encodings(encodings)
         writer_function, writer_param = writers[VR]
         is_undefined_length = data_element.is_undefined_length
         if VR in text_VRs:
-            writer_function(buffer, data_element, encoding=encoding)
+            writer_function(buffer, data_element, encodings=encodings)
         elif VR in ('PN', 'SQ'):
-            writer_function(buffer, data_element, encoding=encoding)
+            writer_function(buffer, data_element, encodings=encodings)
         else:
             # Many numeric types use the same writer but with numeric format
             # parameter
@@ -539,16 +541,16 @@ def _harmonize_properties(dataset, fp):
     fp.is_little_endian = dataset.is_little_endian
 
 
-def write_sequence(fp, data_element, encoding):
+def write_sequence(fp, data_element, encodings):
     """Write a dicom Sequence contained in data_element to the file fp."""
     # write_data_element has already written the VR='SQ' (if needed) and
     #    a placeholder for length"""
     sequence = data_element.value
     for dataset in sequence:
-        write_sequence_item(fp, dataset, encoding)
+        write_sequence_item(fp, dataset, encodings)
 
 
-def write_sequence_item(fp, dataset, encoding):
+def write_sequence_item(fp, dataset, encodings):
     """Write an item (dataset) in a dicom Sequence to the dicom file fp.
 
     This is similar to writing a data_element, but with a specific tag for
@@ -560,7 +562,7 @@ def write_sequence_item(fp, dataset, encoding):
     length_location = fp.tell()  # save location for later.
     # will fill in real value later if not undefined length
     fp.write_UL(0xffffffff)
-    write_dataset(fp, dataset, parent_encoding=encoding)
+    write_dataset(fp, dataset, parent_encoding=encodings)
     if getattr(dataset, "is_undefined_length_sequence_item", False):
         fp.write_tag(ItemDelimiterTag)
         fp.write_UL(0)  # 4-bytes 'length' field for delimiter item

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -15,7 +15,7 @@ from pydicom.multival import MultiValue
 from pydicom.tag import (Tag, ItemTag, ItemDelimiterTag, SequenceDelimiterTag,
                          tag_in_exception)
 from pydicom.uid import UncompressedPixelTransferSyntaxes
-from pydicom.valuerep import extra_length_VRs
+from pydicom.valuerep import extra_length_VRs, PersonNameUnicode
 from pydicom.values import convert_numbers
 
 
@@ -262,7 +262,9 @@ def write_PN(fp, data_element, encoding=None):
         try:
             val = [elem.encode(encoding) for elem in val]
         except TypeError:
-            val = [elem.encode(encoding[0]) for elem in val]
+            # we get here in Python 2 if val is a unicode string
+            val = [PersonNameUnicode(elem, encoding) for elem in val]
+            val = [elem.encode(encoding) for elem in val]
 
     val = b'\\'.join(val)
 

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -143,10 +143,19 @@ class TestCharset(object):
     def test_convert_encodings_warnings(self):
         """Test warning if stand-alone encodings are used as code extension"""
         with pytest.warns(UserWarning, match="Value 'GBK' cannot be used as "
-                                             "code extension, ignoring it"):
+                                "code extension, ignoring it"):
             encodings = pydicom.charset.convert_encodings(
                 ['ISO_IR 126', 'GBK', 'ISO 2022 IR 144', 'ISO_IR 192'])
             assert ['iso_ir_126', 'iso_ir_144'] == encodings
+
+    def test_convert_python_encodings(self):
+        """Test that unknown encodings are returned unchanged by
+        `convert_encodings`"""
+        encodings = ['iso_ir_126', 'iso_ir_144']
+        assert encodings == pydicom.charset.convert_encodings(encodings)
+
+        encodings = ['ISO IR 199', 'ISO_IR 100']
+        assert encodings == pydicom.charset.convert_encodings(encodings)
 
     def test_bad_encoded_multi_byte_encoding(self):
         """Test handling bad encoding for single encoding"""

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -133,8 +133,8 @@ class TestCharset(object):
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xc3\xa9r\xc3\xb4me')
 
         msg = ("Value 'ISO_IR 192' for Specific Character Set does not "
-                      "allow code extensions, ignoring: ISO 2022 IR 100, "
-                      "ISO 2022 IR 144")
+               "allow code extensions, ignoring: ISO 2022 IR 100, "
+               "ISO 2022 IR 144")
         with pytest.warns(UserWarning, match=msg):
             pydicom.charset.decode(elem, ['ISO_IR 192', 'ISO 2022 IR 100',
                                           'ISO 2022 IR 144'])
@@ -143,7 +143,7 @@ class TestCharset(object):
     def test_convert_encodings_warnings(self):
         """Test warning if stand-alone encodings are used as code extension"""
         with pytest.warns(UserWarning, match="Value 'GBK' cannot be used as "
-                                "code extension, ignoring it"):
+                                             "code extension, ignoring it"):
             encodings = pydicom.charset.convert_encodings(
                 ['ISO_IR 126', 'GBK', 'ISO 2022 IR 144', 'ISO_IR 192'])
             assert ['iso_ir_126', 'iso_ir_144'] == encodings

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -234,9 +234,9 @@ class TestCharset(object):
 
         # multiple values with different encodings
         encoded = (b'Buc^J\xe9r\xf4me\\\x1b\x2d\x46'
-                           b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2\\'
-                           b'\x1b\x2d\x4C'
-                           b'\xbb\xee\xda\x63\x65\xdc\xd1\x79\x70\xd3')
+                   b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2\\'
+                   b'\x1b\x2d\x4C'
+                   b'\xbb\xee\xda\x63\x65\xdc\xd1\x79\x70\xd3')
         elem = DataElement(0x00100060, 'PN', encoded)
         pydicom.charset.decode(elem, ['ISO 2022 IR 100',
                                       'ISO 2022 IR 144',

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -8,6 +8,7 @@ from io import BytesIO
 import os
 import sys
 import unittest
+from platform import python_implementation
 
 from struct import unpack
 from tempfile import TemporaryFile
@@ -2152,8 +2153,8 @@ class TestWritePN(object):
         fp.is_little_endian = True
         encodings = ['latin_1', 'iso_ir_126']
         # data element with encoded value
-        encoded = (b'Dionysios=\x1b\x2d\x46'                           
-                    b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
+        encoded = (b'Dionysios=\x1b\x2d\x46'
+                   b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
         elem = DataElement(0x00100010, 'PN', encoded)
         write_PN(fp, elem, encoding=encodings)
         assert encoded == fp.getvalue()
@@ -2234,9 +2235,9 @@ class TestWriteText(object):
         fp = DicomBytesIO()
         fp.is_little_endian = True
         encoded = (b'Buc^J\xe9r\xf4me\\\x1b\x2d\x46'
-                           b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2\\'
-                           b'\x1b\x2d\x4C'
-                           b'\xbb\xee\xda\x63\x65\xdc\xd1\x79\x70\xd3 ')
+                   b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2\\'
+                   b'\x1b\x2d\x4C'
+                   b'\xbb\xee\xda\x63\x65\xdc\xd1\x79\x70\xd3 ')
         # data element with encoded value
         elem = DataElement(0x00081039, 'LO', encoded)
         encodings = ['latin_1', 'iso_ir_144', 'iso_ir_126']
@@ -2261,7 +2262,11 @@ class TestWriteText(object):
         msg = 'Failed to encode value with encodings: iso-2022-jp'
         with pytest.warns(UserWarning, match=msg):
             write_text(fp, elem, encoding=['iso-2022-jp'])
-            assert b'Dionysios \x1b$B&$&I&O&M&T&R&I&O\x1b(B? ' == fp.getvalue()
+            if 'PyPy' in python_implementation():
+                expected = b'Dionysios \x1b$B&$&I&O&M&T&R&I&O?\x1b(B '
+            else:
+                expected = b'Dionysios \x1b$B&$&I&O&M&T&R&I&O\x1b(B? '
+            assert expected == fp.getvalue()
 
 
 class TestWriteDT(object):

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -2145,8 +2145,6 @@ class TestWritePN(object):
         write_PN(fp, elem)
         assert b'Test' == fp.getvalue()
 
-    @pytest.mark.skipif(sys.version_info[0] == 2,
-                        reason='Not working with PersonNameUnicode')
     def test_single_byte_multi_charset_groups(self):
         """Test component groups with different encodings"""
         fp = DicomBytesIO()
@@ -2166,8 +2164,6 @@ class TestWritePN(object):
         write_PN(fp, elem, encoding=encodings)
         assert encoded == fp.getvalue()
 
-    @pytest.mark.skipif(sys.version_info[0] == 2,
-                        reason='Not working with PersonNameUnicode')
     def test_single_byte_multi_charset_values(self):
         """Test multiple values with different encodings"""
         fp = DicomBytesIO()

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -1364,9 +1364,9 @@ class TestWriteToStandard(object):
         out = dcmread(fp)
         assert out.file_meta.MediaStorageSOPClassUID == ds.SOPClassUID
         assert out.file_meta.MediaStorageSOPInstanceUID == ds.SOPInstanceUID
-        assert (
-                out.file_meta.ImplementationClassUID == PYDICOM_IMPLEMENTATION_UID)
-        assert (out.file_meta.ImplementationVersionName == version)
+        assert (out.file_meta.ImplementationClassUID ==
+                PYDICOM_IMPLEMENTATION_UID)
+        assert out.file_meta.ImplementationVersionName == version
         assert out.file_meta.TransferSyntaxUID == transfer_syntax
 
         fp = DicomBytesIO()
@@ -1374,12 +1374,11 @@ class TestWriteToStandard(object):
         ds.save_as(fp, write_like_original=False)
         fp.seek(0)
         out = dcmread(fp)
-        assert (out.file_meta.MediaStorageSOPClassUID == ds.SOPClassUID)
-        assert (
-                out.file_meta.MediaStorageSOPInstanceUID == ds.SOPInstanceUID)
-        assert (
-                out.file_meta.ImplementationClassUID == PYDICOM_IMPLEMENTATION_UID)
-        assert (out.file_meta.ImplementationVersionName == version)
+        assert out.file_meta.MediaStorageSOPClassUID == ds.SOPClassUID
+        assert out.file_meta.MediaStorageSOPInstanceUID == ds.SOPInstanceUID
+        assert (out.file_meta.ImplementationClassUID ==
+                PYDICOM_IMPLEMENTATION_UID)
+        assert out.file_meta.ImplementationVersionName == version
         assert out.file_meta.TransferSyntaxUID == transfer_syntax
 
     def test_raise_no_file_meta(self):

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -2140,14 +2140,14 @@ class TestWritePN(object):
         encoded = (b'Dionysios=\x1b\x2d\x46'
                    b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
         elem = DataElement(0x00100010, 'PN', encoded)
-        write_PN(fp, elem, encoding=encodings)
+        write_PN(fp, elem, encodings=encodings)
         assert encoded == fp.getvalue()
 
         fp = DicomBytesIO()
         fp.is_little_endian = True
         # data element with decoded value
         elem = DataElement(0x00100010, 'PN', u'Dionysios=Διονυσιος')
-        write_PN(fp, elem, encoding=encodings)
+        write_PN(fp, elem, encodings=encodings)
         assert encoded == fp.getvalue()
 
     def test_single_byte_multi_charset_values(self):
@@ -2161,7 +2161,7 @@ class TestWritePN(object):
                    b'\x1b\x2d\x4C'
                    b'\xbb\xee\xda\x63\x65\xdc\xd1\x79\x70\xd3 ')
         elem = DataElement(0x00100060, 'PN', encoded)
-        write_PN(fp, elem, encoding=encodings)
+        write_PN(fp, elem, encodings=encodings)
         assert encoded == fp.getvalue()
 
         fp = DicomBytesIO()
@@ -2169,7 +2169,7 @@ class TestWritePN(object):
         # data element with decoded value
         elem = DataElement(0x00100060, 'PN', [u'Buc^Jérôme', u'Διονυσιος',
                                               u'Люкceмбypг'])
-        write_PN(fp, elem, encoding=encodings)
+        write_PN(fp, elem, encodings=encodings)
         assert encoded == fp.getvalue()
 
 
@@ -2201,14 +2201,14 @@ class TestWriteText(object):
         # data element with encoded value
         elem = DataElement(0x00081039, 'LO', encoded)
         encodings = ['latin_1', 'iso_ir_126']
-        write_text(fp, elem, encoding=encodings)
+        write_text(fp, elem, encodings=encodings)
         assert encoded == fp.getvalue()
 
         fp = DicomBytesIO()
         fp.is_little_endian = True
         # data element with decoded value
         elem = DataElement(0x00081039, 'LO', u'Dionysios is Διονυσιος')
-        write_text(fp, elem, encoding=encodings)
+        write_text(fp, elem, encodings=encodings)
         # encoding may not be the same, so decode it first
         encoded = fp.getvalue()
         assert u'Dionysios is Διονυσιος' == convert_text(encoded, encodings)
@@ -2222,7 +2222,7 @@ class TestWriteText(object):
 
         # data element with encoded value
         elem = DataElement(0x00081039, 'LO', decoded)
-        write_text(fp, elem, encoding=encodings)
+        write_text(fp, elem, encodings=encodings)
         encoded = fp.getvalue()
         # make sure that the encoded string can be converted back
         assert decoded == convert_text(encoded, encodings)
@@ -2238,7 +2238,7 @@ class TestWriteText(object):
         # data element with encoded value
         elem = DataElement(0x00081039, 'LO', encoded)
         encodings = ['latin_1', 'iso_ir_144', 'iso_ir_126']
-        write_text(fp, elem, encoding=encodings)
+        write_text(fp, elem, encodings=encodings)
         assert encoded == fp.getvalue()
 
         fp = DicomBytesIO()
@@ -2246,7 +2246,7 @@ class TestWriteText(object):
         # data element with decoded value
         decoded = [u'Buc^Jérôme', u'Διονυσιος', u'Люкceмбypг']
         elem = DataElement(0x00081039, 'LO', decoded)
-        write_text(fp, elem, encoding=encodings)
+        write_text(fp, elem, encodings=encodings)
         # encoding may not be the same, so decode it first
         encoded = fp.getvalue()
         assert decoded == convert_text(encoded, encodings)
@@ -2258,7 +2258,7 @@ class TestWriteText(object):
         elem = DataElement(0x00081039, 'LO', u'Dionysios Διονυσιος')
         msg = 'Failed to encode value with encodings: iso-2022-jp'
         with pytest.warns(UserWarning, match=msg):
-            write_text(fp, elem, encoding=['iso-2022-jp'])
+            write_text(fp, elem, encodings=['iso-2022-jp'])
             if 'PyPy' in python_implementation():
                 # PyPy seems to have a different implementation of
                 # replacement mode with regard to escape sequences
@@ -2274,7 +2274,7 @@ class TestWriteText(object):
         decoded = u'Διονυσιος\r\nJérôme/Люкceмбypг\tJérôme'
         elem = DataElement(0x00081039, 'LO', decoded)
         encodings = ('latin_1', 'iso_ir_144', 'iso_ir_126')
-        write_text(fp, elem, encoding=encodings)
+        write_text(fp, elem, encodings=encodings)
         encoded = fp.getvalue()
         assert decoded == convert_text(encoded, encodings)
 

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -623,7 +623,7 @@ class PersonName3(object):
 
     def _create_dict(self):
         """Creates a dictionary of person name group and component names.
-        Used exclusivelt for `formatted` for backwards compatibility."""
+        Used exclusively for `formatted` for backwards compatibility."""
         if not self._dict:
             for name in ('family_name', 'given_name', 'middle_name',
                          'name_prefix', 'name_suffix',
@@ -632,6 +632,10 @@ class PersonName3(object):
 
     @property
     def components(self):
+        """Return the up to three decoded person name components, representing
+        the alphabetic, ideographic and phonetic representations as a list
+        of unicode strings.
+        """
         if self._components is None:
             groups = self.original_string.split(b'=')
             self._components = _decode_personname(groups, self.encodings)
@@ -646,26 +650,38 @@ class PersonName3(object):
 
     @property
     def family_name(self):
+        """Return the first (family name) group of the alphabetic person name
+        representation as a unicode string"""
         return self._name_part(0)
 
     @property
     def given_name(self):
+        """Return the second (given name) group of the alphabetic person name
+        representation as a unicode string"""
         return self._name_part(1)
 
     @property
     def middle_name(self):
+        """Return the third (middle name) group of the alphabetic person name
+        representation as a unicode string"""
         return self._name_part(2)
 
     @property
     def name_prefix(self):
+        """Return the fourth (name prefix) group of the alphabetic person name
+        representation as a unicode string"""
         return self._name_part(3)
 
     @property
     def name_suffix(self):
+        """Return the fifth (name suffix) group of the alphabetic person name
+        representation as a unicode string"""
         return self._name_part(4)
 
     @property
     def ideographic(self):
+        """Return the second (ideographic) person name component as a
+        unicode string"""
         try:
             return self.components[1]
         except IndexError:
@@ -673,6 +689,8 @@ class PersonName3(object):
 
     @property
     def phonetic(self):
+        """Return the third (phonetic) person name component as a
+        unicode string"""
         try:
             return self.components[2]
         except IndexError:

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -1,6 +1,5 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Special classes for DICOM value representations (VR)"""
-
 from copy import deepcopy
 from decimal import Decimal
 import re
@@ -39,16 +38,6 @@ TEXT_VR_DELIMS = ({'\n', '\r', '\t', '\f'} if compat.in_py2
 # Character/Character code for PN delimiter: name part separator '^'
 # (the component separator '=' is handled separately)
 PN_DELIMS = {'^'} if compat.in_py2 else {0xe5}
-
-match_string = b''.join([
-    b'(?P<single_byte>', br'(?P<family_name>[^=\^]*)',
-    br'\^?(?P<given_name>[^=\^]*)', br'\^?(?P<middle_name>[^=\^]*)',
-    br'\^?(?P<name_prefix>[^=\^]*)', br'\^?(?P<name_suffix>[^=\^]*)', b')',
-    b'=?(?P<ideographic>[^=]*)', b'=?(?P<phonetic>[^=]*)$'
-])
-
-match_string_uni = re.compile(match_string.decode('iso8859'))
-match_string_bytes = re.compile(match_string)
 
 
 class DA(date):
@@ -549,7 +538,23 @@ def _verify_encodings(encodings):
 
 
 def _decode_personname(components, encodings):
-    """Return a list of decoded person name components."""
+    """Return a list of decoded person name components.
+
+    Parameters
+    ----------
+    components : list of byte string
+        The list of the up to three encoded person name components
+    encodings : list of str
+        The Python encodings uses to decode `components`.
+
+    Returns
+    -------
+    text type
+        The unicode string representing the person name.
+        If the decoding of some component parts is not possible using the
+        given encodings, they are decoded with the first encoding using
+        replacement characters for bytes that cannot be decoded.
+    """
     from pydicom.charset import decode_string
 
     if isinstance(components[0], compat.text_type):
@@ -564,55 +569,126 @@ def _decode_personname(components, encodings):
 
 
 def _encode_personname(components, encodings):
-    if not compat.in_py2 and isinstance(components[0], bytes):
-        comps = components
-    else:
-        comps = [
-            C.encode(enc) for C, enc in zip(components, encodings)
-        ]
+    """Encode a list of text string person name components.
+
+    Parameters
+    ----------
+    components : list of text type
+        The list of the up to three unicode person name components
+    encodings : list of str
+        The Python encodings uses to encode `components`.
+
+    Returns
+    -------
+    byte string
+        The byte string that can be written as a PN DICOM tag value.
+        If the encoding of some component parts is not possible using the
+        given encodings, they are encoded with the first encoding using
+        replacement bytes for characters that cannot be encoded.
+    """
+    from pydicom.charset import encode_string
+
+    encoded_comps = []
+    for comp in components:
+        groups = [encode_string(group, encodings)
+                  for group in comp.split('^')]
+        encoded_comps.append(b'^'.join(groups))
 
     # Remove empty elements from the end
-    while len(comps) and not comps[-1]:
-        comps.pop()
-
-    return b'='.join(comps)
+    while len(encoded_comps) and not encoded_comps[-1]:
+        encoded_comps.pop()
+    return b'='.join(encoded_comps)
 
 
 class PersonName3(object):
-    def __init__(self, val, encodings=None):
+    def __init__(self, val, encodings=None, original_string=None):
+        # handle None `val` as empty string
+        val = val or ''
         if isinstance(val, PersonName3):
             encodings = val.encodings
-            val = val.original_string
-
-        self.original_string = val
+            self.original_string = val.original_string
+            self._components = str(val).split('=')
+        elif isinstance(val, bytes):
+            # this is the raw byte string - decode it on demand
+            self.original_string = val
+            self._components = None
+        else:
+            # this is the decoded string - save the original string if
+            # available for easier writing back
+            self.original_string = original_string
+            self._components = val.split('=')
 
         self.encodings = _verify_encodings(encodings) or [default_encoding]
-        self.parse(val)
+        self._dict = {}
 
-    def parse(self, val):
-        if isinstance(val, bytes):
-            matchstr = match_string_bytes
-        else:
-            matchstr = match_string_uni
+    def _create_dict(self):
+        """Creates a dictionary of person name group and component names.
+        Used exclusivelt for `formatted` for backwards compatibility."""
+        if not self._dict:
+            for name in ('family_name', 'given_name', 'middle_name',
+                         'name_prefix', 'name_suffix',
+                         'ideographic', 'phonetic'):
+                self._dict[name] = getattr(self, name, '')
 
-        matchobj = re.match(matchstr, val)
+    @property
+    def components(self):
+        if self._components is None:
+            groups = self.original_string.split(b'=')
+            self._components = _decode_personname(groups, self.encodings)
 
-        self.__dict__.update(matchobj.groupdict())
+        return self._components
 
-        groups = matchobj.groups()
-        self.components = [groups[i] for i in (0, -2, -1)]
+    def _name_part(self, i):
+        try:
+            return self.components[0].split('^')[i]
+        except IndexError:
+            return ''
+
+    @property
+    def family_name(self):
+        return self._name_part(0)
+
+    @property
+    def given_name(self):
+        return self._name_part(1)
+
+    @property
+    def middle_name(self):
+        return self._name_part(2)
+
+    @property
+    def name_prefix(self):
+        return self._name_part(3)
+
+    @property
+    def name_suffix(self):
+        return self._name_part(4)
+
+    @property
+    def ideographic(self):
+        try:
+            return self.components[1]
+        except IndexError:
+            return ''
+
+    @property
+    def phonetic(self):
+        try:
+            return self.components[2]
+        except IndexError:
+            return ''
 
     def __eq__(self, other):
-        return self.original_string == other
+        return str(self) == other
 
     def __ne__(self, other):
         return not self == other
 
     def __str__(self):
-        return self.original_string.__str__()
+        return '='.join(self.components).__str__()
 
     def __repr__(self):
-        return self.original_string.__repr__()
+        return '='.join(self.components).__repr__()
 
     # For python 3, any override of __cmp__ or __eq__
     # immutable requires explicit redirect of hash
@@ -622,22 +698,63 @@ class PersonName3(object):
     __hash__ = object.__hash__
 
     def decode(self, encodings=None):
-        encodings = _verify_encodings(encodings) or self.encodings
-        comps = _decode_personname(self.components, encodings)
-        return PersonName3(u'='.join(comps), encodings)
+        """Return the patient name decoded by the given encodings.
+
+        Parameters
+        ----------
+        encodings : list of str
+            The list of encodings used for decoding the byte string. If not
+            given, the initial encodings set in the object are used.
+
+        Returns
+        -------
+        PersonName3
+            A person name object that will return the decoded string with
+            the given encodings on demand. If the encodings are not given,
+            the current object is returned.
+        """
+        # in the common case (encoding did not change) we decode on demand
+        if encodings is None or encodings == self.encodings:
+            return self
+        # the encoding was unknown or incorrect - create a new
+        # PersonName object with the changed encoding
+        encodings = _verify_encodings(encodings)
+        return PersonName3(self.original_string, encodings)
 
     def encode(self, encodings=None):
+        """Return the patient name decoded by the given encodings.
+
+        Parameters
+        ----------
+        encodings : list of str
+            The list of encodings used for encoding the unicode string. If
+            not given, the initial encodings set in the object are used.
+
+        Returns
+        -------
+        bytes
+            The person name encoded with the given encodings as a byte string.
+            If no encoding is given, the original byte string is returned, if
+            available, otherwise each group of the patient name is encoded
+            with the first matching of the given encodings.
+        """
         encodings = _verify_encodings(encodings) or self.encodings
-        return _encode_personname(self.components, encodings)
+        # if the encoding is not the original encoding, we have to return
+        # a re-encoded string (without updating the original string)
+        if encodings != self.encodings:
+            return _encode_personname(self.components, encodings)
+        if self.original_string is None:
+            # if the original encoding was not set, we set it now
+            self.original_string = _encode_personname(self.components,
+                                                      encodings)
+        return self.original_string
 
     def family_comma_given(self):
         return self.formatted('%(family_name)s, %(given_name)s')
 
     def formatted(self, format_str):
-        if isinstance(self.original_string, bytes):
-            return format_str % self.decode(default_encoding).__dict__
-        else:
-            return format_str % self.__dict__
+        self._create_dict()
+        return format_str % self._dict
 
 
 class PersonNameBase(object):
@@ -741,7 +858,6 @@ class PersonNameUnicode(PersonNameBase, compat.text_type):
         encodings = _verify_encodings(encodings)
         comps = _decode_personname(val.split(b"="), encodings)
         new_val = u"=".join(comps)
-
         return compat.text_type.__new__(cls, new_val)
 
     def __init__(self, val, encodings):

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -307,7 +307,7 @@ def convert_UR_string(byte_string, is_little_endian, struct_format=None):
     return byte_string
 
 
-def convert_value(VR, raw_data_element, encoding=default_encoding):
+def convert_value(VR, raw_data_element, encodings=None):
     """Return the converted value (from raw bytes) for the given VR"""
     if VR not in converters:
         message = "Unknown Value Representation '{0}'".format(VR)
@@ -322,9 +322,10 @@ def convert_value(VR, raw_data_element, encoding=default_encoding):
         converter = converters[VR]
         num_format = None
 
-    # Ensure that encoding is in the proper 3-element format
-    if isinstance(encoding, compat.string_types):
-        encoding = [encoding]
+    # Ensure that encodings is a list
+    encodings = encodings or [default_encoding]
+    if isinstance(encodings, compat.string_types):
+        encodings = [encodings]
 
     byte_string = raw_data_element.value
     is_little_endian = raw_data_element.is_little_endian
@@ -335,7 +336,7 @@ def convert_value(VR, raw_data_element, encoding=default_encoding):
     try:
         if VR in text_VRs or VR == 'PN':
             value = converter(byte_string,
-                              encodings=encoding)
+                              encodings=encodings)
         elif VR != "SQ":
             value = converter(byte_string,
                               is_little_endian,
@@ -344,7 +345,7 @@ def convert_value(VR, raw_data_element, encoding=default_encoding):
             value = convert_SQ(byte_string,
                                is_implicit_VR,
                                is_little_endian,
-                               encoding,
+                               encodings,
                                raw_data_element.value_tell)
     except ValueError:
         if config.enforce_valid_values:
@@ -357,7 +358,7 @@ def convert_value(VR, raw_data_element, encoding=default_encoding):
             if vr == VR:
                 continue
             try:
-                value = convert_value(vr, raw_data_element, encoding)
+                value = convert_value(vr, raw_data_element, encodings)
                 logger.debug('converted value for tag %s with VR %s'
                              % (raw_data_element.tag, vr))
                 break

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -227,7 +227,6 @@ def convert_string(byte_string,
 
 def convert_text(byte_string, encodings=None):
     """Read and return a string or strings"""
-    encodings = encodings or [default_encoding]
     values = byte_string.split(b'\\')
     values = [convert_single_string(value, encodings) for value in values]
     if len(values) == 1:


### PR DESCRIPTION
- added warnings for encode/decode errors and incorrect encodings
- fixed writing of text VRs with multiple encodings
- fixes #716

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->
This shall fix the encoding of person names and text.
* Encoding of person names with different encodings
* Encoding of text with multiple encodings
* Errors during encoding/decoding are now handled differently: a warning is logged, and the string is encoded/decoded with the default encoding using replacement characters (before it was tried to decode with different VRs like US, SS instead)
* PersonName3 behaves slightly differently:
  * the different components accessors are now read-only
  * decoding is done on demand only
  * the original string is used for encoding if possible 

#### Any other comments?
<!--
-->
This got a bit larger than planned, but it is the final PR for #716.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
