### PR TITLE
[WIP] Add missing datasets to parametrized tests for numpy handler

### DIFF
--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -366,11 +366,11 @@ MATCHING_DATASETS = [
     (EXPL_8_3_2F, EXPB_8_3_2F),
     (EXPL_16_1_1F, EXPB_16_1_1F),
     (EXPL_16_1_10F, EXPB_16_1_10F),
-    # (EXPL_16_3_1F, EXPB_16_3_1F),  # Not supported yet
+    (EXPL_16_3_1F, EXPB_16_3_1F),
     (EXPL_16_3_2F, EXPB_16_3_2F),
     (IMPL_32_1_1F, EXPB_32_1_1F),
     (IMPL_32_1_15F, EXPB_32_1_15F),
-    # (EXPL_32_3_1F, EXPB_32_3_1F),  # Not supported yet
+    (EXPL_32_3_1F, EXPB_32_3_1F),
     (EXPL_32_3_2F, EXPB_32_3_2F)
 ]
 
@@ -387,11 +387,11 @@ REFERENCE_DATA_LITTLE = [
     (EXPL_8_3_2F, (EXPL, 8, 3, 0, 2, (2, 100, 100, 3), 'uint8')),
     (EXPL_16_1_1F, (EXPL, 16, 1, 1, 1, (64, 64), 'int16')),
     (EXPL_16_1_10F, (EXPL, 16, 1, 0, 10, (10, 64, 64), 'uint16')),
-    # (EXPL_16_3_1F, (EXPL, 16, 3, 0, 1, (100, 100, 3), 'uint16')),
+    (EXPL_16_3_1F, (EXPL, 16, 3, 0, 1, (100, 100, 3), 'uint16')),
     (EXPL_16_3_2F, (EXPL, 16, 3, 0, 2, (2, 100, 100, 3), 'uint16')),
     (IMPL_32_1_1F, (IMPL, 32, 1, 0, 1, (10, 10), 'uint32')),
     (IMPL_32_1_15F, (IMPL, 32, 1, 0, 15, (15, 10, 10), 'uint32')),
-    # (EXPL_32_3_1F, (EXPL, 32, 3, 0, 1, (100, 100, 3), 'uint32')),
+    (EXPL_32_3_1F, (EXPL, 32, 3, 0, 1, (100, 100, 3), 'uint32')),
     (EXPL_32_3_2F, (EXPL, 32, 3, 0, 2, (2, 100, 100, 3), 'uint32')),
 ]
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Uncomments the pixel data datasets that were previously skipped because of lack of support.
