### PR TITLE
[WIP] Initial RawDataElement handling

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -342,12 +342,6 @@ class Dataset(object):
         # known private creator blocks
         self._private_blocks = {}
 
-        # for tag, data_elem in self._dict.items():
-        #     if not isinstance(data_elem, DataElement):
-        #         # Don't load the element if it has been deferred
-        #         if data_elem.value is not None:
-        #             self._initial_dataelement_handling(tag, data_elem)
-
     def __enter__(self):
         """Method invoked on entry to a with statement."""
         return self

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -342,11 +342,11 @@ class Dataset(object):
         # known private creator blocks
         self._private_blocks = {}
 
-        for tag, data_elem in self._dict.items():
-            if not isinstance(data_elem, DataElement):
-                # Don't load the element if it has been deferred
-                if data_elem.value is not None:
-                    self._initial_dataelement_handling(tag, data_elem)
+        # for tag, data_elem in self._dict.items():
+        #     if not isinstance(data_elem, DataElement):
+        #         # Don't load the element if it has been deferred
+        #         if data_elem.value is not None:
+        #             self._initial_dataelement_handling(tag, data_elem)
 
     def __enter__(self):
         """Method invoked on entry to a with statement."""

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1,6 +1,7 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Tests for dataset.py"""
 
+import os
 import unittest
 
 import pytest
@@ -67,6 +68,26 @@ class DatasetTests(unittest.TestCase):
             [msg_from_gdcm, msg_from_numpy, msg_from_pillow]) + ")"
         with pytest.raises(AttributeError, match=msg):
             ds.pixel_array
+
+    def test_for_stray_raw_data_element(self):
+        dataset = Dataset()
+        dataset.PatientName = 'MacDonald^George'
+        filename = 'test.dcm'
+        try:
+            pydicom.write_file(filename, dataset)
+
+            ds1 = pydicom.dcmread(filename, force=True)
+            ds2 = pydicom.dcmread(filename, force=True)
+
+            self.assertEqual(ds1, ds2)
+
+            ds1.PatientName
+            self.assertEqual(ds1, ds2)
+
+            ds2.PatientName
+            self.assertEqual(ds1, ds2)
+        finally:
+            os.remove(filename)
 
     def test_attribute_error_in_property_correct_debug(self):
         """Test AttributeError in property raises correctly."""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Since version 1.2.1 of pydicom the following weird issue has occured:

```python
from copy import copy
import pydicom

dataset = pydicom.Dataset()
dataset.PatientName = 'MacDonald^George'
filename = 'test.dcm'
pydicom.write_file(filename, dataset)

ds1 = pydicom.dcmread(filename, force=True)
ds2 = pydicom.dcmread(filename, force=True)

ds1 == ds2  # True

ds1.PatientName
ds1 == ds2  # False in pydicom >= 1.2.1, True in pydicom <= 1.2.0.

ds2.PatientName
ds1 == ds2  # True
```

Discussion of the issue cropped up within `pymedphys` over at https://github.com/pymedphys/pymedphys/issues/182. Credit to @Centrus007 for doing most of the work.


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

It appears like when the change from dict inherited `Dataset` to dict wrapped `Dataset` the logic that is within `__getattr__` that converts `RawDataElement` to `DataElement` is no longer being run on object initialisation.

This fixes this by explicitly running this portion of the logic at the end of the `__init__` method.

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->

I'm more than happy for this not to be the fix. I'm not sure how to solve the test failures, so likely someone else will need to come in and do it quite a bit differently.