### PR TITLE
[MRG+1] Import MutableSequence from collections.abc

### DIFF
--- a/pydicom/multival.py
+++ b/pydicom/multival.py
@@ -3,7 +3,10 @@
 or any list of items that must all be the same type.
 """
 
-from collections import MutableSequence
+try:
+    from collections.abc import MutableSequence
+except ImportError:
+    from collections import MutableSequence
 
 
 class MultiValue(MutableSequence):


### PR DESCRIPTION
#### Reference Issue
Closes #740 


#### What does this implement/fix? Explain your changes.
Changes `MutableSequence` import to from `collections.abc` (required for python 3.8+) while maintaining backwards compatibility.