### PR TITLE
Add option to create Tag instances by DICOM keyword

### DIFF
--- a/doc/whatsnew/v1.3.0.rst
+++ b/doc/whatsnew/v1.3.0.rst
@@ -20,6 +20,7 @@ Enhancements
   ``datadict.add_private_dict_entries`` to add custom private tags
   (:issue:`799`)
 * Added possibility to write into zip file using gzip (:issue:`753`)
+* Added creation of Tag instances by DICOM keyword, e.g Tag("PatientName")
 
 Fixes
 .....

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -50,6 +50,7 @@ def Tag(arg, arg2=None):
     * Tag(0x10, 0x15)
     * Tag(2341, 0x10)
     * Tag('0xFE', '0x0010')
+    * Tag("PatientName")
 
     Parameters
     ----------
@@ -94,11 +95,19 @@ def Tag(arg, arg2=None):
 
     # Single str parameter
     elif isinstance(arg, (str, compat.text_type)):
-        long_value = int(arg, 16)
-        if long_value > 0xFFFFFFFF:
-            raise OverflowError("Tags are limited to 32-bit length; tag {0!r}"
-                                .format(long_value))
-
+        try:
+            long_value = int(arg, 16)
+            if long_value > 0xFFFFFFFF:
+                raise OverflowError("Tags are limited to 32-bit length; "
+                                    "tag {0!r}"
+                                    .format(long_value))
+        except ValueError:
+            # Try a DICOM keyword
+            from pydicom.datadict import tag_for_keyword
+            long_value = tag_for_keyword(arg)
+            if long_value is None:
+                raise ValueError("'{}' is not a valid int or DICOM keyword"
+                                 .format(arg))
     # Single int parameter
     else:
         long_value = arg

--- a/pydicom/tests/test_tag.py
+++ b/pydicom/tests/test_tag.py
@@ -333,12 +333,13 @@ class TestTag(object):
         assert Tag('0x2000') == BaseTag(0x00002000)
         assert Tag('15') == BaseTag(0x00000015)
         assert Tag('0xF') == BaseTag(0x0000000F)
+        assert Tag("PatientName") == BaseTag(0x00100010)
 
         # Must be 32-bit
         pytest.raises(OverflowError, Tag, '0xFFFFFFFF1')
         # Must be positive
         pytest.raises(ValueError, Tag, '-0x01')
-        # Must be numeric str
+        # Must be numeric str or DICOM keyword
         pytest.raises(ValueError, Tag, 'hello')
 
     def test_tag_double_str(self):


### PR DESCRIPTION
We've pointed people to `pydicom.datadict.tag_for_keyword` several times recently.  It occurred to me that tag creation by keyword could easily be added to the Tag class.

This allows, e.g.:
```python
>>> from pydicom.tag import Tag
>>> Tag("WaveformData")
(5400, 1010)
```

