### PR TITLE
[MRG+1] Check really used implicit/explicit VR before reading a data set

### DIFF
--- a/doc/whatsnew/v1.3.0.rst
+++ b/doc/whatsnew/v1.3.0.rst
@@ -20,6 +20,8 @@ Enhancements
   ``datadict.add_private_dict_entries`` to add custom private tags
   (:issue:`799`)
 * Added possibility to write into zip file using gzip (:issue:`753`)
+* Added handling of incorrect transfer syntax (explicit vs implicit)
+  (:issue:`820`)
 
 Fixes
 .....


### PR DESCRIPTION
- if the expected representation do not match the used one, a warning
  is issued, or an exception raised if config.enforce_valid_values is set
- see #819 and #820

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
