### PR TITLE
[MRG+1] Do not try to seek back in an empty file

### DIFF
--- a/doc/whatsnew/v1.3.0.rst
+++ b/doc/whatsnew/v1.3.0.rst
@@ -32,3 +32,4 @@ Fixes
   immutable (:issue:`785`)
 * Fixed `generate_uid()` returning non-conformant UIDs when `prefix=None`
   (:issue:`788`)
+* Avoid exception if reading from empty file (:issue:`810`)

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -689,7 +689,8 @@ def read_partial(fileobj, stop_when=None, defer_size=None,
 
     # Check to see if there's anything left to read
     peek = fileobj.read(1)
-    fileobj.seek(-1, 1)
+    if peek != b'':
+        fileobj.seek(-1, 1)
 
     # `filobj` should be positioned at the start of the dataset by this point.
     # Ensure we have appropriate values for `is_implicit_VR` and

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -672,6 +672,14 @@ class ReaderTests(unittest.TestCase):
         self.assertEqual(ds.file_meta, Dataset())
         self.assertEqual(ds[:], Dataset())
 
+    def test_empty_file(self):
+        """Test reading no elements from file produces empty Dataset"""
+        with tempfile.NamedTemporaryFile() as f:
+            ds = dcmread(f, force=True)
+            self.assertTrue(ds.preamble is None)
+            self.assertEqual(ds.file_meta, Dataset())
+            self.assertEqual(ds[:], Dataset())
+
     def test_dcmread_does_not_raise(self):
         """Test that reading from DicomBytesIO does not raise on EOF.
         Regression test for #358."""


### PR DESCRIPTION
- fixes #810

#### Any other comments?
This is the easy fix as proposed by the author of the issue.