### PR TITLE
[MRG+1] Removed superfluous encoding argument in tests

### DIFF
--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -460,9 +460,7 @@ def write_data_element(fp, data_element, encodings=None):
         encodings = convert_encodings(encodings)
         writer_function, writer_param = writers[VR]
         is_undefined_length = data_element.is_undefined_length
-        if VR in text_VRs:
-            writer_function(buffer, data_element, encodings=encodings)
-        elif VR in ('PN', 'SQ'):
+        if VR in text_VRs or VR in ('PN', 'SQ'):
             writer_function(buffer, data_element, encodings=encodings)
         else:
             # Many numeric types use the same writer but with numeric format

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -2139,7 +2139,7 @@ class TestWritePN(object):
         encoded = (b'Dionysios=\x1b\x2d\x46'
                    b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
         elem = DataElement(0x00100010, 'PN', encoded)
-        write_PN(fp, elem, encodings=encodings)
+        write_PN(fp, elem)
         assert encoded == fp.getvalue()
 
         fp = DicomBytesIO()
@@ -2160,7 +2160,7 @@ class TestWritePN(object):
                    b'\x1b\x2d\x4C'
                    b'\xbb\xee\xda\x63\x65\xdc\xd1\x79\x70\xd3 ')
         elem = DataElement(0x00100060, 'PN', encoded)
-        write_PN(fp, elem, encodings=encodings)
+        write_PN(fp, elem)
         assert encoded == fp.getvalue()
 
         fp = DicomBytesIO()
@@ -2203,7 +2203,7 @@ class TestWriteText(object):
         # data element with encoded value
         elem = DataElement(0x00081039, 'LO', encoded)
         encodings = ['latin_1', 'iso_ir_126']
-        write_text(fp, elem, encodings=encodings)
+        write_text(fp, elem)
         assert encoded == fp.getvalue()
 
         fp = DicomBytesIO()


### PR DESCRIPTION
- the argument did not make sense - writing raw bytes and reading
  them back does not involve encoding

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
Took me some time to understand that this is not a bug...
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
