### PR TITLE
[MRG+1] Add tests for TravisCI build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,54 +11,50 @@ cache:
 
 matrix:
   include:
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
 
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=false PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
 
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
 
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=false PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
 
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=false PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG2000=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both  JPEG2000=false JPEG_LS=true  GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
 
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=jpeg  JPEG2000=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=jpeg  JPEG2000=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
 
-    - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=false
-    - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true
-    - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=false
-    - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=true
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true
-      addons:
-        apt:
-          packages:
-              - python-numpy
+    - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
 
 install: source build_tools/travis/install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ cache:
 
 matrix:
   include:
+    - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
@@ -41,18 +46,14 @@ matrix:
 
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+    #- env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
+    #- env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
 
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
 
-    - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
     - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
 

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -46,8 +46,8 @@ if [[ "$DISTRIB" == "conda" ]]; then
     #    sudo apt-get install libopenjp2-7 libopenjp2-7-dev
     #fi
     if [[ "$PILLOW" == "both" ]]; then
-        conda install --yes pillow jpeg
         sudo apt-get install libopenjp2-7 libopenjp2-7-dev
+        conda install --yes pillow jpeg
         python -c "from PIL import _imaging; print('JPEG plugin:', hasattr(_imaging, 'jpeg_decoder'))"
         python -c "from PIL import _imaging; print('JPEG2k plugin:', hasattr(_imaging, 'jpeg2k_decoder'))"
     elif [[ "$PILLOW" == "jpeg" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -46,8 +46,8 @@ if [[ "$DISTRIB" == "conda" ]]; then
     #    sudo apt-get install libopenjp2-7 libopenjp2-7-dev
     #fi
     if [[ "$PILLOW" == "both" ]]; then
-        conda install --yes -c conda-forge openjpeg
-        conda install --yes pillow jpeg
+        conda install --yes -c conda-forge openjpeg jpeg
+        pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
         python -c "from PIL import _imaging; print('JPEG plugin:', hasattr(_imaging, 'jpeg_decoder'))"
         python -c "from PIL import _imaging; print('JPEG2k plugin:', hasattr(_imaging, 'jpeg2k_decoder'))"
     elif [[ "$PILLOW" == "jpeg" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -42,9 +42,9 @@ if [[ "$DISTRIB" == "conda" ]]; then
     if [[ "$NUMPY" == "true" ]]; then
         conda install --yes numpy
     fi
-    if [[ "$JPEG2000" == "true" ]]; then
-        sudo apt-get install libopenjp2-7 libopenjp2-7-dev
-    fi
+    #if [[ "$JPEG2000" == "true" ]]; then
+    #    sudo apt-get install libopenjp2-7 libopenjp2-7-dev
+    #fi
     if [[ "$PILLOW" == "both" ]]; then
         conda install --yes pillow jpeg
         python -c "from PIL import _imaging; print('JPEG plugin:', hasattr(_imaging, 'jpeg_decoder'))"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -46,7 +46,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
     #    sudo apt-get install libopenjp2-7 libopenjp2-7-dev
     #fi
     if [[ "$PILLOW" == "both" ]]; then
-        conda install -c conda-forge openjpeg
+        conda install --yes -c conda-forge openjpeg
         conda install --yes pillow jpeg
         python -c "from PIL import _imaging; print('JPEG plugin:', hasattr(_imaging, 'jpeg_decoder'))"
         python -c "from PIL import _imaging; print('JPEG2k plugin:', hasattr(_imaging, 'jpeg2k_decoder'))"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -47,6 +47,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
     #fi
     if [[ "$PILLOW" == "both" ]]; then
         conda install --yes pillow jpeg
+        sudo apt-get install libopenjp2-7 libopenjp2-7-dev
         python -c "from PIL import _imaging; print('JPEG plugin:', hasattr(_imaging, 'jpeg_decoder'))"
         python -c "from PIL import _imaging; print('JPEG2k plugin:', hasattr(_imaging, 'jpeg2k_decoder'))"
     elif [[ "$PILLOW" == "jpeg" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -42,9 +42,6 @@ if [[ "$DISTRIB" == "conda" ]]; then
     if [[ "$NUMPY" == "true" ]]; then
         conda install --yes numpy
     fi
-    #if [[ "$JPEG2000" == "true" ]]; then
-    #    sudo apt-get install libopenjp2-7 libopenjp2-7-dev
-    #fi
     if [[ "$PILLOW" == "both" ]]; then
         conda install --yes -c conda-forge openjpeg jpeg
         pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
@@ -102,10 +99,7 @@ elif [[ "$DISTRIB" == "pypy" ]]; then
     export PATH="$BIN_PATH:$PATH"
     # install pip
     python -m ensurepip --upgrade
-    if [[ "$NUMPY" == "true" ]] && [[ "$PYTHON_VERSION" == "2.7" ]]; then
-        python -m pip install git+https://bitbucket.org/pypy/numpy.git
-    # numpypy does not work with pypy3 so fall back on numpy
-    elif [[ "$NUMPY" == "true" ]]; then
+    if [[ "$NUMPY" == "true" ]]; then
         python -m pip install cython numpy
     fi
     python -m pip install nose nose-timer pytest pytest-cov codecov setuptools

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -46,7 +46,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
     #    sudo apt-get install libopenjp2-7 libopenjp2-7-dev
     #fi
     if [[ "$PILLOW" == "both" ]]; then
-        sudo apt-get install libopenjp2-7 libopenjp2-7-dev
+        conda install -c conda-forge openjpeg
         conda install --yes pillow jpeg
         python -c "from PIL import _imaging; print('JPEG plugin:', hasattr(_imaging, 'jpeg_decoder'))"
         python -c "from PIL import _imaging; print('JPEG2k plugin:', hasattr(_imaging, 'jpeg2k_decoder'))"

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -196,20 +196,10 @@ def pack_bits(arr):
 
     # Reshape so each row is 8 bits
     arr = np.reshape(arr, (-1, 8))
-    if 'PyPy' not in python_implementation() or not IN_PYTHON2:
-        arr = np.fliplr(arr)
-        arr = np.packbits(arr.astype('uint8'))
-        bytestream = arr.tobytes()
-    else:
-        # Implementation for PyPy as it lacks np.packbits
-        def _convert_to_decimal(x):
-            """Return a decimal from the length 8 binary array."""
-            return np.sum(x * [1, 2, 4, 8, 16, 32, 64, 128])
+    arr = np.fliplr(arr)
+    arr = np.packbits(arr.astype('uint8'))
 
-        arr = np.apply_along_axis(_convert_to_decimal, axis=1, arr=arr)
-        bytestream = arr.astype('uint8').tobytes()
-
-    return bytestream
+    return arr.tobytes()
 
 
 def unpack_bits(bytestream):
@@ -236,36 +226,19 @@ def unpack_bits(bytestream):
     ----------
     DICOM Standard, Part 5, Section 8.1.1 and Annex D
     """
-    if 'PyPy' not in python_implementation() or not IN_PYTHON2:
-        # Thanks to @sbrodehl (#643)
-        # e.g. b'\xC0\x09' -> [192, 9]
-        arr = np.frombuffer(bytestream, dtype='uint8')
-        # -> [1 1 0 0 0 0 0 0 0 0 0 0 1 0 0 1]
-        arr = np.unpackbits(arr)
-        # -> [[1 1 0 0 0 0 0 0],
-        #     [0 0 0 0 1 0 0 1]]
-        arr = np.reshape(arr, (-1, 8))
-        # -> [[0 0 0 0 0 0 1 1],
-        #     [1 0 0 1 0 0 0 0]]
-        arr = np.fliplr(arr)
-        # -> [0 0 0 0 0 0 1 1 1 0 0 1 0 0 0 0]
-        arr = np.ravel(arr)
-    else:
-        # Slow!
-        # if single bits are used for binary representation, a uint8 array
-        # has to be converted to a binary-valued array (that is 8 times bigger)
-        bit = 0
-        arr = np.ndarray(shape=(len(bytestream) * 8), dtype='uint8')
-        # bit-packed pixels are packed from the right; i.e., the first pixel
-        #  in the image frame corresponds to the first from the right bit of
-        #  the first byte of the packed PixelData!
-        for byte in bytestream:
-            byte = ord(byte)
-            for bit in range(bit, bit + 8):
-                arr[bit] = byte & 1
-                byte >>= 1
-
-            bit += 1
+    # Thanks to @sbrodehl (#643)
+    # e.g. b'\xC0\x09' -> [192, 9]
+    arr = np.frombuffer(bytestream, dtype='uint8')
+    # -> [1 1 0 0 0 0 0 0 0 0 0 0 1 0 0 1]
+    arr = np.unpackbits(arr)
+    # -> [[1 1 0 0 0 0 0 0],
+    #     [0 0 0 0 1 0 0 1]]
+    arr = np.reshape(arr, (-1, 8))
+    # -> [[0 0 0 0 0 0 1 1],
+    #     [1 0 0 1 0 0 0 0]]
+    arr = np.fliplr(arr)
+    # -> [0 0 0 0 0 0 1 1 1 0 0 1 0 0 0 0]
+    arr = np.ravel(arr)
 
     return arr
 

--- a/pydicom/tests/test_environment.py
+++ b/pydicom/tests/test_environment.py
@@ -118,7 +118,7 @@ class TestBuilds(object):
 
         if have_pillow == 'both':
             try:
-                import PIL import _imaging
+                from PIL import _imaging
             except ImportError:
                 pytest.fail("PILLOW is both but PIL is not importable")
 
@@ -126,7 +126,7 @@ class TestBuilds(object):
             assert getattr(_imaging, "jpeg2k_decoder", False)
         elif have_pillow == 'jpeg':
             try:
-                import PIL import _imaging
+                from PIL import _imaging
             except ImportError:
                 pytest.fail("PILLOW is both but PIL is not importable")
 

--- a/pydicom/tests/test_environment.py
+++ b/pydicom/tests/test_environment.py
@@ -31,7 +31,6 @@ DISTRIB: conda, pypy, ubuntu
 PYTHON_VERSION: 2.7, 3.4, 3.5, 3.6, 3.7
 NUMPY: true, false
 PILLOW: jpeg, both, false
-JPEG2000: false
 JPEG_LS: false, true
 GDCM: false, true
 """

--- a/pydicom/tests/test_environment.py
+++ b/pydicom/tests/test_environment.py
@@ -108,11 +108,13 @@ class TestBuilds(object):
             with pytest.raises(ImportError):
                 import numpy
         else:
-            raise NotImplementedError("Unknown 'NUMPY' value")
+            raise NotImplementedError(
+                "Unknown 'NUMPY' value of '{}'".format(have_np)
+            )
 
     def test_pillow(self):
         """Test that pillow is absent/present with the correct plugins."""
-        have_pillow = get_envar('NUMPY')
+        have_pillow = get_envar('PILLOW')
         if not have_pillow:
             raise RuntimeError("No 'PILLOW' envar has been set")
 
@@ -136,13 +138,15 @@ class TestBuilds(object):
             with pytest.raises(ImportError):
                 import PIL
         else:
-            raise NotImplementedError("Unknown 'PILLOW' value")
+            raise NotImplementedError(
+                "Unknown 'PILLOW' value of '{}'".format(have_pillow)
+            )
 
     def test_jpegls(self):
         """Test that jpeg-ls is absent/present."""
         have_jpegls = get_envar('JPEG_LS')
         if not have_jpegls:
-            raise RuntimeError("No 'NUMPY' envar has been set")
+            raise RuntimeError("No 'JPEG_LS' envar has been set")
 
         if have_jpegls == 'true':
             try:
@@ -153,7 +157,9 @@ class TestBuilds(object):
             with pytest.raises(ImportError):
                 import jpeg_ls
         else:
-            raise NotImplementedError("Unknown 'JPEG_LS' value")
+            raise NotImplementedError(
+                "Unknown 'JPEG_LS' value of '{}'".format(have_jpegls)
+            )
 
     def test_gdcm(self):
         """Test that gdcm is absent/present."""
@@ -170,4 +176,6 @@ class TestBuilds(object):
             with pytest.raises(ImportError):
                 import gdcm
         else:
-            raise NotImplementedError("Unknown 'GDCM' value")
+            raise NotImplementedError(
+                "Unknown 'GDCM' value of '{}'".format(have_gdcm)
+            )

--- a/pydicom/tests/test_environment.py
+++ b/pydicom/tests/test_environment.py
@@ -76,11 +76,11 @@ class TestBuilds(object):
         if distrib == 'conda':
             # May not be robust
             assert os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
-            assert "CPython" in platform.python_implementation
+            assert "CPython" in platform.python_implementation()
         elif distrib == 'pypy':
-            assert 'PyPy' in platform.python_implementation
+            assert 'PyPy' in platform.python_implementation()
         elif distrib == 'ubuntu':
-            assert "CPython" in platform.python_implementation
+            assert "CPython" in platform.python_implementation()
         else:
             raise NotImplementedError("Unknown 'DISTRIB' value")
 

--- a/pydicom/tests/test_environment.py
+++ b/pydicom/tests/test_environment.py
@@ -1,0 +1,173 @@
+# Copyright 2008-2018 pydicom authors. See LICENSE file for details.
+"""Tests for the TravisCI testing environments.
+
+The current pydicom testing environments are as follows:
+
+* conda:
+  * Python 2.7:
+    * no additional packages
+    * numpy
+    * numpy, gdcm
+    * numpy, pillow (jpg, jpg2k)
+    * numpy, jpeg-ls
+    * numpy, pillow (jpg, jpg2k), jpeg-ls
+    * numpy, pillow (jpg, jpg2k), jpeg-ls, gdcm
+  * Python 3.4, 3.5, 3.6, 3.7:
+    * As with 2.7
+  * Python 2.7, 3.7:
+    * numpy, pillow (jpg)
+* pypy
+  * Python 2.7, 3.5:
+    * no additional packages
+    * numpy
+* ubuntu
+  * Python 2.7:
+    * no additional packages
+    * numpy
+
+Environmental variables
+-----------------------
+DISTRIB: conda, pypy, ubuntu
+PYTHON_VERSION: 2.7, 3.4, 3.5, 3.6, 3.7
+NUMPY: true, false
+PILLOW: jpeg, both, false
+JPEG2000: false
+JPEG_LS: false, true
+GDCM: false, true
+"""
+import os
+import platform
+import sys
+
+import pytest
+
+
+def get_envar(envar):
+    """Return the value of the environmental variable `envar`.
+
+    Parameters
+    ----------
+    envar : str
+        The environmental variable to check for.
+
+    Returns
+    -------
+    str or None
+        If the envar is present then return its value otherwise returns None.
+    """
+    if envar in os.environ:
+        return os.environ.get(envar)
+
+    return None
+
+
+IN_TRAVIS = get_envar("TRAVIS") == 'true'
+
+
+@pytest.mark.skipif(not IN_TRAVIS, reason="Tests not running in Travis")
+class TestBuilds(object):
+    """Tests for the testing builds in Travis CI."""
+    def test_distribution(self):
+        """Test that the distribution is correct."""
+        distrib = get_envar('DISTRIB')
+        if not distrib:
+            raise RuntimeError("No 'DISTRIB' envar has been set")
+
+        if distrib == 'conda':
+            # May not be robust
+            assert os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
+            assert "CPython" in platform.python_implementation
+        elif distrib == 'pypy':
+            assert 'PyPy' in platform.python_implementation
+        elif distrib == 'ubuntu':
+            assert "CPython" in platform.python_implementation
+        else:
+            raise NotImplementedError("Unknown 'DISTRIB' value")
+
+    def test_python_version(self):
+        """Test that the python version is correct."""
+        version = get_envar('PYTHON_VERSION')
+        if not version:
+            raise RuntimeError("No 'PYTHON_VERSION' envar has been set")
+
+        version = tuple([int(vv) for vv in version.split('.')])
+        assert version == sys.version_info[:2]
+
+    def test_numpy(self):
+        """Test that numpy is absent/present."""
+        have_np = get_envar('NUMPY')
+        if not have_np:
+            raise RuntimeError("No 'NUMPY' envar has been set")
+
+        if have_np == 'true':
+            try:
+                import numpy
+            except ImportError:
+                pytest.fail("NUMPY is true but numpy is not importable")
+        elif have_np == 'false':
+            with pytest.raises(ImportError):
+                import numpy
+        else:
+            raise NotImplementedError("Unknown 'NUMPY' value")
+
+    def test_pillow(self):
+        """Test that pillow is absent/present with the correct plugins."""
+        have_pillow = get_envar('NUMPY')
+        if not have_pillow:
+            raise RuntimeError("No 'PILLOW' envar has been set")
+
+        if have_pillow == 'both':
+            try:
+                import PIL import _imaging
+            except ImportError:
+                pytest.fail("PILLOW is both but PIL is not importable")
+
+            assert getattr(_imaging, "jpeg_decoder", False)
+            assert getattr(_imaging, "jpeg2k_decoder", False)
+        elif have_pillow == 'jpeg':
+            try:
+                import PIL import _imaging
+            except ImportError:
+                pytest.fail("PILLOW is both but PIL is not importable")
+
+            assert getattr(_imaging, "jpeg_decoder", False)
+            assert not getattr(_imaging, "jpeg2k_decoder", False)
+        elif have_pillow == 'false':
+            with pytest.raises(ImportError):
+                import PIL
+        else:
+            raise NotImplementedError("Unknown 'PILLOW' value")
+
+    def test_jpegls(self):
+        """Test that jpeg-ls is absent/present."""
+        have_jpegls = get_envar('JPEG_LS')
+        if not have_jpegls:
+            raise RuntimeError("No 'NUMPY' envar has been set")
+
+        if have_jpegls == 'true':
+            try:
+                import jpeg_ls
+            except ImportError:
+                pytest.fail("JPEG_LS is true but jpeg_ls is not importable")
+        elif have_jpegls == 'false':
+            with pytest.raises(ImportError):
+                import jpeg_ls
+        else:
+            raise NotImplementedError("Unknown 'JPEG_LS' value")
+
+    def test_gdcm(self):
+        """Test that gdcm is absent/present."""
+        have_gdcm = get_envar('GDCM')
+        if not have_gdcm:
+            raise RuntimeError("No 'GDCM' envar has been set")
+
+        if have_gdcm == 'true':
+            try:
+                import gdcm
+            except ImportError:
+                pytest.fail("GDCM is true but gdcm is not importable")
+        elif have_gdcm == 'false':
+            with pytest.raises(ImportError):
+                import gdcm
+        else:
+            raise NotImplementedError("Unknown 'GDCM' value")


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
* Adds tests that confirm the TravisCI build environments are as expected.
* Fix pillow 'both' not installing with openjpeg (and hence no tests with jp2k plugin were running)
* Remove GDCM tests with python3.7 ([no installer available](https://anaconda.org/conda-forge/gdcm/files) for that version, builds were using 3.6 instead)
* Reorder builds so pypy runs first (workaround for #732)
* Use numpy with PyPy2 instead of numpypy
* Remove numpypy specific workaround from numpy handler