### PR TITLE
[MRG] Added handling of ambiguous tags in a sequence item

### DIFF
--- a/doc/whatsnew/v1.3.0.rst
+++ b/doc/whatsnew/v1.3.0.rst
@@ -33,3 +33,4 @@ Fixes
 * Fixed `generate_uid()` returning non-conformant UIDs when `prefix=None`
   (:issue:`788`)
 * Avoid exception if reading from empty file (:issue:`810`)
+* Correctly handle elements with ambiguous VR in sequence items (:issue:`804`)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -198,7 +198,7 @@ class Dataset(object):
         self.is_implicit_VR = None
 
         # the parent data set, if this dataset is a sequence item
-        self.parent_dataset = None
+        self.parent = None
 
     def __enter__(self):
         """Method invoked on entry to a with statement."""
@@ -561,7 +561,9 @@ class Dataset(object):
             data_elem = self[tag]
             value = data_elem.value
             if data_elem.VR == 'SQ':
-                value.dataset = self
+                # let a sequence know its parent dataset, as sequence items
+                # may need parent dataset tags to resolve ambiguous tags
+                value.parent = self
             return value
 
     @property
@@ -1173,7 +1175,7 @@ class Dataset(object):
                 VR = dictionary_VR(tag)
                 data_element = DataElement(tag, VR, value)
                 if VR == 'SQ':
-                    data_element.dataset = self
+                    data_element.parent = self
             else:
                 # already have this data_element, just changing its value
                 data_element = self[tag]

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1175,6 +1175,9 @@ class Dataset(object):
                 VR = dictionary_VR(tag)
                 data_element = DataElement(tag, VR, value)
                 if VR == 'SQ':
+                    # let a sequence know its parent dataset to pass it
+                    # to its items, who may need parent dataset tags
+                    # to resolve ambiguous tags
                     data_element.parent = self
             else:
                 # already have this data_element, just changing its value

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -197,6 +197,9 @@ class Dataset(object):
         self.is_little_endian = None
         self.is_implicit_VR = None
 
+        # the parent data set, if this dataset is a sequence item
+        self.parent_dataset = None
+
     def __enter__(self):
         """Method invoked on entry to a with statement."""
         return self
@@ -555,7 +558,11 @@ class Dataset(object):
             # Try the base class attribute getter (fix for issue 332)
             return super(Dataset, self).__getattribute__(name)
         else:
-            return self[tag].value
+            data_elem = self[tag]
+            value = data_elem.value
+            if data_elem.VR == 'SQ':
+                value.dataset = self
+            return value
 
     @property
     def _character_set(self):
@@ -1165,6 +1172,8 @@ class Dataset(object):
                 # don't have this tag yet->create the data_element instance
                 VR = dictionary_VR(tag)
                 data_element = DataElement(tag, VR, value)
+                if VR == 'SQ':
+                    data_element.dataset = self
             else:
                 # already have this data_element, just changing its value
                 data_element = self[tag]

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -69,6 +69,9 @@ def _correct_ambiguous_vr_element(elem, ds, is_little_endian):
         # US if PixelRepresentation value is 0x0000, else SS
         #   For references, see the list at
         #   https://github.com/darcymason/pydicom/pull/298
+        # PixelRepresentation is usually set in the root dataset
+        while 'PixelRepresentation' not in ds and ds.parent_dataset:
+            ds = ds.parent_dataset
         if ds.PixelRepresentation == 0:
             elem.VR = 'US'
             byte_type = 'H'

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -70,8 +70,8 @@ def _correct_ambiguous_vr_element(elem, ds, is_little_endian):
         #   For references, see the list at
         #   https://github.com/darcymason/pydicom/pull/298
         # PixelRepresentation is usually set in the root dataset
-        while 'PixelRepresentation' not in ds and ds.parent_dataset:
-            ds = ds.parent_dataset
+        while 'PixelRepresentation' not in ds and ds.parent:
+            ds = ds.parent
         if ds.PixelRepresentation == 0:
             elem.VR = 'US'
             byte_type = 'H'

--- a/pydicom/sequence.py
+++ b/pydicom/sequence.py
@@ -43,12 +43,32 @@ class Sequence(MultiValue):
         if isinstance(iterable, Dataset):
             raise TypeError('The Sequence constructor requires an iterable')
 
+        self._dataset = None
+
         # If no inputs are provided, we create an empty Sequence
         if not iterable:
             iterable = list()
 
         # validate_dataset is used as a pseudo type_constructor
         super(Sequence, self).__init__(validate_dataset, iterable)
+
+    @property
+    def dataset(self):
+        """Return the parent dataset."""
+        return self._dataset
+
+    @dataset.setter
+    def dataset(self, value):
+        """Set the parent dataset and pass it to all items."""
+        if value != self._dataset:
+            self._dataset = value
+            for item in self._list:
+                item.parent_dataset = self._dataset
+
+    def __setitem__(self, i, val):
+        """Set the parent dataset to the new sequence item"""
+        super(Sequence, self).__setitem__(i, val)
+        val.parent_dataset = self._dataset
 
     def __str__(self):
         """String description of the Sequence."""

