### PR TITLE
[MRG+1] Add missing methods to Dataset, change Dataset.tags to Dataset._dict

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -508,7 +508,7 @@ class Dataset(object):
         list of tuple
             The top-level (element tag, element) for the Dataset.
         """
-        return [(kk, self[kk]) for kk in self.tags]
+        return self.tags.items()
 
     def keys(self):
         """Return the DICOM tag keys to simulate dict."""

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -177,11 +177,11 @@ class Dataset(object):
         """Create a new Dataset instance."""
         self._parent_encoding = kwargs.get('parent_encoding', default_encoding)
         if not args:
-            self.tags = {}
+            self._dict = {}
         elif isinstance(args[0], Dataset):
-            self.tags = args[0].tags
+            self._dict = args[0]._dict
         else:
-            self.tags = args[0]
+            self._dict = args[0]
         self.is_decompressed = False
 
         # the following read_XXX attributes are used internally to store
@@ -239,7 +239,7 @@ class Dataset(object):
         """
         data_element = DataElement(tag, VR, value)
         # use data_element.tag since DataElement verified it
-        self.tags[data_element.tag] = data_element
+        self._dict[data_element.tag] = data_element
 
     def data_element(self, name):
         """Return the DataElement corresponding to the element keyword `name`.
@@ -287,9 +287,9 @@ class Dataset(object):
                 return False
         # Test against None as (0000,0000) is a possible tag
         if tag is not None:
-            return tag in self.tags
+            return tag in self._dict
         else:
-            return name in self.tags  # will no doubt raise an exception
+            return name in self._dict  # will no doubt raise an exception
 
     def decode(self):
         """Apply character set decoding to all DataElements in the Dataset.
@@ -333,8 +333,8 @@ class Dataset(object):
         """
         # First check if a valid DICOM keyword and if we have that data element
         tag = tag_for_keyword(name)
-        if tag is not None and tag in self.tags:
-            del self.tags[tag]
+        if tag is not None and tag in self._dict:
+            del self._dict[tag]
         # If not a DICOM name in this dataset, check for regular instance name
         #   can't do delete directly, that will call __delattr__ again
         elif name in self.__dict__:
@@ -374,15 +374,15 @@ class Dataset(object):
         # If passed a slice, delete the corresponding DataElements
         if isinstance(key, slice):
             for tag in self._slice_dataset(key.start, key.stop, key.step):
-                del self.tags[tag]
+                del self._dict[tag]
         else:
             # Assume is a standard tag (for speed in common case)
             try:
-                del self.tags[key]
+                del self._dict[key]
             # If not a standard tag, than convert to Tag and try again
             except KeyError:
                 tag = Tag(key)
-                del self.tags[tag]
+                del self._dict[tag]
 
     def __dir__(self):
         """Give a list of attributes available in the Dataset.
@@ -419,7 +419,7 @@ class Dataset(object):
             The matching DataElement keywords in the dataset. If no filters are
             used then all DataElement keywords are returned.
         """
-        allnames = [keyword_for_tag(tag) for tag in self.tags.keys()]
+        allnames = [keyword_for_tag(tag) for tag in self._dict.keys()]
         # remove blanks - tags without valid names (e.g. private tags)
         allnames = [x for x in allnames if x]
         # Store found names in a dict, so duplicate names appear only once
@@ -454,8 +454,8 @@ class Dataset(object):
             # Convert values() to a list for compatibility between
             #   python 2 and 3
             # Sort values() by element tag
-            self_elem = sorted(list(self.tags.values()), key=lambda x: x.tag)
-            other_elem = sorted(list(other.tags.values()), key=lambda x: x.tag)
+            self_elem = sorted(list(self._dict.values()), key=lambda x: x.tag)
+            other_elem = sorted(list(other._dict.values()), key=lambda x: x.tag)
             return self_elem == other_elem
 
         return NotImplemented
@@ -508,25 +508,25 @@ class Dataset(object):
         list of tuple
             The top-level (element tag, element) for the Dataset.
         """
-        return self.tags.items()
+        return self._dict.items()
 
     def keys(self):
         """Return the DICOM tag keys to simulate dict."""
-        return self.tags.keys()
+        return self._dict.keys()
 
     def values(self):
         """Return the DICOM tag values to simulate dict."""
-        return self.tags.values()
+        return self._dict.values()
 
     if compat.in_py2:
         def iterkeys(self):
-            return self.tags.iterkeys()
+            return self._dict.iterkeys()
 
         def itervalues(self):
-            return self.tags.itervalues()
+            return self._dict.itervalues()
 
         def iteritems(self):
