### PR TITLE
[MRG] Fix generate_uid(None) producing non-conformant UIDs

### DIFF
--- a/doc/whatsnew/v1.3.0.rst
+++ b/doc/whatsnew/v1.3.0.rst
@@ -25,3 +25,5 @@ Fixes
   (:issue:`765`)
 * Make hash for `PersonName3` behave as expected, make `PersonName` objects
   immutable (:issue:`785`)
+* Fixed `generate_uid()` returning non-conformant UIDs when `prefix=None`
+  (:issue:`788`)

--- a/pydicom/tests/test_uid.py
+++ b/pydicom/tests/test_uid.py
@@ -1,6 +1,8 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Test suite for uid.py"""
 
+import uuid
+
 import pytest
 
 from pydicom.uid import UID, generate_uid, PYDICOM_ROOT_UID, JPEGLSLossy
@@ -56,6 +58,17 @@ class TestGenerateUID(object):
         rf = '1.2.826.0.1.3680043.8.498.87507166259346337659265156363895084463'
         assert uid == rf
         assert len(uid) == 64
+
+    def test_none(self):
+        """Test generate_uid() with None as a prefix."""
+        uid = generate_uid(prefix=None)
+        # Check prefix
+        assert '2.25.' == uid[:5]
+        # Check UUID suffix
+        as_uuid = uuid.UUID(int=int(uid[5:]))
+        assert isinstance(as_uuid, uuid.UUID)
+        assert as_uuid.version == 4
+        assert as_uuid.variant == uuid.RFC_4122
 
 
 class TestUID(object):

--- a/pydicom/tests/test_uid.py
+++ b/pydicom/tests/test_uid.py
@@ -60,7 +60,7 @@ class TestGenerateUID(object):
         assert len(uid) == 64
 
     def test_none(self):
-        """Test generate_uid() with None as a prefix."""
+        """Test generate_uid(None)."""
         uid = generate_uid(prefix=None)
         # Check prefix
         assert '2.25.' == uid[:5]
@@ -69,6 +69,13 @@ class TestGenerateUID(object):
         assert isinstance(as_uuid, uuid.UUID)
         assert as_uuid.version == 4
         assert as_uuid.variant == uuid.RFC_4122
+
+    def test_none_iterate(self):
+        """Test generate_uid(None) generates valid UIDs."""
+        # Generate random UIDs, if a bad method then should eventually fail
+        for ii in range(100000):
+            uid = generate_uid(None)
+            assert uid.is_valid
 
 
 class TestUID(object):

--- a/pydicom/uid.py
+++ b/pydicom/uid.py
@@ -250,9 +250,9 @@ def generate_uid(prefix=PYDICOM_ROOT_UID, entropy_srcs=None):
     ----------
     prefix : str or None
         The UID prefix to use when creating the UID. Default is the pydicom
-        root UID '1.2.826.0.1.3680043.8.498.'. If None then a value of '2.25.'
-        will be used (as described on `David Clunie's website
-        <http://www.dclunie.com/medical-image-faq/html/part2.html#UID>`_).
+        root UID '1.2.826.0.1.3680043.8.498.'. If None then a prefix of '2.25.'
+        will be used with the integer form of a UUID generated using the
+        UUID4 algorithm.
     entropy_srcs : list of str or None
         If a list of str, the prefix will be appended with a SHA512 hash of the
         list which means the result is deterministic and should make the
@@ -284,7 +284,9 @@ def generate_uid(prefix=PYDICOM_ROOT_UID, entropy_srcs=None):
     max_uid_len = 64
 
     if prefix is None:
-        prefix = '2.25.'
+        # UUID -> as 128-bit int -> max 39 characters long
+        return UID('2.25.{}'.format(uuid.uuid4().int))
+
 
     if len(prefix) > max_uid_len - 1:
         raise ValueError("The prefix must be less than 63 chars")

--- a/pydicom/uid.py
+++ b/pydicom/uid.py
@@ -254,15 +254,15 @@ def generate_uid(prefix=PYDICOM_ROOT_UID, entropy_srcs=None):
         will be used with the integer form of a UUID generated using the
         UUID4 algorithm.
     entropy_srcs : list of str or None
-        If a list of str, the prefix will be appended with a SHA512 hash of the
-        list which means the result is deterministic and should make the
-        original data unrecoverable. If None random data will be used
-        (default).
+        If `prefix` is not None, then the prefix will be appended with a
+        SHA512 hash of the list which means the result is deterministic and
+        should make the original data unrecoverable. If None random data will
+        be used (default).
 
     Returns
     -------
     pydicom.uid.UID
-        A 64 character DICOM UID.
+        A DICOM UID of up to 64 characters.
 
     Raises
     ------
@@ -275,19 +275,17 @@ def generate_uid(prefix=PYDICOM_ROOT_UID, entropy_srcs=None):
     >>> generate_uid()
     1.2.826.0.1.3680043.8.498.22463838056059845879389038257786771680
     >>> generate_uid(prefix=None)
-    2.25.12586835699909622925962004639368649121731805922235633382942
+    2.25.167161297070865690102504091919570542144
     >>> generate_uid(entropy_srcs=['lorem', 'ipsum'])
     1.2.826.0.1.3680043.8.498.87507166259346337659265156363895084463
     >>> generate_uid(entropy_srcs=['lorem', 'ipsum'])
     1.2.826.0.1.3680043.8.498.87507166259346337659265156363895084463
     """
-    max_uid_len = 64
-
     if prefix is None:
         # UUID -> as 128-bit int -> max 39 characters long
         return UID('2.25.{}'.format(uuid.uuid4().int))
 
-
+    max_uid_len = 64
     if len(prefix) > max_uid_len - 1:
         raise ValueError("The prefix must be less than 63 chars")
     if not re.match(RE_VALID_UID_PREFIX, prefix):


### PR DESCRIPTION
#### Reference Issue
Closes #788

#### What does this implement/fix? Explain your changes.
If `generate_uid(None)` then use the integer form of a UUID v4 to create the UID instead of a combination of UUID v1 and hashing.