### PR TITLE
[MRG+1] Fix bug causing errors when loading from saved DicomDir

### DIFF
--- a/pydicom/dicomdir.py
+++ b/pydicom/dicomdir.py
@@ -52,8 +52,8 @@ class DicomDir(FileDataset):
             dataset,
             preamble,
             file_meta,
-            is_implicit_VR=True,
-            is_little_endian=True)
+            is_implicit_VR=is_implicit_VR,
+            is_little_endian=is_little_endian)
         self.parse_records()
 
     def parse_records(self):


### PR DESCRIPTION
This pull request fixes a bug in the DicomDir init method that always sets is_implict_VR and is_little_endian to True. This causes errors when saving a DicomDir and loading the new file, as discussed in #9 and [here](https://groups.google.com/forum/#!topic/pydicom/DVeqyvXxpzU).