### PR TITLE
[MRG+1] Make returned pixel data writeable, add tests

### DIFF
--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -62,5 +62,5 @@ Fixes
   (:pull_request:`729`)
 * Fixed numpy arrays returned by the pixel data handlers sometimes being
   read-only. Read-only arrays are still available for uncompressed transfer
-  syntaxes via a keyword argument for the numpy pixel data handler.
-  (:issue:`717`)
+  syntaxes via a keyword argument for the numpy pixel data handler and should
+  help reduce memory consumption if required. (:issue:`717`)

--- a/doc/whatsnew/v1.2.0.rst
+++ b/doc/whatsnew/v1.2.0.rst
@@ -25,6 +25,7 @@ Changes
   handler's ``is_available`` method.
 * ``DeferredDataElement`` class deprecated and will be removed in v1.3
   (:issue:`291`)
+* The use of numpypy with PyPy is no longer supported, use numpy instead.
 
 
 Enhancements
@@ -54,9 +55,12 @@ Fixes
   (:pull_request:`660`)
 * Improve performance for Python 3 when dealing with compressed multi-frame
   Pixel Data with pillow and jpeg-ls (:issue:`682`).
-* Improve performance of bit unpacking for non-PyPy2 interpreters
-  (:pull_request:`715`)
+* Improve performance of bit unpacking (:pull_request:`715`)
 * First character set no longer removed (:issue:`707`)
 * Fixed RLE decoded data having the wrong byte order (:pull_request:`729`)
 * Fixed RLE decoded data having the wrong planar configuration
   (:pull_request:`729`)
+* Fixed numpy arrays returned by the pixel data handlers sometimes being
+  read-only. Read-only arrays are still available for uncompressed transfer
+  syntaxes via a keyword argument for the numpy pixel data handler.
+  (:issue:`717`)

--- a/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -46,7 +46,6 @@ def is_available():
     return HAVE_NP and HAVE_GDCM
 
 
-
 def needs_to_convert_to_RGB(dicom_dataset):
     should_convert = (dicom_dataset.file_meta.TransferSyntaxUID in
                       should_convert_these_syntaxes_to_RGB)

--- a/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -174,6 +174,7 @@ def get_pixeldata(dicom_dataset):
         n_bytes *= dicom_dataset.SamplesPerPixel
     except Exception:
         pass
+
     if len(pixel_bytearray) > n_bytes:
         # We make sure that all the bytes after are in fact zeros
         padding = pixel_bytearray[n_bytes:]
@@ -183,7 +184,9 @@ def get_pixeldata(dicom_dataset):
             # We revert to the old behavior which should then result
             #   in a Numpy error later on.
             pass
+
     pixel_array = numpy.frombuffer(pixel_bytearray, dtype=numpy_dtype)
+
     length_of_pixel_array = pixel_array.nbytes
     expected_length = dicom_dataset.Rows * dicom_dataset.Columns
 
@@ -192,10 +195,13 @@ def get_pixeldata(dicom_dataset):
 
     if dicom_dataset.BitsAllocated > 8:
         expected_length *= (dicom_dataset.BitsAllocated // 8)
+
     if length_of_pixel_array != expected_length:
         raise AttributeError("Amount of pixel data %d does "
                              "not match the expected data %d" %
                              (length_of_pixel_array, expected_length))
+
     if should_change_PhotometricInterpretation_to_RGB(dicom_dataset):
         dicom_dataset.PhotometricInterpretation = "RGB"
-    return pixel_array
+
+    return pixel_array.copy()

--- a/pydicom/pixel_data_handlers/jpeg_ls_handler.py
+++ b/pydicom/pixel_data_handlers/jpeg_ls_handler.py
@@ -137,7 +137,7 @@ def get_pixeldata(dicom_dataset):
             dicom_dataset.PixelData)
         decompressed_image = jpeg_ls.decode(
             numpy.frombuffer(CompressedPixelData, dtype=numpy.uint8))
-        UncompressedPixelData = decompressed_image.tobytes()
+        UncompressedPixelData.extend(decompressed_image.tobytes())
 
     pixel_array = numpy.frombuffer(UncompressedPixelData, numpy_format)
     if should_change_PhotometricInterpretation_to_RGB(dicom_dataset):

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -38,6 +38,7 @@ elements have values given in the table below.
 
 from platform import python_implementation
 from sys import byteorder
+import warnings
 
 try:
     import numpy as np
@@ -270,7 +271,7 @@ def unpack_bits(bytestream):
     return arr
 
 
