### PR TITLE
[MRG] Replace invalid encoding by default encoding

### DIFF
--- a/doc/whatsnew/v1.3.0.rst
+++ b/doc/whatsnew/v1.3.0.rst
@@ -33,3 +33,5 @@ Fixes
 * Fixed `generate_uid()` returning non-conformant UIDs when `prefix=None`
   (:issue:`788`)
 * Avoid exception if reading from empty file (:issue:`810`)
+* An invalid encoding is now replaced by the default encoding, if
+  ``config.enforce_valid_values`` is not set (:issue:`815`)

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -125,15 +125,24 @@ def decode_string(value, encodings, delimiters):
     """
     # shortcut for the common case - no escape sequences present
     if ESC not in value:
+        first_encoding = encodings[0]
         try:
-            return value.decode(encodings[0])
+            return value.decode(first_encoding)
+        except LookupError:
+            if config.enforce_valid_values:
+                raise
+            warnings.warn(u"Unknown encoding '{}' - "
+                          u"using default encoding instead"
+                          .format(first_encoding))
+            first_encoding = default_encoding
+            return value.decode(first_encoding)
         except UnicodeError:
             if config.enforce_valid_values:
                 raise
-            warnings.warn(u"Failed to decode byte string with encoding {} - "
+            warnings.warn(u"Failed to decode byte string with encoding '{}' - "
                           u"using replacement characters in decoded "
-                          u"string".format(encodings[0]))
-            return value.decode(encodings[0], errors='replace')
+                          u"string".format(first_encoding))
+            return value.decode(first_encoding, errors='replace')
 
     # Each part of the value that starts with an escape sequence is decoded
     # separately. If it starts with an escape sequence, the

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -100,6 +100,26 @@ class TestCharset(object):
         ds.decode()
         assert u'CompressedSamples^CT1' == ds.PatientName
 
+    def test_invalid_character_set(self):
+        """charset: replace invalid encoding with default encoding"""
+        ds = dcmread(get_testdata_files("CT_small.dcm")[0])
+        ds.read_encoding = None
+        ds.SpecificCharacterSet = 'Unsupported'
+        with pytest.warns(UserWarning,
+                          match=u"Unknown encoding 'Unsupported' "
+                                u"- using default encoding instead"):
+            ds.decode()
+            assert u'CompressedSamples^CT1' == ds.PatientName
+
+    def test_invalid_character_set_enforce_valid(self):
+        """charset: raise on invalid encoding"""
+        config.enforce_valid_values = True
+        ds = dcmread(get_testdata_files("CT_small.dcm")[0])
+        ds.read_encoding = None
+        ds.SpecificCharacterSet = 'Unsupported'
+        with pytest.raises(LookupError, match='unknown encoding: Unsupported'):
+            ds.decode()
+
     def test_decoding_with_specific_tags(self):
         """Decoding is correctly applied even if  Specific Character Set
         is not in specific tags..."""
@@ -126,8 +146,8 @@ class TestCharset(object):
         elem = DataElement(0x00100010, 'PN',
                            b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
 
-        with pytest.warns(UserWarning, match='Failed to decode byte string '
-                                             'with encoding UTF8'):
+        with pytest.warns(UserWarning, match="Failed to decode byte string "
+                                             "with encoding 'UTF8'"):
             pydicom.charset.decode(elem, ['ISO_IR 192'])
             assert u'���������' == elem.value
 
@@ -235,9 +255,11 @@ class TestCharset(object):
             # make sure no warning is issued for the correct value
             assert 1 == len(w)
 
-        # not patched incorrect encoding raises
+        # not patched incorrect encoding is replaced by default encoding
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xc3\xa9r\xc3\xb4me')
-        with pytest.raises(LookupError):
+        with pytest.warns(UserWarning,
+                          match=u"Unknown encoding 'ISOIR 192' - "
+                                u"using default encoding instead"):
             pydicom.charset.decode(elem, ['ISOIR 192'])
 
         # Python encoding also can be used directly


### PR DESCRIPTION
- only raise if config.enforce_valid_values is set
- fixes #815

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
