### PR TITLE
[MRG] Fix ambiguous VR correction not being used

### DIFF
--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -75,8 +75,10 @@ def _correct_ambiguous_vr_element(elem, ds, is_little_endian):
         else:
             elem.VR = 'SS'
             byte_type = 'h'
-        elem.value = convert_numbers(elem.value, is_little_endian,
-                                     byte_type)
+
+        if not isinstance(elem.value, int):
+            elem.value = convert_numbers(elem.value, is_little_endian,
+                                         byte_type)
 
     # 'OB or OW' and dependent on WaveformBitsAllocated
     # (5400, 0110) Channel Minimum Value
@@ -515,7 +517,7 @@ def write_dataset(fp, dataset, parent_encoding=default_encoding):
     """
     _harmonize_properties(dataset, fp)
 
-    if not fp.is_implicit_VR and not dataset.is_original_encoding:
+    if not dataset.is_original_encoding:
         dataset = correct_ambiguous_vr(dataset, fp.is_little_endian)
 
     dataset_encoding = dataset.get('SpecificCharacterSet', parent_encoding)

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -76,7 +76,9 @@ def _correct_ambiguous_vr_element(elem, ds, is_little_endian):
             elem.VR = 'SS'
             byte_type = 'h'
 
-        if not isinstance(elem.value, int):
+        # Need to handle type check for elements with VM > 1
+        elem_value = elem.value if elem.VM == 1 else elem.value[0]
+        if not isinstance(elem_value, int):
             elem.value = convert_numbers(elem.value, is_little_endian,
                                          byte_type)
 
@@ -101,8 +103,10 @@ def _correct_ambiguous_vr_element(elem, ds, is_little_endian):
         # As per PS3.3 C.11.1.1.1
         if ds.LUTDescriptor[0] == 1:
             elem.VR = 'US'
-            elem.value = convert_numbers(elem.value, is_little_endian,
-                                         'H')
+            elem_value = elem.value if elem.VM == 1 else elem.value[0]
+            if not isinstance(elem_value, int):
+                elem.value = convert_numbers(elem.value, is_little_endian,
+                                             'H')
         else:
             elem.VR = 'OW'
 
@@ -511,9 +515,6 @@ def write_data_element(fp, data_element, encodings=None):
 
 def write_dataset(fp, dataset, parent_encoding=default_encoding):
     """Write a Dataset dictionary to the file. Return the total length written.
-
-    Attempt to correct ambiguous VR elements when explicit little/big
-      encoding Elements that can't be corrected will be returned unchanged.
     """
     _harmonize_properties(dataset, fp)
 

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -851,8 +851,19 @@ class TestCorrectAmbiguousVR(object):
         ds.SmallestImagePixelValue = 0
         assert ds[0x00280106].VR == 'US or SS'
         ds.PixelRepresentation = 0
+        ds.LUTDescriptor = [1, 0]
+        assert ds[0x00283002].VR == 'US or SS'
+        ds.LUTData = 0
+        assert ds[0x00283006].VR == 'US or OW'
         ds.save_as(DicomBytesIO())
+
         assert ds[0x00280106].VR == 'US'
+        assert ds.SmallestImagePixelValue == 0
+        assert ds[0x00283006].VR == 'US'
+        assert ds.LUTData == 0
+        assert ds[0x00283002].VR == 'US'
+        assert ds.LUTDescriptor == [1, 0]
+
 
 
 class TestCorrectAmbiguousVRElement(object):

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -865,7 +865,6 @@ class TestCorrectAmbiguousVR(object):
         assert ds.LUTDescriptor == [1, 0]
 
 
-
 class TestCorrectAmbiguousVRElement(object):
     """Test filewriter.correct_ambiguous_vr_element"""
 

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -843,6 +843,17 @@ class TestCorrectAmbiguousVR(object):
                     0].SmallestValidPixelValue == 256)
         assert ds.BeamSequence[0].BeamSequence[0][0x00280104].VR == 'US'
 
+    def test_write_new_ambiguous(self):
+        """Regression test for #781"""
+        ds = Dataset()
+        ds.is_little_endian = True
+        ds.is_implicit_VR = True
+        ds.SmallestImagePixelValue = 0
+        assert ds[0x00280106].VR == 'US or SS'
+        ds.PixelRepresentation = 0
+        ds.save_as(DicomBytesIO())
+        assert ds[0x00280106].VR == 'US'
+
 
 class TestCorrectAmbiguousVRElement(object):
     """Test filewriter.correct_ambiguous_vr_element"""


### PR DESCRIPTION
#### Reference Issue
<!-- Example: Fixes #1234 -->#781

#### What does this implement/fix? Explain your changes.
Ensures ambiguous VR correction applied on saving newly created datasets.