-def get_pixeldata(ds):
+def get_pixeldata(ds, read_only=False):
     """Return an ndarray of the Pixel Data.
 
     Parameters
@@ -278,6 +279,8 @@ def get_pixeldata(ds):
     ds : dataset.Dataset
         The DICOM dataset containing an Image Pixel module and the Pixel Data
         to be converted.
+    read_only : bool, optional
+        T
 
     Returns
     -------
@@ -339,5 +342,14 @@ def get_pixeldata(ds):
 
     if should_change_PhotometricInterpretation_to_RGB(ds):
         ds.PhotometricInterpretation = "RGB"
+
+    if not read_only and ds.BitsAllocated > 1:
+        return arr.copy()
+    elif read_only and ds.BitsAllocated == 1:
+        warnings.warn(
+            "'read_only=True' is not compatible with bit-packed pixel data, "
+            "a writeable array will be returned instead",
+            UserWarning
+        )
 
     return arr

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -280,7 +280,11 @@ def get_pixeldata(ds, read_only=False):
         The DICOM dataset containing an Image Pixel module and the Pixel Data
         to be converted.
     read_only : bool, optional
-        T
+        If False (default) then returns a writeable array that no longer uses
+        the original memory. If True and the value of (0028,0100) *Bits
+        Allocated* > 1 then returns a read-only array that uses the original
+        memory buffer of the pixel data. If *Bits Allocated* = 1 then always
+        returns a writeable array.
 
     Returns
     -------

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -322,11 +322,5 @@ def get_pixeldata(ds, read_only=False):
 
     if not read_only and ds.BitsAllocated > 1:
         return arr.copy()
-    elif read_only and ds.BitsAllocated == 1:
-        warnings.warn(
-            "'read_only=True' is not compatible with bit-packed pixel data, "
-            "a writeable array will be returned instead",
-            UserWarning
-        )
 
     return arr

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -197,19 +197,23 @@ def get_pixeldata(dicom_dataset):
                 decompressed_image = Image.open(fio)
             except IOError as e:
                 raise NotImplementedError(e.strerror)
-            UncompressedPixelData = decompressed_image.tobytes()
+            UncompressedPixelData.extend(decompressed_image.tobytes())
     except Exception:
         raise
+
     logger.debug(
-        "Successfully read %s pixel bytes",
-        len(UncompressedPixelData))
-    pixel_array = numpy.copy(
-        numpy.frombuffer(UncompressedPixelData, numpy_format))
+        "Successfully read %s pixel bytes", len(UncompressedPixelData)
+    )
+
+    pixel_array = numpy.frombuffer(UncompressedPixelData, numpy_format)
+
     if (transfer_syntax in
             PillowJPEG2000TransferSyntaxes and
             dicom_dataset.BitsStored == 16):
         # WHY IS THIS EVEN NECESSARY??
         pixel_array &= 0x7FFF
+
     if should_change_PhotometricInterpretation_to_RGB(dicom_dataset):
         dicom_dataset.PhotometricInterpretation = "RGB"
+
     return pixel_array

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -188,12 +188,12 @@ def get_pixeldata(dicom_dataset):
                 UncompressedPixelData.extend(decompressed_image.tobytes())
         else:
             # single compressed frame
-            UncompressedPixelData = pydicom.encaps.defragment_data(
+            pixel_data = pydicom.encaps.defragment_data(
                 dicom_dataset.PixelData)
-            UncompressedPixelData = generic_jpeg_file_header + \
-                UncompressedPixelData[frame_start_from:]
+            pixel_data = generic_jpeg_file_header + \
+                pixel_data[frame_start_from:]
             try:
-                fio = io.BytesIO(UncompressedPixelData)
+                fio = io.BytesIO(pixel_data)
                 decompressed_image = Image.open(fio)
             except IOError as e:
                 raise NotImplementedError(e.strerror)

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -272,7 +272,7 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
             "all {0} (mean == {1})".format(b.mean(), a.mean()))
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
+        assert a.flags.writeable is True
 
     def test_emri_JPEG_LS_PixelArray_with_gdcm(self):
         a = self.emri_jpeg_ls_lossless.pixel_array
@@ -284,8 +284,7 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
             "(mean == {1})".format(b.mean(), a.mean()))
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
-
+        assert a.flags.writeable is True
 
 
 @pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
@@ -334,7 +333,7 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
             "(mean == {1})".format(b.mean(), a.mean()))
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
+        assert a.flags.writeable is True
 
     def test_emri_JPEG2000PixelArray(self):
         a = self.emri_jpeg_2k_lossless.pixel_array
@@ -346,7 +345,7 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
             "(mean == {1})".format(b.mean(), a.mean()))
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
+        assert a.flags.writeable is True
 
     def test_jpeg2000_lossy(self):
         a = self.sc_rgb_jpeg2k_gdcm_KY.pixel_array
@@ -361,7 +360,7 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
                 "(mean == {1})".format(b.mean(), a.mean()))
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
+        assert a.flags.writeable is True
 
 
 @pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
@@ -401,7 +400,7 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
         self.assertEqual(a[230, 120], 95)
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
+        assert a.flags.writeable is True
 
     def test_JPEGBaselineColor3DPixelArray(self):
         self.assertEqual(
@@ -418,7 +417,7 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
             "YBR_FULL_422")
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
+        assert a.flags.writeable is True
 
 
 @pytest.fixture(scope="module")
@@ -591,7 +590,7 @@ def test_PI_RGB(test_with_gdcm,
     a = t.pixel_array
 
     # Returned array is not read-only
-    assert a.flags.writeable == True
+    assert a.flags.writeable is True
 
     assert a.shape == (100, 100, 3)
     if convert_yuv_to_rgb:
@@ -642,4 +641,4 @@ class GDCM_JPEGlosslessTests_with_gdcm(unittest.TestCase):
         self.assertEqual(a[230, 120], 105)
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
+        assert a.flags.writeable is True

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -407,6 +407,10 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
             self.color_3d_jpeg.PhotometricInterpretation,
             "YBR_FULL_422")
         a = self.color_3d_jpeg.pixel_array
+
+        # Returned array is read-only
+        assert a.flags.writeable is False
+
         self.assertEqual(a.shape, (120, 480, 640, 3))
         a = _convert_YBR_FULL_to_RGB(a)
         # this test points were manually identified in Osirix viewer
@@ -415,9 +419,6 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
         self.assertEqual(
             self.color_3d_jpeg.PhotometricInterpretation,
             "YBR_FULL_422")
-
-        # Returned array is read-only
-        assert a.flags.writeable is False
 
 
 @pytest.fixture(scope="module")

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -271,8 +271,8 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
             "using GDCM Decoded pixel data is not "
             "all {0} (mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is not read-only
-        assert a.flags.writeable is True
+        # Returned array is read-only
+        assert a.flags.writeable is False
 
     def test_emri_JPEG_LS_PixelArray_with_gdcm(self):
         a = self.emri_jpeg_ls_lossless.pixel_array
@@ -283,8 +283,8 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is not read-only
-        assert a.flags.writeable is True
+        # Returned array is read-only
+        assert a.flags.writeable is False
 
 
 @pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
@@ -332,8 +332,8 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is not read-only
-        assert a.flags.writeable is True
+        # Returned array is read-only
+        assert a.flags.writeable is False
 
     def test_emri_JPEG2000PixelArray(self):
         a = self.emri_jpeg_2k_lossless.pixel_array
@@ -344,8 +344,8 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is not read-only
-        assert a.flags.writeable is True
+        # Returned array is read-only
+        assert a.flags.writeable is False
 
     def test_jpeg2000_lossy(self):
         a = self.sc_rgb_jpeg2k_gdcm_KY.pixel_array
@@ -359,8 +359,8 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
                 "Decoded pixel data is not all {0} "
                 "(mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is not read-only
-        assert a.flags.writeable is True
+        # Returned array is read-only
+        assert a.flags.writeable is False
 
 
 @pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
@@ -399,8 +399,8 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
         self.assertEqual(a[420, 140], 244)
         self.assertEqual(a[230, 120], 95)
 
-        # Returned array is not read-only
-        assert a.flags.writeable is True
+        # Returned array is read-only
+        assert a.flags.writeable is False
 
     def test_JPEGBaselineColor3DPixelArray(self):
         self.assertEqual(
@@ -416,8 +416,8 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
             self.color_3d_jpeg.PhotometricInterpretation,
             "YBR_FULL_422")
 
-        # Returned array is not read-only
-        assert a.flags.writeable is True
+        # Returned array is read-only
+        assert a.flags.writeable is False
 
 
 @pytest.fixture(scope="module")
@@ -589,8 +589,8 @@ def test_PI_RGB(test_with_gdcm,
     assert t.PhotometricInterpretation == PhotometricInterpretation
     a = t.pixel_array
 
-    # Returned array is not read-only
-    assert a.flags.writeable is True
+    # Returned array is read-only
+    assert a.flags.writeable is False
 
     assert a.shape == (100, 100, 3)
     if convert_yuv_to_rgb:
@@ -640,5 +640,5 @@ class GDCM_JPEGlosslessTests_with_gdcm(unittest.TestCase):
         self.assertEqual(a[420, 140], 227)
         self.assertEqual(a[230, 120], 105)
 
-        # Returned array is not read-only
-        assert a.flags.writeable is True
+        # Returned array is read-only
+        assert a.flags.writeable is False

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -271,8 +271,7 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
             "using GDCM Decoded pixel data is not "
             "all {0} (mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is read-only
-        assert a.flags.writeable is False
+        assert a.flags.writeable
 
     def test_emri_JPEG_LS_PixelArray_with_gdcm(self):
         a = self.emri_jpeg_ls_lossless.pixel_array
@@ -283,8 +282,7 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is read-only
-        assert a.flags.writeable is False
+        assert a.flags.writeable
 
 
 @pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
@@ -332,8 +330,7 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is read-only
-        assert a.flags.writeable is False
+        assert a.flags.writeable
 
     def test_emri_JPEG2000PixelArray(self):
         a = self.emri_jpeg_2k_lossless.pixel_array
@@ -344,8 +341,7 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is read-only
-        assert a.flags.writeable is False
+        assert a.flags.writeable
 
     def test_jpeg2000_lossy(self):
         a = self.sc_rgb_jpeg2k_gdcm_KY.pixel_array
@@ -359,8 +355,7 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
                 "Decoded pixel data is not all {0} "
                 "(mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is read-only
-        assert a.flags.writeable is False
+        assert a.flags.writeable
 
 
 @pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
@@ -399,8 +394,7 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
         self.assertEqual(a[420, 140], 244)
         self.assertEqual(a[230, 120], 95)
 
-        # Returned array is read-only
-        assert a.flags.writeable is False
+        assert a.flags.writeable
 
     def test_JPEGBaselineColor3DPixelArray(self):
         self.assertEqual(
@@ -408,8 +402,7 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
             "YBR_FULL_422")
         a = self.color_3d_jpeg.pixel_array
 
-        # Returned array is read-only
-        assert a.flags.writeable is False
+        assert a.flags.writeable
 
         self.assertEqual(a.shape, (120, 480, 640, 3))
         a = _convert_YBR_FULL_to_RGB(a)
@@ -590,8 +583,7 @@ def test_PI_RGB(test_with_gdcm,
     assert t.PhotometricInterpretation == PhotometricInterpretation
     a = t.pixel_array
 
-    # Returned array is read-only
-    assert a.flags.writeable is False
+    assert a.flags.writeable
 
     assert a.shape == (100, 100, 3)
     if convert_yuv_to_rgb:
@@ -641,5 +633,4 @@ class GDCM_JPEGlosslessTests_with_gdcm(unittest.TestCase):
         self.assertEqual(a[420, 140], 227)
         self.assertEqual(a[230, 120], 105)
 
-        # Returned array is read-only
-        assert a.flags.writeable is False
+        assert a.flags.writeable

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -271,6 +271,9 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
             "using GDCM Decoded pixel data is not "
             "all {0} (mean == {1})".format(b.mean(), a.mean()))
 
+        # Returned array is not read-only
+        assert a.flags.writeable == True
+
     def test_emri_JPEG_LS_PixelArray_with_gdcm(self):
         a = self.emri_jpeg_ls_lossless.pixel_array
         b = self.emri_small.pixel_array
@@ -279,6 +282,10 @@ class GDCM_JPEG_LS_Tests_with_gdcm(unittest.TestCase):
             b.mean(),
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
+
+        # Returned array is not read-only
+        assert a.flags.writeable == True
+
 
 
 @pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
@@ -326,6 +333,9 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
+        # Returned array is not read-only
+        assert a.flags.writeable == True
+
     def test_emri_JPEG2000PixelArray(self):
         a = self.emri_jpeg_2k_lossless.pixel_array
         b = self.emri_small.pixel_array
@@ -334,6 +344,9 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
             b.mean(),
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
+
+        # Returned array is not read-only
+        assert a.flags.writeable == True
 
     def test_jpeg2000_lossy(self):
         a = self.sc_rgb_jpeg2k_gdcm_KY.pixel_array
@@ -346,6 +359,9 @@ class GDCM_JPEG2000Tests_with_gdcm(unittest.TestCase):
                 b.mean(),
                 "Decoded pixel data is not all {0} "
                 "(mean == {1})".format(b.mean(), a.mean()))
+
+        # Returned array is not read-only
+        assert a.flags.writeable == True
 
 
 @pytest.mark.skipif(not HAVE_GDCM, reason=gdcm_missing_message)
@@ -384,6 +400,9 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
         self.assertEqual(a[420, 140], 244)
         self.assertEqual(a[230, 120], 95)
 
+        # Returned array is not read-only
+        assert a.flags.writeable == True
+
     def test_JPEGBaselineColor3DPixelArray(self):
         self.assertEqual(
             self.color_3d_jpeg.PhotometricInterpretation,
@@ -397,6 +416,9 @@ class GDCM_JPEGlossyTests_with_gdcm(unittest.TestCase):
         self.assertEqual(
             self.color_3d_jpeg.PhotometricInterpretation,
             "YBR_FULL_422")
+
+        # Returned array is not read-only
+        assert a.flags.writeable == True
 
 
 @pytest.fixture(scope="module")
@@ -567,6 +589,10 @@ def test_PI_RGB(test_with_gdcm,
     t = dcmread(image)
     assert t.PhotometricInterpretation == PhotometricInterpretation
     a = t.pixel_array
+
+    # Returned array is not read-only
+    assert a.flags.writeable == True
+
     assert a.shape == (100, 100, 3)
     if convert_yuv_to_rgb:
         a = _convert_YBR_FULL_to_RGB(a)
@@ -614,3 +640,6 @@ class GDCM_JPEGlosslessTests_with_gdcm(unittest.TestCase):
         # this test points were manually identified in Osirix viewer
         self.assertEqual(a[420, 140], 227)
         self.assertEqual(a[230, 120], 105)
+
+        # Returned array is not read-only
+        assert a.flags.writeable == True

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -199,7 +199,7 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
             "(mean == {1})".format(b.mean(), a.mean()))
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
+        assert a.flags.writeable is True
 
     def test_emri_JPEG_LS_PixelArray(self):
         a = self.emri_jpeg_ls_lossless.pixel_array
@@ -211,7 +211,7 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
             "(mean == {1})".format(b.mean(), a.mean()))
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
+        assert a.flags.writeable is True
 
 
 @pytest.mark.skipif(

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -198,8 +198,7 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is read-only as NumberOfFrames == 1
-        assert a.flags.writeable is False
+        assert arr.flags.writeable
 
     def test_emri_JPEG_LS_PixelArray(self):
         a = self.emri_jpeg_ls_lossless.pixel_array
@@ -210,8 +209,7 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is not read-only as NumberOfFrames > 1
-        assert a.flags.writeable is True
+        assert arr.flags.writeable
 
 
 @pytest.mark.skipif(

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -198,8 +198,8 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is not read-only
-        assert a.flags.writeable is True
+        # Returned array is read-only as NumberOfFrames == 1
+        assert a.flags.writeable is False
 
     def test_emri_JPEG_LS_PixelArray(self):
         a = self.emri_jpeg_ls_lossless.pixel_array
@@ -210,7 +210,7 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
-        # Returned array is not read-only
+        # Returned array is not read-only as NumberOfFrames > 1
         assert a.flags.writeable is True
 
 

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -198,6 +198,9 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
+        # Returned array is not read-only
+        assert a.flags.writeable == True
+
     def test_emri_JPEG_LS_PixelArray(self):
         a = self.emri_jpeg_ls_lossless.pixel_array
         b = self.emri_small.pixel_array
@@ -206,6 +209,9 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
             b.mean(),
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
+
+        # Returned array is not read-only
+        assert a.flags.writeable == True
 
 
 @pytest.mark.skipif(

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -198,7 +198,7 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
-        assert arr.flags.writeable
+        assert a.flags.writeable
 
     def test_emri_JPEG_LS_PixelArray(self):
         a = self.emri_jpeg_ls_lossless.pixel_array
@@ -209,7 +209,7 @@ class jpeg_ls_JPEG_LS_Tests_with_jpeg_ls(unittest.TestCase):
             "Decoded pixel data is not all {0} "
             "(mean == {1})".format(b.mean(), a.mean()))
 
-        assert arr.flags.writeable
+        assert a.flags.writeable
 
 
 @pytest.mark.skipif(

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -1003,9 +1003,8 @@ class TestNumpy_GetPixelData(object):
         arr = get_pixeldata(ds, read_only=False)
         assert arr.flags.writeable
 
-        with pytest.warns(UserWarning, match=r"compatible with bit-packed"):
-            arr = get_pixeldata(ds, read_only=True)
-            assert arr.flags.writeable
+        arr = get_pixeldata(ds, read_only=True)
+        assert arr.flags.writeable
 
 
 REFERENCE_PACK_UNPACK = [

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -843,7 +843,7 @@ class TestNumpy_NumpyHandler(object):
             ar = ds.pixel_array
 
             # Returned array is read-only
-            assert ar.flags.writeable == False
+            assert ar.flags.writeable is False
 
             assert (4294967295, 0, 0) == tuple(ar[5, 50, :])
             assert (4294967295, 2155905152, 2155905152) == tuple(ar[15, 50, :])

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -509,8 +509,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is read-only
-            assert arr.flags.writeable is False
+            assert arr.flags.writeable
 
             assert (600, 800) == arr.shape
             assert 244 == arr[0].min() == arr[0].max()
@@ -525,8 +524,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is read-only
-            assert arr.flags.writeable is False
+            assert arr.flags.writeable
 
             assert (2, 600, 800) == arr.shape
             # Frame 1
@@ -562,8 +560,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is read-only
-            assert arr.flags.writeable is False
+            assert arr.flags.writeable
 
             assert (255, 0, 0) == tuple(arr[5, 50, :])
             assert (255, 128, 128) == tuple(arr[15, 50, :])
@@ -584,8 +581,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is read-only
-            assert arr.flags.writeable is False
+            assert arr.flags.writeable
 
             # Frame 1
             frame = arr[0]
@@ -636,8 +632,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is not read-only
-            assert arr.flags.writeable is True
+            assert arr.flags.writeable
 
             assert arr.max() == 1
             assert arr.min() == 0
@@ -655,8 +650,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is not read-only
-            assert arr.flags.writeable is True
+            assert arr.flags.writeable
 
             assert arr.max() == 1
             assert arr.min() == 0
@@ -717,8 +711,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is read-only
-            assert arr.flags.writeable is False
+            assert arr.flags.writeable
 
             assert (422, 319, 361) == tuple(arr[0, 31:34])
             assert (366, 363, 322) == tuple(arr[31, :3])
@@ -732,8 +725,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is read-only
-            assert arr.flags.writeable is False
+            assert arr.flags.writeable
 
             # Frame 1
             assert (206, 197, 159) == tuple(arr[0, 0, 31:34])
@@ -756,8 +748,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is read-only
-            assert arr.flags.writeable is False
+            assert arr.flags.writeable
 
             assert (65535, 0, 0) == tuple(arr[5, 50, :])
             assert (65535, 32896, 32896) == tuple(arr[15, 50, :])
@@ -778,8 +769,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is read-only
-            assert arr.flags.writeable is False
+            assert arr.flags.writeable
 
             # Frame 1
             assert (65535, 0, 0) == tuple(arr[0, 5, 50, :])
@@ -803,8 +793,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is read-only
-            assert arr.flags.writeable is False
+            assert arr.flags.writeable
 
             assert (1249000, 1249000, 1250000) == tuple(arr[0, :3])
             assert (1031000, 1029000, 1027000) == tuple(arr[4, 3:6])
@@ -818,8 +807,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is read-only
-            assert arr.flags.writeable is False
+            assert arr.flags.writeable
 
             # Frame 1
             assert (1249000, 1249000, 1250000) == tuple(arr[0, 0, :3])
@@ -842,8 +830,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             ar = ds.pixel_array
 
-            # Returned array is read-only
-            assert ar.flags.writeable is False
+            assert ar.flags.writeable
 
             assert (4294967295, 0, 0) == tuple(ar[5, 50, :])
             assert (4294967295, 2155905152, 2155905152) == tuple(ar[15, 50, :])
@@ -864,8 +851,7 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
-            # Returned array is read-only
-            assert arr.flags.writeable is False
+            assert arr.flags.writeable
 
             # Frame 1
             assert (4294967295, 0, 0) == tuple(arr[0, 5, 50, :])
@@ -919,6 +905,15 @@ class TestNumpy_NumpyHandler(object):
 
         assert ds.pixel_array.max() == 1
 
+    def test_read_only(self):
+        """Test for #717, returned array read-only."""
+        ds = dcmread(EXPL_8_1_1F)
+        arr = ds.pixel_array
+        assert 0 != arr[0, 0]
+        arr[0, 0] = 0
+        assert 0 == arr[0, 0]
+        assert arr.flags.writeable
+
 
 # Tests for numpy_handler module with Numpy available
 @pytest.mark.skipif(not HAVE_NP, reason='Numpy is not available')
