### PR TITLE
[MRG] Use fixed NumPy version for PyPy to avoid PyPy bug

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -100,7 +100,8 @@ elif [[ "$DISTRIB" == "pypy" ]]; then
     # install pip
     python -m ensurepip --upgrade
     if [[ "$NUMPY" == "true" ]]; then
-        python -m pip install cython numpy
+        # see #794 - avoid PyPy bug with newer NumPy versions
+        python -m pip install cython numpy==1.15.4
     fi
     python -m pip install nose nose-timer pytest pytest-cov codecov setuptools
 fi


### PR DESCRIPTION
- fixes #794 by avoiding to use the affexted NumPy version 1.16 in PyPy

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
