### PR TITLE
[MRG+1] Remove deprecated variables/class

### DIFF
--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -81,7 +81,6 @@ pixel_data_handlers = [
     pillow_handler,
     jpegls_handler,
 ]
-image_handlers = [hh for hh in pixel_data_handlers if hh.is_available()]
 """Handlers for converting (7fe0,0010) Pixel Data.
 This is an ordered list that the dataset.convert_pixel_data()
 method will try to extract a correctly sized numpy array from the

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -401,60 +401,6 @@ class DataElement(object):
             return str(self)
 
 
-class DeferredDataElement(DataElement):
-    """Subclass of DataElement where value is not read
-       into memory until needed"""
-
-    def __init__(self, tag, VR, fp, file_mtime, data_element_tell, length):
-        """Store basic info for the data element but value
-           will be read later
-
-        fp -- DicomFile object representing the dicom file being read
-        file_mtime -- last modification time on file, used to make sure
-           it has not changed since original read
-        data_element_tell -- file position at start of data element,
-           (not the start of the value part, but start of whole element)
-        """
-        warnings.warn(
-            "DeferredDataElement is deprecated and will be removed in "
-            "pydicom v1.3",
-            DeprecationWarning
-        )
-
-        if not isinstance(tag, BaseTag):
-            tag = Tag(tag)
-        self.tag = tag
-        self.VR = VR
-        self._value = None  # flag as unread
-
-        # Check current file object and save info needed for read later
-        self.fp_is_implicit_VR = fp.is_implicit_VR
-        self.fp_is_little_endian = fp.is_little_endian
-        self.filepath = fp.name
-        self.file_mtime = file_mtime
-        self.data_element_tell = data_element_tell
-        self.length = length
-
-    @property
-    def repval(self):
-        if self._value is None:
-            return "Deferred read: length %d" % self.length
-        else:
-            return DataElement.repval.fget(self)
-
-    @property
-    def value(self):
-        """Get method for 'value' property"""
-        # Must now read the value if haven't already
-        if self._value is None:
-            self.read_value()
-        return DataElement.value.fget(self)
-
-    @value.setter
-    def value(self, val):
-        DataElement.value.fset(self, val)
-
-
 msg = 'tag VR length value value_tell is_implicit_VR is_little_endian'
 RawDataElement = namedtuple('RawDataElement', msg)
 RawDataElement.is_raw = True

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -14,7 +14,6 @@ from pydicom.dataelem import (
     RawDataElement,
     DataElement_from_raw,
     isStringOrStringList,
-    DeferredDataElement
 )
 from pydicom.dataset import Dataset
 from pydicom.filebase import DicomBytesIO
@@ -409,12 +408,3 @@ class RawDataElementTests(unittest.TestCase):
                              0, False, True)
         with pytest.raises(NotImplementedError):
             DataElement_from_raw(raw, default_encoding)
-
-
-def test_deferred_data_element_deprecated():
-    """Test the deprecation warning is working"""
-    fp = DicomBytesIO()
-    fp.is_little_endian = True
-    fp.is_implicit_VR = True
-    with pytest.deprecated_call():
-        elem = DeferredDataElement(0x00000000, 'UL', fp, 0, 0, 4)

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -14,8 +14,11 @@ from pydicom import dcmread
 from pydicom.filebase import DicomBytesIO
 from pydicom.sequence import Sequence
 from pydicom.tag import Tag
-from pydicom.uid import ImplicitVRLittleEndian, JPEGBaseLineLossy8bit, \
-    ExplicitVRBigEndian, ExplicitVRLittleEndian, PYDICOM_IMPLEMENTATION_UID
+from pydicom.uid import (
+    ImplicitVRLittleEndian,
+    ExplicitVRBigEndian,
+    PYDICOM_IMPLEMENTATION_UID
+)
 
 
 class DatasetTests(unittest.TestCase):

--- a/pydicom/uid.py
+++ b/pydicom/uid.py
@@ -208,11 +208,6 @@ JPEG2000MultiComponentLossless = UID('1.2.840.10008.1.2.4.92')
 JPEG2000MultiComponent = UID('1.2.840.10008.1.2.4.93')
 RLELossless = UID('1.2.840.10008.1.2.5')
 
-# Deprecated, to be removed in v1.3
-JPEGBaseLineLossy8bit = JPEGBaseline
-JPEGBaseLineLossy12bit = JPEGExtended
-JPEG2000Lossy = JPEG2000
-
 UncompressedPixelTransferSyntaxes = [
     ExplicitVRLittleEndian,
     ImplicitVRLittleEndian,


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Removes deprecated `uid` variables, `config.image_handlers` and `DeferredDataElement`