@@ -948,6 +943,24 @@ class TestNumpy_GetPixelData(object):
                            match=' the transfer syntax is not supported'):
             get_pixeldata(ds)
 
+    def test_bad_length_raises(self):
+        """Test bad pixel data length raises exception."""
+        ds = dcmread(EXPL_8_1_1F)
+        # Too short
+        ds.PixelData = ds.PixelData[:-1]
+        msg = (
+            r"The length of the pixel data in the dataset doesn't match the "
+            r"expected amount \(479999 vs. 480000 bytes\). The dataset may be "
+            r"corrupted or there may be an issue with the pixel data handler."
+        )
+        with pytest.raises(ValueError, match=msg):
+            get_pixeldata(ds)
+
+        # Too long
+        ds.PixelData += b'\x00\x00'
+        with pytest.raises(ValueError, match=r"480001 vs. 480000 bytes"):
+            get_pixeldata(ds)
+
     def test_change_photometric_interpretation(self):
         """Test get_pixeldata changes PhotometricInterpretation if required."""
         def to_rgb(ds):
@@ -969,6 +982,31 @@ class TestNumpy_GetPixelData(object):
         assert ds.PhotometricInterpretation == 'RGB'
 
         NP_HANDLER.should_change_PhotometricInterpretation_to_RGB = orig_fn
