### PR TITLE
[MRG] Fix JSON representation of ImageOrientationPatient (and MultiValue in general)

### DIFF
--- a/pydicom/multival.py
+++ b/pydicom/multival.py
@@ -60,7 +60,7 @@ class MultiValue(MutableSequence):
 
     def __str__(self):
         lines = [str(x) for x in self]
-        return "['" + "', '".join(lines) + "']"
+        return "[\"" + "\", \"".join(lines) + "\"]"
 
     __repr__ = __str__
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

`json.dumps()` uses the output of `__repr__` to encode objects, which
means that in order for JSON encoding to work, `__repr__` must produce
valid JSON if possible.

The string `__repr__` of all dicom values that are represented as a string
use double quotes which results in valid JSON.

The only exception in pydicom is `multival.MultiValue` which produces 
invalid JSON with single quotes.

This PR changes the `__repr__` of `MultiValue` to use double quotes.

We've experienced a similar issue before:
https://github.com/pydicom/pydicom/pull/235

Thanks!


