### PR TITLE
[MRG] Added possibility to add tags to the private dictionary

### DIFF
--- a/doc/whatsnew/v1.3.0.rst
+++ b/doc/whatsnew/v1.3.0.rst
@@ -10,10 +10,15 @@ Changes
   Use ``dataelem.DataElement.VM`` instead.
 * ``dataelem.isStringOrStringList`` and ``dataelem.isString`` functions are
   removed
+* ``datadict.add_dict_entry`` and ``datadict.add_dict_entries`` now raise if
+  trying to add a private tag
 
 Enhancements
 ............
 
+* Added ``datadict.add_private_dict_entry`` and
+  ``datadict.add_private_dict_entries`` to add custom private tags
+  (:issue:`799`)
 * Added possibility to write into zip file using gzip (:issue:`753`)
 
 Fixes

--- a/pydicom/tests/test_dictionary.py
+++ b/pydicom/tests/test_dictionary.py
@@ -1,80 +1,136 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Test for datadict.py"""
 
-import unittest
+import pytest
+
+from pydicom import DataElement
 from pydicom.dataset import Dataset
 from pydicom.datadict import (keyword_for_tag, dictionary_description,
                               dictionary_has_tag, repeater_has_tag,
                               repeater_has_keyword, get_private_entry,
                               dictionary_VM, private_dictionary_VR,
-                              private_dictionary_VM)
+                              private_dictionary_VM, add_private_dict_entries,
+                              add_private_dict_entry)
 from pydicom.datadict import add_dict_entry, add_dict_entries
 
 
-class DictTests(unittest.TestCase):
-    def testTagNotFound(self):
+class TestDict(object):
+    def test_tag_not_found(self):
         """dicom_dictionary: CleanName returns blank string for unknown tag"""
-        self.assertTrue(keyword_for_tag(0x99991111) == "")
+        assert '' == keyword_for_tag(0x99991111)
 
-    def testRepeaters(self):
+    def test_repeaters(self):
         """dicom_dictionary: Tags with "x" return correct dict info........"""
-        self.assertEqual(dictionary_description(0x280400), 'Transform Label')
-        self.assertEqual(dictionary_description(0x280410),
-                         'Rows For Nth Order Coefficients')
+        assert 'Transform Label' == dictionary_description(0x280400)
+        assert ('Rows For Nth Order Coefficients' ==
+                dictionary_description(0x280410))
 
     def test_dict_has_tag(self):
         """Test dictionary_has_tag"""
-        self.assertTrue(dictionary_has_tag(0x00100010))
-        self.assertFalse(dictionary_has_tag(0x11110010))
+        assert dictionary_has_tag(0x00100010)
+        assert not dictionary_has_tag(0x11110010)
 
     def test_repeater_has_tag(self):
         """Test repeater_has_tag"""
-        self.assertTrue(repeater_has_tag(0x60000010))
-        self.assertTrue(repeater_has_tag(0x60020010))
-        self.assertFalse(repeater_has_tag(0x00100010))
+        assert repeater_has_tag(0x60000010)
+        assert repeater_has_tag(0x60020010)
+        assert not repeater_has_tag(0x00100010)
 
     def test_repeater_has_keyword(self):
         """Test repeater_has_keyword"""
-        self.assertTrue(repeater_has_keyword('OverlayData'))
-        self.assertFalse(repeater_has_keyword('PixelData'))
+        assert repeater_has_keyword('OverlayData')
+        assert not repeater_has_keyword('PixelData')
 
     def test_get_private_entry(self):
         """Test get_private_entry"""
         # existing entry
         entry = get_private_entry((0x0903, 0x0011), 'GEIIS PACS')
-        self.assertEqual('US', entry[0])  # VR
-        self.assertEqual('1', entry[1])  # VM
-        self.assertEqual('Significant Flag', entry[2])  # name
-        self.assertFalse(entry[3])  # is retired
+        assert 'US' == entry[0]  # VR
+        assert '1' == entry[1]  # VM
+        assert 'Significant Flag' == entry[2]  # name
+        assert not entry[3]  # is retired
 
         # existing entry in another slot
         entry = get_private_entry((0x0903, 0x1011), 'GEIIS PACS')
-        self.assertEqual('Significant Flag', entry[2])  # name
+        assert 'Significant Flag' == entry[2]  # name
 
         # non-existing entry
-        self.assertRaises(KeyError, get_private_entry,
-                          (0x0903, 0x0011), 'Nonexisting')
-        self.assertRaises(KeyError, get_private_entry,
-                          (0x0903, 0x0091), 'GEIIS PACS')
+        with pytest.raises(KeyError):
+            get_private_entry((0x0903, 0x0011), 'Nonexisting')
+        with pytest.raises(KeyError):
+            get_private_entry((0x0903, 0x0091), 'GEIIS PACS')
 
-    def testAddEntry(self):
+    def test_add_entry(self):
         """dicom_dictionary: Can add and use a single dictionary entry"""
-        add_dict_entry(0x10011001, "UL", "TestOne", "Test One")
-        add_dict_entry(0x10011002, "DS", "TestTwo", "Test Two", VM='3')
+        add_dict_entry(0x10021001, "UL", "TestOne", "Test One")
+        add_dict_entry(0x10021002, "DS", "TestTwo", "Test Two", VM='3')
         ds = Dataset()
         ds.TestOne = 'test'
         ds.TestTwo = ['1', '2', '3']
 
-    def testAddEntries(self):
+    def test_add_entry_raises_for_private_tag(self):
+        with pytest.raises(ValueError,
+                           match='Private tags cannot be '
+                                 'added using "add_dict_entries"'):
+            add_dict_entry(0x10011101, 'DS', 'Test One', 'Test One')
+
+    def test_add_entries(self):
         """dicom_dictionary: add and use a dict of new dictionary entries"""
         new_dict_items = {
-            0x10011001: ('UL', '1', "Test One", '', 'TestOne'),
-            0x10011002: ('DS', '3', "Test Two", '', 'TestTwo'),
-            }
+            0x10021001: ('UL', '1', "Test One", '', 'TestOne'),
+            0x10021002: ('DS', '3', "Test Two", '', 'TestTwo'),
+        }
         add_dict_entries(new_dict_items)
         ds = Dataset()
         ds.TestOne = 'test'
         ds.TestTwo = ['1', '2', '3']
+
+    def test_add_entries_raises_for_private_tags(self):
+        new_dict_items = {
+            0x10021001: ('UL', '1', 'Test One', '', 'TestOne'),
+            0x10011002: ('DS', '3', 'Test Two', '', 'TestTwo'),
+        }
+        with pytest.raises(ValueError, match='Private tags cannot be added '
+                                             'using "add_dict_entries"'):
+            add_dict_entries(new_dict_items)
+
+    def test_add_private_entry(self):
+        add_private_dict_entry('ACME 3.1', 0x10011101, 'DS', 'Test One', '3')
+        entry = get_private_entry((0x1001, 0x0001), 'ACME 3.1')
+        assert 'DS' == entry[0]  # VR
+        assert '3' == entry[1]  # VM
+        assert 'Test One' == entry[2]  # description
+
+    def test_add_private_entry_raises_for_non_private_tag(self):
+        with pytest.raises(ValueError,
+                           match='Non-private tags cannot be '
+                                 'added using "add_private_dict_entries"'):
+            add_private_dict_entry('ACME 3.1', 0x10021101, 'DS', 'Test One')
+
+    def test_add_private_entries(self):
+        """dicom_dictionary: add and use a dict of new dictionary entries"""
+        new_dict_items = {
+            0x10011001: ('SH', '1', "Test One",),
+            0x10011002: ('DS', '3', "Test Two", '', 'TestTwo'),
+        }
+        add_private_dict_entries('ACME 3.1', new_dict_items)
+        ds = Dataset()
+        ds[0x10010010] = DataElement(0x10010010, 'LO', 'ACME 3.1')
+        ds[0x10011001] = DataElement(0x10011001, 'SH', 'Test')
+        ds[0x10011002] = DataElement(0x10011002, 'DS', '1\\2\\3')
+
+        assert 'Test' == ds[0x10011001].value
+        assert [1, 2, 3] == ds[0x10011002].value
+
+    def test_add_private_entries_raises_for_non_private_tags(self):
+        new_dict_items = {
+            0x10021001: ('UL', '1', 'Test One', '', 'TestOne'),
+            0x10011002: ('DS', '3', 'Test Two', '', 'TestTwo'),
+        }
+        with pytest.raises(ValueError,
+                           match='Non-private tags cannot be '
+                                 'added using "add_private_dict_entries"'):
+            add_private_dict_entries('ACME 3.1', new_dict_items)
 
     def test_dictionary_VM(self):
         """Test dictionary_VM"""
@@ -93,7 +149,3 @@ class DictTests(unittest.TestCase):
     def test_private_dict_VM(self):
         """Test private_dictionary_VM"""
         assert private_dictionary_VM(0x00090000, 'ACUSON') == '1'
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
- datadict.add_dict_entry and datadict.add_dict_entries now raise if
  trying to add a private tag
- the new methods datadict.add_private_dict_entry/add_private_dict_entries
  likely raise if trying to add non-private entries
- see #799

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
