### PR TITLE
[MRG+1] Handle no encoding argument in PersonName3 as unknown encoding

### DIFF
--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -2142,6 +2142,15 @@ class TestWritePN(object):
         write_PN(fp, elem)
         assert encoded == fp.getvalue()
 
+        # regression test: make sure no warning is issued, e.g. the
+        # PersonName3 value has not saved the default encoding
+        fp = DicomBytesIO()
+        fp.is_little_endian = True
+        with pytest.warns(None) as warnings:
+            write_PN(fp, elem, encodings)
+        assert not warnings
+        assert encoded == fp.getvalue()
+
         fp = DicomBytesIO()
         fp.is_little_endian = True
         # data element with decoded value

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -618,7 +618,8 @@ class PersonName3(object):
             self.original_string = original_string
             self._components = val.split('=')
 
-        self.encodings = _verify_encodings(encodings) or [default_encoding]
+        # if the encoding is not given, leave it as undefined (None)
+        self.encodings = _verify_encodings(encodings)
         self._dict = {}
 
     def _create_dict(self):
@@ -638,7 +639,8 @@ class PersonName3(object):
         """
         if self._components is None:
             groups = self.original_string.split(b'=')
-            self._components = _decode_personname(groups, self.encodings)
+            encodings = self.encodings or [default_encoding]
+            self._components = _decode_personname(groups, encodings)
 
         return self._components
 
@@ -757,14 +759,15 @@ class PersonName3(object):
             with the first matching of the given encodings.
         """
         encodings = _verify_encodings(encodings) or self.encodings
+
         # if the encoding is not the original encoding, we have to return
         # a re-encoded string (without updating the original string)
-        if encodings != self.encodings:
+        if encodings != self.encodings and self.encodings is not None:
             return _encode_personname(self.components, encodings)
         if self.original_string is None:
             # if the original encoding was not set, we set it now
-            self.original_string = _encode_personname(self.components,
-                                                      encodings)
+            self.original_string = _encode_personname(
+                self.components, encodings or [default_encoding])
         return self.original_string
 
     def family_comma_given(self):


### PR DESCRIPTION
- ensures that the default encoding is not set as the encoding if not known
- implies that decoding is called with the correct encodings

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
This fixes the warning (found by @darcymason in #733) that was triggered by setting the encoding of `PersonName3` to default encoding, if none was given, which always happens if creating a `DataElement` with a PN value manually and accessing it afterwards (see also the discussion in #751).
I couldn't find a scenario where this caused a real error (apart from the incorrect warning), so I tested only for the warning not issued, but there may be some case which I overlooked. 
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
