### PR TITLE
Use super in constructor of FileDataset

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1415,7 +1415,7 @@ class FileDataset(Dataset):
             True (default) if little-endian transfer syntax used; False if
             big-endian.
         """
-        Dataset.__init__(self, dataset)
+        super(FileDataset, self).__init__(dataset)
         self.preamble = preamble
         self.file_meta = file_meta
         self.is_implicit_VR = is_implicit_VR


### PR DESCRIPTION

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->
Instances of `FileDataset` did not inherit all methods from `Dataset`, e.g., `items()`.