-            return self.tags.iteritems()
+            return self._dict.iteritems()
 
     def __getattr__(self, name):
         """Intercept requests for Dataset attribute names.
@@ -551,7 +551,7 @@ class Dataset(object):
             # Try the base class attribute getter (fix for issue 332)
             return super(Dataset, self).__getattribute__(name)
         tag = Tag(tag)
-        if tag not in self.tags:  # DICOM DataElement not in the Dataset
+        if tag not in self._dict:  # DICOM DataElement not in the Dataset
             # Try the base class attribute getter (fix for issue 332)
             return super(Dataset, self).__getattribute__(name)
         else:
@@ -617,7 +617,7 @@ class Dataset(object):
             tag = key
         else:
             tag = Tag(key)
-        data_elem = self.tags[tag]
+        data_elem = self._dict[tag]
 
         if isinstance(data_elem, DataElement):
             return data_elem
@@ -642,7 +642,7 @@ class Dataset(object):
                 self[tag] = correct_ambiguous_vr_element(
                     self[tag], self, data_elem[6])
 
-        return self.tags.get(tag)
+        return self._dict.get(tag)
 
     def get_item(self, key):
         """Return the raw data element if possible.
@@ -669,7 +669,7 @@ class Dataset(object):
             tag = key
         else:
             tag = Tag(key)
-        data_elem = self.tags.get(tag)
+        data_elem = self._dict.get(tag)
         # If a deferred read, return using __getitem__ to read and convert it
         if isinstance(data_elem, tuple) and data_elem.value is None:
             return self[key]
@@ -746,7 +746,7 @@ class Dataset(object):
         # Note this is different than the underlying dict class,
         #        which returns the key of the key:value mapping.
         #   Here the value is returned (but data_element.tag has the key)
-        taglist = sorted(self.tags.keys())
+        taglist = sorted(self._dict.keys())
         for tag in taglist:
             yield self[tag]
 
@@ -764,12 +764,12 @@ class Dataset(object):
         pydicom.dataelem.DataElement or pydicom.dataelem.RawDataElement
             The Dataset's DataElements, sorted by increasing tag order.
         """
-        taglist = sorted(self.tags.keys())
+        taglist = sorted(self._dict.keys())
         for tag in taglist:
             yield self.get_item(tag)
 
     def __len__(self):
-        return len(self.tags)
+        return len(self._dict)
 
     def __ne__(self, other):
         """Compare `self` and `other` for inequality."""
@@ -777,16 +777,16 @@ class Dataset(object):
 
     def clear(self):
         """Delete all data elements."""
-        self.tags.clear()
+        self._dict.clear()
 
     def pop(self, *args, **kwargs):
-        return self.tags.pop(*args, **kwargs)
+        return self._dict.pop(*args, **kwargs)
 
     def popitem(self):
-        return self.tags.popitem()
+        return self._dict.popitem()
 
     def setdefault(self,  *args, **kwargs):
-        return self.tags.setdefault(*args, **kwargs)
+        return self._dict.setdefault(*args, **kwargs)
 
     def convert_pixel_data(self):
         """Convert the Pixel Data to a numpy array internally.
@@ -1227,7 +1227,7 @@ class Dataset(object):
                     data_element = DataElement_from_raw(
                         data_element, self._character_set)
                 data_element.private_creator = self[private_creator_tag].value
-        self.tags[tag] = data_element
+        self._dict[tag] = data_element
 
     def _slice_dataset(self, start, stop, step):
         """Return the element tags in the Dataset that match the slice.
@@ -1254,7 +1254,7 @@ class Dataset(object):
         if stop is not None:
             stop = Tag(stop)
 
-        all_tags = sorted(self.tags.keys())
+        all_tags = sorted(self._dict.keys())
         # If the Dataset is empty, return an empty list
         if not all_tags:
             return []
@@ -1346,7 +1346,7 @@ class Dataset(object):
         recursive : bool
             Flag to indicate whether to recurse into Sequences.
         """
-        taglist = sorted(self.tags.keys())
+        taglist = sorted(self._dict.keys())
         for tag in taglist:
 
             with tag_in_exception(tag):

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -518,6 +518,16 @@ class Dataset(object):
         """Return the DICOM tag values to simulate dict."""
         return self.tags.values()
 