--- a/pydicom/sequence.py
+++ b/pydicom/sequence.py
@@ -43,7 +43,8 @@ class Sequence(MultiValue):
         if isinstance(iterable, Dataset):
             raise TypeError('The Sequence constructor requires an iterable')
 
-        self._dataset = None
+        # the parent dataset
+        self._parent = None
 
         # If no inputs are provided, we create an empty Sequence
         if not iterable:
@@ -53,22 +54,22 @@ class Sequence(MultiValue):
         super(Sequence, self).__init__(validate_dataset, iterable)
 
     @property
-    def dataset(self):
+    def parent(self):
         """Return the parent dataset."""
-        return self._dataset
+        return self._parent
 
-    @dataset.setter
-    def dataset(self, value):
+    @parent.setter
+    def parent(self, value):
         """Set the parent dataset and pass it to all items."""
-        if value != self._dataset:
-            self._dataset = value
+        if value != self._parent:
+            self._parent = value
             for item in self._list:
-                item.parent_dataset = self._dataset
+                item.parent = self._parent
 
     def __setitem__(self, i, val):
         """Set the parent dataset to the new sequence item"""
         super(Sequence, self).__setitem__(i, val)
-        val.parent_dataset = self._dataset
+        val.parent = self._parent
 
     def __str__(self):
         """String description of the Sequence."""

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -864,6 +864,47 @@ class TestCorrectAmbiguousVR(object):
         assert ds[0x00283002].VR == 'US'
         assert ds.LUTDescriptor == [1, 0]
 
+    def test_ambiguous_element_in_sequence_explicit(self):
+        """Test that writing a sequence with an ambiguous element
+        as explicit transfer syntax works."""
+        # regression test for #804
+        ds = Dataset()
+        ds.PixelRepresentation = 0
+        ds.ModalityLUTSequence = [Dataset()]
+        ds.ModalityLUTSequence[0].LUTDescriptor = [0, 0, 16]
+        ds.ModalityLUTSequence[0].LUTExplanation = None
+        ds.ModalityLUTSequence[0].ModalityLUTType = 'US'  # US = unspecified
+        ds.ModalityLUTSequence[0].LUTData = b'\x0000\x149a\x1f1c\c2637'
+
+        ds.is_little_endian = True
+        ds.is_implicit_VR = False
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+
+        ds = dcmread(fp, force=True)
+        assert 'US' == ds.ModalityLUTSequence[0][0x00283002].VR
+
+    def test_ambiguous_element_in_sequence_implicit(self):
+        """Test that reading a sequence with an ambiguous element
+        from a file with implicit transfer syntax works."""
+        # regression test for #804
+        ds = Dataset()
+        ds.PixelRepresentation = 0
+        ds.ModalityLUTSequence = [Dataset()]
+        ds.ModalityLUTSequence[0].LUTDescriptor = [0, 0, 16]
+        ds.ModalityLUTSequence[0].LUTExplanation = None
+        ds.ModalityLUTSequence[0].ModalityLUTType = 'US'  # US = unspecified
+        ds.ModalityLUTSequence[0].LUTData = b'\x0000\x149a\x1f1c\c2637'
+
+        ds.is_little_endian = True
+        ds.is_implicit_VR = True
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        # we first have to access the value to trigger correcting the VR
+        assert 16 == ds.ModalityLUTSequence[0].LUTDescriptor[2]
+        assert 'US' == ds.ModalityLUTSequence[0][0x00283002].VR
+
 
 class TestCorrectAmbiguousVRElement(object):
     """Test filewriter.correct_ambiguous_vr_element"""

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -874,7 +874,7 @@ class TestCorrectAmbiguousVR(object):
         ds.ModalityLUTSequence[0].LUTDescriptor = [0, 0, 16]
         ds.ModalityLUTSequence[0].LUTExplanation = None
         ds.ModalityLUTSequence[0].ModalityLUTType = 'US'  # US = unspecified
-        ds.ModalityLUTSequence[0].LUTData = b'\x0000\x149a\x1f1c\c2637'
+        ds.ModalityLUTSequence[0].LUTData = b'\x0000\x149a\x1f1c\xc2637'
 
         ds.is_little_endian = True
         ds.is_implicit_VR = False
@@ -894,7 +894,7 @@ class TestCorrectAmbiguousVR(object):
         ds.ModalityLUTSequence[0].LUTDescriptor = [0, 0, 16]
         ds.ModalityLUTSequence[0].LUTExplanation = None
         ds.ModalityLUTSequence[0].ModalityLUTType = 'US'  # US = unspecified
-        ds.ModalityLUTSequence[0].LUTData = b'\x0000\x149a\x1f1c\c2637'
+        ds.ModalityLUTSequence[0].LUTData = b'\x0000\x149a\x1f1c\xc2637'
 
         ds.is_little_endian = True
         ds.is_implicit_VR = True


### PR DESCRIPTION
- set the parent dataset in sequences and sequence items
- use the parent dataset to access top-level tags
- fixes #804

#### Any other comments?
I'm not really happy with this solution, but couldn't come up with a better one so far.
Fixing the writing was easier, but the reading part (which was the original issue) is a bit less straightforward.
Note that the issue has been seen elsewhere (while receiving and reading Little Endian datasets via pynetdicom), so I think this has to be fixed. If someone has a better idea though...