+
+    def test_array_read_only(self):
+        """Test returning a read only array for BitsAllocated > 8."""
+        ds = dcmread(EXPL_8_1_1F)
+        arr = get_pixeldata(ds, read_only=False)
+        assert arr.flags.writeable
+        assert 0 != arr[10]
+        arr[10] = 0
+        assert 0 == arr[10]
+
+        arr = get_pixeldata(ds, read_only=True)
+        assert not arr.flags.writeable
+        with pytest.raises(ValueError, match="is read-only"):
+            arr[10] = 0
+
+    def test_array_read_only_bit_packed(self):
+        """Test returning a read only array for BitsAllocated = 1."""
+        ds = dcmread(EXPL_1_1_1F)
+        arr = get_pixeldata(ds, read_only=False)
+        assert arr.flags.writeable
+
+        with pytest.warns(UserWarning, match=r"compatible with bit-packed"):
+            arr = get_pixeldata(ds, read_only=True)
+            assert arr.flags.writeable
+
 
 
 REFERENCE_PACK_UNPACK = [

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -1008,7 +1008,6 @@ class TestNumpy_GetPixelData(object):
             assert arr.flags.writeable
 
 
-
 REFERENCE_PACK_UNPACK = [
     (b'', []),
     (b'\x00', [0, 0, 0, 0, 0, 0, 0, 0]),

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -509,6 +509,9 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
+            # Returned array is read-only
+            assert arr.flags.writeable == False
+
             assert (600, 800) == arr.shape
             assert 244 == arr[0].min() == arr[0].max()
             assert (1, 246, 1) == tuple(arr[300, 491:494])
@@ -521,6 +524,9 @@ class TestNumpy_NumpyHandler(object):
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
+
+            # Returned array is read-only
+            assert arr.flags.writeable == False
 
             assert (2, 600, 800) == arr.shape
             # Frame 1
@@ -556,6 +562,9 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
+            # Returned array is read-only
+            assert arr.flags.writeable == False
+
             assert (255, 0, 0) == tuple(arr[5, 50, :])
             assert (255, 128, 128) == tuple(arr[15, 50, :])
             assert (0, 255, 0) == tuple(arr[25, 50, :])
@@ -574,6 +583,9 @@ class TestNumpy_NumpyHandler(object):
         for uid in SUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
+
+            # Returned array is read-only
+            assert arr.flags.writeable == False
 
             # Frame 1
             frame = arr[0]
@@ -624,6 +636,9 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
+            # Returned array is not read-only
+            assert arr.flags.writeable == True
+
             assert arr.max() == 1
             assert arr.min() == 0
 
@@ -639,6 +654,9 @@ class TestNumpy_NumpyHandler(object):
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
+
+            # Returned array is not read-only
+            assert arr.flags.writeable == True
 
             assert arr.max() == 1
             assert arr.min() == 0
@@ -699,6 +717,9 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
+            # Returned array is read-only
+            assert arr.flags.writeable == False
+
             assert (422, 319, 361) == tuple(arr[0, 31:34])
             assert (366, 363, 322) == tuple(arr[31, :3])
             assert (1369, 1129, 862) == tuple(arr[-1, -3:])
@@ -710,6 +731,9 @@ class TestNumpy_NumpyHandler(object):
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
+
+            # Returned array is read-only
+            assert arr.flags.writeable == False
 
             # Frame 1
             assert (206, 197, 159) == tuple(arr[0, 0, 31:34])
@@ -732,6 +756,9 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
+            # Returned array is read-only
+            assert arr.flags.writeable == False
+
             assert (65535, 0, 0) == tuple(arr[5, 50, :])
             assert (65535, 32896, 32896) == tuple(arr[15, 50, :])
             assert (0, 65535, 0) == tuple(arr[25, 50, :])
@@ -750,6 +777,9 @@ class TestNumpy_NumpyHandler(object):
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
+
+            # Returned array is read-only
+            assert arr.flags.writeable == False
 
             # Frame 1
             assert (65535, 0, 0) == tuple(arr[0, 5, 50, :])
@@ -773,6 +803,9 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
 
+            # Returned array is read-only
+            assert arr.flags.writeable == False
+
             assert (1249000, 1249000, 1250000) == tuple(arr[0, :3])
             assert (1031000, 1029000, 1027000) == tuple(arr[4, 3:6])
             assert (803000, 801000, 798000) == tuple(arr[-1, -3:])
@@ -784,6 +817,9 @@ class TestNumpy_NumpyHandler(object):
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
+
+            # Returned array is read-only
+            assert arr.flags.writeable == False
 
             # Frame 1
             assert (1249000, 1249000, 1250000) == tuple(arr[0, 0, :3])
@@ -806,6 +842,9 @@ class TestNumpy_NumpyHandler(object):
             ds.file_meta.TransferSyntaxUID = uid
             ar = ds.pixel_array
 
+            # Returned array is read-only
+            assert ar.flags.writeable == False
+
             assert (4294967295, 0, 0) == tuple(ar[5, 50, :])
             assert (4294967295, 2155905152, 2155905152) == tuple(ar[15, 50, :])
             assert (0, 4294967295, 0) == tuple(ar[25, 50, :])
@@ -824,6 +863,9 @@ class TestNumpy_NumpyHandler(object):
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
+
+            # Returned array is read-only
+            assert arr.flags.writeable == False
 
             # Frame 1
             assert (4294967295, 0, 0) == tuple(arr[0, 5, 50, :])

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -510,7 +510,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is read-only
-            assert arr.flags.writeable == False
+            assert arr.flags.writeable is False
 
             assert (600, 800) == arr.shape
             assert 244 == arr[0].min() == arr[0].max()
@@ -526,7 +526,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is read-only
-            assert arr.flags.writeable == False
+            assert arr.flags.writeable is False
 
             assert (2, 600, 800) == arr.shape
             # Frame 1
@@ -563,7 +563,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is read-only
-            assert arr.flags.writeable == False
+            assert arr.flags.writeable is False
 
             assert (255, 0, 0) == tuple(arr[5, 50, :])
             assert (255, 128, 128) == tuple(arr[15, 50, :])
@@ -585,7 +585,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is read-only
-            assert arr.flags.writeable == False
+            assert arr.flags.writeable is False
 
             # Frame 1
             frame = arr[0]
@@ -637,7 +637,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is not read-only
-            assert arr.flags.writeable == True
+            assert arr.flags.writeable is True
 
             assert arr.max() == 1
             assert arr.min() == 0
@@ -656,7 +656,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is not read-only
-            assert arr.flags.writeable == True
+            assert arr.flags.writeable is True
 
             assert arr.max() == 1
             assert arr.min() == 0
@@ -718,7 +718,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is read-only
-            assert arr.flags.writeable == False
+            assert arr.flags.writeable is False
 
             assert (422, 319, 361) == tuple(arr[0, 31:34])
             assert (366, 363, 322) == tuple(arr[31, :3])
@@ -733,7 +733,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is read-only
-            assert arr.flags.writeable == False
+            assert arr.flags.writeable is False
 
             # Frame 1
             assert (206, 197, 159) == tuple(arr[0, 0, 31:34])
@@ -757,7 +757,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is read-only
-            assert arr.flags.writeable == False
+            assert arr.flags.writeable is False
 
             assert (65535, 0, 0) == tuple(arr[5, 50, :])
             assert (65535, 32896, 32896) == tuple(arr[15, 50, :])
@@ -779,7 +779,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is read-only
-            assert arr.flags.writeable == False
+            assert arr.flags.writeable is False
 
             # Frame 1
             assert (65535, 0, 0) == tuple(arr[0, 5, 50, :])
@@ -804,7 +804,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is read-only
-            assert arr.flags.writeable == False
+            assert arr.flags.writeable is False
 
             assert (1249000, 1249000, 1250000) == tuple(arr[0, :3])
             assert (1031000, 1029000, 1027000) == tuple(arr[4, 3:6])
@@ -819,7 +819,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is read-only
-            assert arr.flags.writeable == False
+            assert arr.flags.writeable is False
 
             # Frame 1
             assert (1249000, 1249000, 1250000) == tuple(arr[0, 0, :3])
@@ -865,7 +865,7 @@ class TestNumpy_NumpyHandler(object):
             arr = ds.pixel_array
 
             # Returned array is read-only
-            assert arr.flags.writeable == False
+            assert arr.flags.writeable is False
 
             # Frame 1
             assert (4294967295, 0, 0) == tuple(arr[0, 5, 50, :])

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -307,11 +307,17 @@ class Test_JPEG2000Tests_with_pillow(object):
         b = self.mr_small.pixel_array
         assert np.array_equal(a, b)
 
+        # Returned array is not read-only
+        assert a.flags.writeable == True
+
     def test_emri_JPEG2000PixelArray(self):
         """Test decoding JPEG2K with pillow handler succeeds."""
         a = self.emri_jpeg_2k_lossless.pixel_array
         b = self.emri_small.pixel_array
         assert np.array_equal(a, b)
+
+        # Returned array is not read-only
+        assert a.flags.writeable == True
 
     def test_jpeg2000_lossy(self):
         """Test decoding JPEG2K lossy with pillow handler fails."""
@@ -358,6 +364,10 @@ class Test_JPEGlossyTests_with_pillow(object):
         assert "YBR_FULL_422" == self.color_3d_jpeg.PhotometricInterpretation
 
         a = self.color_3d_jpeg.pixel_array
+
+        # Returned array is not read-only
+        assert a.flags.writeable == True
+
         assert (120, 480, 640, 3) == a.shape
         # this test points were manually identified in Osirix viewer
         assert (41, 41, 41) == tuple(a[3, 159, 290, :])
@@ -552,6 +562,9 @@ def test_PI_RGB(test_with_pillow,
     assert t.PhotometricInterpretation == PhotometricInterpretation
     a = t.pixel_array
     assert a.shape == (100, 100, 3)
+
+    # Returned array is not read-only
+    assert a.flags.writeable == True
     """
     This complete test never gave a different result than
     just the 10 point test below

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -307,8 +307,7 @@ class Test_JPEG2000Tests_with_pillow(object):
         b = self.mr_small.pixel_array
         assert np.array_equal(a, b)
 
-        # Returned array is not read-only
-        assert a.flags.writeable is True
+        assert a.flags.writeable
 
     def test_emri_JPEG2000PixelArray(self):
         """Test decoding JPEG2K with pillow handler succeeds."""
@@ -316,8 +315,7 @@ class Test_JPEG2000Tests_with_pillow(object):
         b = self.emri_small.pixel_array
         assert np.array_equal(a, b)
 
-        # Returned array is not read-only
-        assert a.flags.writeable is True
+        assert a.flags.writeable
 
     def test_jpeg2000_lossy(self):
         """Test decoding JPEG2K lossy with pillow handler fails."""
@@ -365,8 +363,7 @@ class Test_JPEGlossyTests_with_pillow(object):
 
         a = self.color_3d_jpeg.pixel_array
 
-        # Returned array is not read-only
-        assert a.flags.writeable is True
+        assert a.flags.writeable
 
         assert (120, 480, 640, 3) == a.shape
         # this test points were manually identified in Osirix viewer
@@ -563,8 +560,7 @@ def test_PI_RGB(test_with_pillow,
     a = t.pixel_array
     assert a.shape == (100, 100, 3)
 
-    # Returned array is not read-only
-    assert a.flags.writeable is True
+    assert a.flags.writeable
     """
     This complete test never gave a different result than
     just the 10 point test below

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -308,7 +308,7 @@ class Test_JPEG2000Tests_with_pillow(object):
         assert np.array_equal(a, b)
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
+        assert a.flags.writeable is True
 
     def test_emri_JPEG2000PixelArray(self):
         """Test decoding JPEG2K with pillow handler succeeds."""
@@ -317,7 +317,7 @@ class Test_JPEG2000Tests_with_pillow(object):
         assert np.array_equal(a, b)
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
+        assert a.flags.writeable is True
 
     def test_jpeg2000_lossy(self):
         """Test decoding JPEG2K lossy with pillow handler fails."""
@@ -366,7 +366,7 @@ class Test_JPEGlossyTests_with_pillow(object):
         a = self.color_3d_jpeg.pixel_array
 
         # Returned array is not read-only
-        assert a.flags.writeable == True
+        assert a.flags.writeable is True
 
         assert (120, 480, 640, 3) == a.shape
         # this test points were manually identified in Osirix viewer
@@ -564,7 +564,7 @@ def test_PI_RGB(test_with_pillow,
     assert a.shape == (100, 100, 3)
 
     # Returned array is not read-only
-    assert a.flags.writeable == True
+    assert a.flags.writeable is True
     """
     This complete test never gave a different result than
     just the 10 point test below

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -397,6 +397,9 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(OB_EXPL_LITTLE_1F)
         arr = ds.pixel_array
 
+        # Returned array is not read-only
+        assert arr.flags.writeable == True
+
         assert np.array_equal(arr, ref)
         assert (600, 800) == arr.shape
         assert 244 == arr[0].min() == arr[0].max()
@@ -412,6 +415,9 @@ class TestNumpy_RLEHandler(object):
         assert ds.NumberOfFrames == 2
         ref = _get_pixel_array(OB_EXPL_LITTLE_2F)
         arr = ds.pixel_array
+
+        # Returned array is not read-only
+        assert arr.flags.writeable == True
 
         assert np.array_equal(arr, ref)
         assert (2, 600, 800) == arr.shape
@@ -431,6 +437,9 @@ class TestNumpy_RLEHandler(object):
         assert 'NumberOfFrames' not in ds
         ref = _get_pixel_array(SC_EXPL_LITTLE_1F)
         arr = ds.pixel_array
+
+        # Returned array is not read-only
+        assert arr.flags.writeable == True
 
         assert np.array_equal(arr, ref)
         assert (255, 0, 0) == tuple(arr[5, 50, :])
@@ -453,6 +462,9 @@ class TestNumpy_RLEHandler(object):
         assert ds.NumberOfFrames == 2
         ref = _get_pixel_array(SC_EXPL_LITTLE_2F)
         arr = ds.pixel_array
+
+        # Returned array is not read-only
+        assert arr.flags.writeable == True
 
         assert np.array_equal(arr, ref)
 
@@ -483,6 +495,9 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(MR_EXPL_LITTLE_1F)
         arr = ds.pixel_array
 
+        # Returned array is not read-only
+        assert arr.flags.writeable == True
+
         assert np.array_equal(arr, ref)
         assert (64, 64) == arr.shape
 
@@ -499,6 +514,9 @@ class TestNumpy_RLEHandler(object):
         assert ds.NumberOfFrames == 10
         ref = _get_pixel_array(EMRI_EXPL_LITTLE_10F)
         arr = ds.pixel_array
+
+        # Returned array is not read-only
+        assert arr.flags.writeable == True
 
         assert np.array_equal(arr, ref)
         assert (10, 64, 64) == arr.shape
@@ -528,6 +546,9 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
         ref = _get_pixel_array(SC_EXPL_LITTLE_16_1F)
 
+        # Returned array is not read-only
+        assert arr.flags.writeable == True
+
         assert np.array_equal(ds.pixel_array, ref)
 
         assert (65535, 0, 0) == tuple(arr[5, 50, :])
@@ -550,6 +571,9 @@ class TestNumpy_RLEHandler(object):
         assert ds.NumberOfFrames == 2
         arr = ds.pixel_array
         ref = _get_pixel_array(SC_EXPL_LITTLE_16_2F)
+
+        # Returned array is not read-only
+        assert arr.flags.writeable == True
 
         assert np.array_equal(ds.pixel_array, ref)
 
@@ -579,6 +603,9 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(RTDOSE_EXPL_LITTLE_1F)
         arr = ds.pixel_array
 
+        # Returned array is not read-only
+        assert arr.flags.writeable == True
+
         assert np.array_equal(arr, ref)
         assert (10, 10) == arr.shape
         assert (1249000, 1249000, 1250000) == tuple(arr[0, :3])
@@ -594,6 +621,9 @@ class TestNumpy_RLEHandler(object):
         assert ds.NumberOfFrames == 15
         ref = _get_pixel_array(RTDOSE_EXPL_LITTLE_15F)
         arr = ds.pixel_array
+
+        # Returned array is not read-only
+        assert arr.flags.writeable == True
 
         assert np.array_equal(arr, ref)
         assert (15, 10, 10) == arr.shape
@@ -623,6 +653,9 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
         ref = _get_pixel_array(SC_EXPL_LITTLE_32_1F)
 
+        # Returned array is not read-only
+        assert arr.flags.writeable == True
+
         assert np.array_equal(ds.pixel_array, ref)
 
         assert (4294967295, 0, 0) == tuple(arr[5, 50, :])
@@ -645,6 +678,9 @@ class TestNumpy_RLEHandler(object):
         assert ds.NumberOfFrames == 2
         arr = ds.pixel_array
         ref = _get_pixel_array(SC_EXPL_LITTLE_32_2F)
+
+        # Returned array is not read-only
+        assert arr.flags.writeable == True
 
         assert np.array_equal(ds.pixel_array, ref)
 

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -398,7 +398,7 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
 
         # Returned array is not read-only
-        assert arr.flags.writeable == True
+        assert arr.flags.writeable is True
 
         assert np.array_equal(arr, ref)
         assert (600, 800) == arr.shape
@@ -417,7 +417,7 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
 
         # Returned array is not read-only
-        assert arr.flags.writeable == True
+        assert arr.flags.writeable is True
 
         assert np.array_equal(arr, ref)
         assert (2, 600, 800) == arr.shape
@@ -439,7 +439,7 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
 
         # Returned array is not read-only
-        assert arr.flags.writeable == True
+        assert arr.flags.writeable is True
 
         assert np.array_equal(arr, ref)
         assert (255, 0, 0) == tuple(arr[5, 50, :])
@@ -464,7 +464,7 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
 
         # Returned array is not read-only
-        assert arr.flags.writeable == True
+        assert arr.flags.writeable is True
 
         assert np.array_equal(arr, ref)
 
@@ -496,7 +496,7 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
 
         # Returned array is not read-only
-        assert arr.flags.writeable == True
+        assert arr.flags.writeable is True
 
         assert np.array_equal(arr, ref)
         assert (64, 64) == arr.shape
@@ -516,7 +516,7 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
 
         # Returned array is not read-only
-        assert arr.flags.writeable == True
+        assert arr.flags.writeable is True
 
         assert np.array_equal(arr, ref)
         assert (10, 64, 64) == arr.shape
@@ -547,7 +547,7 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(SC_EXPL_LITTLE_16_1F)
 
         # Returned array is not read-only
-        assert arr.flags.writeable == True
+        assert arr.flags.writeable is True
 
         assert np.array_equal(ds.pixel_array, ref)
 
@@ -573,7 +573,7 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(SC_EXPL_LITTLE_16_2F)
 
         # Returned array is not read-only
-        assert arr.flags.writeable == True
+        assert arr.flags.writeable is True
 
         assert np.array_equal(ds.pixel_array, ref)
 
@@ -604,7 +604,7 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
 
         # Returned array is not read-only
-        assert arr.flags.writeable == True
+        assert arr.flags.writeable is True
 
         assert np.array_equal(arr, ref)
         assert (10, 10) == arr.shape
@@ -623,7 +623,7 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
 
         # Returned array is not read-only
-        assert arr.flags.writeable == True
+        assert arr.flags.writeable is True
 
         assert np.array_equal(arr, ref)
         assert (15, 10, 10) == arr.shape
@@ -654,7 +654,7 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(SC_EXPL_LITTLE_32_1F)
 
         # Returned array is not read-only
-        assert arr.flags.writeable == True
+        assert arr.flags.writeable is True
 
         assert np.array_equal(ds.pixel_array, ref)
 
@@ -680,7 +680,7 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(SC_EXPL_LITTLE_32_2F)
 
         # Returned array is not read-only
-        assert arr.flags.writeable == True
+        assert arr.flags.writeable is True
 
         assert np.array_equal(ds.pixel_array, ref)
 

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -397,8 +397,7 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(OB_EXPL_LITTLE_1F)
         arr = ds.pixel_array
 
-        # Returned array is not read-only
-        assert arr.flags.writeable is True
+        assert arr.flags.writeable
 
         assert np.array_equal(arr, ref)
         assert (600, 800) == arr.shape
@@ -416,8 +415,7 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(OB_EXPL_LITTLE_2F)
         arr = ds.pixel_array
 
-        # Returned array is not read-only
-        assert arr.flags.writeable is True
+        assert arr.flags.writeable
 
         assert np.array_equal(arr, ref)
         assert (2, 600, 800) == arr.shape
@@ -438,8 +436,7 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(SC_EXPL_LITTLE_1F)
         arr = ds.pixel_array
 
-        # Returned array is not read-only
-        assert arr.flags.writeable is True
+        assert arr.flags.writeable
 
         assert np.array_equal(arr, ref)
         assert (255, 0, 0) == tuple(arr[5, 50, :])
@@ -463,8 +460,7 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(SC_EXPL_LITTLE_2F)
         arr = ds.pixel_array
 
-        # Returned array is not read-only
-        assert arr.flags.writeable is True
+        assert arr.flags.writeable
 
         assert np.array_equal(arr, ref)
 
@@ -495,8 +491,7 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(MR_EXPL_LITTLE_1F)
         arr = ds.pixel_array
 
-        # Returned array is not read-only
-        assert arr.flags.writeable is True
+        assert arr.flags.writeable
 
         assert np.array_equal(arr, ref)
         assert (64, 64) == arr.shape
@@ -515,8 +510,7 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(EMRI_EXPL_LITTLE_10F)
         arr = ds.pixel_array
 
-        # Returned array is not read-only
-        assert arr.flags.writeable is True
+        assert arr.flags.writeable
 
         assert np.array_equal(arr, ref)
         assert (10, 64, 64) == arr.shape
@@ -546,8 +540,7 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
         ref = _get_pixel_array(SC_EXPL_LITTLE_16_1F)
 
-        # Returned array is not read-only
-        assert arr.flags.writeable is True
+        assert arr.flags.writeable
 
         assert np.array_equal(ds.pixel_array, ref)
 
@@ -572,8 +565,7 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
         ref = _get_pixel_array(SC_EXPL_LITTLE_16_2F)
 
-        # Returned array is not read-only
-        assert arr.flags.writeable is True
+        assert arr.flags.writeable
 
         assert np.array_equal(ds.pixel_array, ref)
 
@@ -603,8 +595,7 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(RTDOSE_EXPL_LITTLE_1F)
         arr = ds.pixel_array
 
-        # Returned array is not read-only
-        assert arr.flags.writeable is True
+        assert arr.flags.writeable
 
         assert np.array_equal(arr, ref)
         assert (10, 10) == arr.shape
@@ -622,8 +613,7 @@ class TestNumpy_RLEHandler(object):
         ref = _get_pixel_array(RTDOSE_EXPL_LITTLE_15F)
         arr = ds.pixel_array
 
-        # Returned array is not read-only
-        assert arr.flags.writeable is True
+        assert arr.flags.writeable
 
         assert np.array_equal(arr, ref)
         assert (15, 10, 10) == arr.shape
@@ -653,8 +643,7 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
         ref = _get_pixel_array(SC_EXPL_LITTLE_32_1F)
 
-        # Returned array is not read-only
-        assert arr.flags.writeable is True
+        assert arr.flags.writeable
 
         assert np.array_equal(ds.pixel_array, ref)
 
@@ -679,8 +668,7 @@ class TestNumpy_RLEHandler(object):
         arr = ds.pixel_array
         ref = _get_pixel_array(SC_EXPL_LITTLE_32_2F)
 
-        # Returned array is not read-only
-        assert arr.flags.writeable is True
+        assert arr.flags.writeable
 
         assert np.array_equal(ds.pixel_array, ref)
 


### PR DESCRIPTION
#### Reference Issue
Closes #717 


#### What does this implement/fix? Explain your changes.
* Ensure pixel data handlers return writeable arrays by default
* Adds tests for writeability

#### Any other comments?
Original array writeabilities:
* Numpy handler arrays with  BitsAllocated = 1 are writeable
* Numpy handler arrays with BitsAllocated > 1 are read-only
* RLE handler arrays are writeable (except with numpypy)
* Pillow handler arrays are writeable
* JPEG-LS handler arrays with NumberOfFrames = 1 are read-only
* JPEG-LS handler arrays with NumberOfFrames > 1 are writable
* GDCM handler arrays are read-only