+    if compat.in_py2:
+        def iterkeys(self):
+            return self.tags.iterkeys()
+
+        def itervalues(self):
+            return self.tags.itervalues()
+
+        def iteritems(self):
+            return self.tags.iteritems()
+
     def __getattr__(self, name):
         """Intercept requests for Dataset attribute names.
 

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -500,6 +500,16 @@ class Dataset(object):
         except KeyError:
             return default
 
+    def items(self):
+        """Return the elements in the Dataset as a list of tuple.
+
+        Returns
+        -------
+        list of tuple
+            The top-level (element tag, element) for the Dataset.
+        """
+        return [(kk, self[kk]) for kk in self.tags]
+
     def keys(self):
         """Return the DICOM tag keys to simulate dict."""
         return self.tags.keys()
@@ -1276,7 +1286,13 @@ class Dataset(object):
         return dir(self)  # only valid python >=2.6, else use self.__dir__()
 
     def update(self, dictionary):
-        """Extend dict.update() to handle DICOM keywords."""
+        """Extend dict.update() to handle DICOM keywords.
+
+        Parameters
+        ----------
+        dictionary : dict or Dataset
+            The dict or Dataset to use when updating the current object.
+        """
         for key, value in list(dictionary.items()):
             if isinstance(key, (str, compat.text_type)):
                 setattr(self, key, value)

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -539,7 +539,7 @@ def _read_file_meta_info(fp):
     start_file_meta = fp.tell()
     file_meta = read_dataset(fp, is_implicit_VR=False, is_little_endian=True,
                              stop_when=_not_group_0002)
-    if not file_meta.tags:
+    if not file_meta._dict:
         return file_meta
 
     # Test the file meta for correct interpretation by requesting the first
@@ -759,7 +759,7 @@ def read_partial(fileobj, stop_when=None, defer_size=None,
         pass  # error already logged in read_dataset
 
     # Add the command set elements to the dataset (if any)
-    dataset.update(command_set.tags)
+    dataset.update(command_set._dict)
 
     class_uid = file_meta_dataset.get("MediaStorageSOPClassUID", None)
     if class_uid and class_uid.name == "Media Storage Directory Storage":

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1152,6 +1152,14 @@ class DatasetTests(unittest.TestCase):
         assert ds.BeamSequence[1].PatientID == 'FIXED'
         assert ds.BeamSequence[1].PatientName == 'Other^Name'
 
+    def test_update_with_dataset(self):
+        """Regression test for #779"""
+        ds = Dataset()
+        ds.PatientName = "Test"
+        ds2 = Dataset()
+        ds2.update(ds)
+        assert ds2.PatientName == 'Test'
+
 
 class DatasetElementsTests(unittest.TestCase):
     """Test valid assignments of data elements"""

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -2,6 +2,7 @@
 """Tests for dataset.py"""
 
 import unittest
+from collections import OrderedDict
 
 import pytest
 
@@ -781,6 +782,39 @@ class DatasetTests(unittest.TestCase):
         self.assertFalse(0x00090001 in ds)
         self.assertFalse(0x00090010 in ds)
         self.assertTrue('PatientName' in ds)
+
+    @pytest.mark.skipif(not compat.in_py2, reason='Python 2 only iterators')
+    def test_iteritems(self):
+        ds = Dataset()
+        ds.Overlays = 12  # 0000,51B0
+        ds.LengthToEnd = 12  # 0008,0001
+        ds.SOPInstanceUID = '1.2.3.4'  # 0008,0018
+        ds.SkipFrameRangeFlag = 'TEST'  # 0008,9460
+
+        keys = []
+        for key in ds.iterkeys():
+            keys.append(key)
+        assert 4 == len(keys)
+        assert 0x000051B0 in keys
+        assert 0x00089460 in keys
+
+        values = []
+        for value in ds.itervalues():
+            values.append(value)
+
+        assert 4 == len(values)
+        assert DataElement(0x00080018, 'UI', '1.2.3.4') in values
+        assert DataElement(0x00089460, 'CS', 'TEST') in values
+
+        items = {}
+        for key, value in ds.iteritems():
+            items[key] = value
+
+        assert 4 == len(items)
+        assert 0x000051B0 in items
+        assert 0x00080018 in items
+        assert '1.2.3.4' == items[0x00080018].value
+        assert 12 == items[0x00080001].value
 
     def test_group_dataset(self):
         """Test Dataset.group_dataset"""

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1160,6 +1160,21 @@ class DatasetTests(unittest.TestCase):
         ds2.update(ds)
         assert ds2.PatientName == 'Test'
 
+        # Test sequences
+        ds2 = Dataset()
+        ds.BeamSequence = [Dataset(), Dataset()]
+        ds.BeamSequence[0].PatientName = 'TestA'
+        ds.BeamSequence[1].PatientName = 'TestB'
+
+        ds2.update(ds)
+        assert ds2.BeamSequence[0].PatientName == 'TestA'
+        assert ds2.BeamSequence[1].PatientName == 'TestB'
+
+        # Test overwrite
+        ds.PatientName = 'TestC'
+        ds2.update(ds)
+        assert ds2.PatientName == 'TestC'
+
 
 class DatasetElementsTests(unittest.TestCase):
     """Test valid assignments of data elements"""


### PR DESCRIPTION
#### Reference Issue
Related to #779 

#### What does this implement/fix? Explain your changes.
* Implement missing `dict` methods:
  * `Dataset.items()`
  * `Dataset.itervalues()`, `Dataset.iterkeys()`, `Dataset.iteritems()` in Python 2
* Rename `Dataset.tags` to `Dataset._dict`
