### PR TITLE
[MRG] new dataset test with numpy

### DIFF
--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -5,6 +5,8 @@ import unittest
 
 import pytest
 
+import numpy as np
+
 import pydicom
 from pydicom import compat
 from pydicom.data import get_testdata_files
@@ -67,6 +69,28 @@ class DatasetTests(unittest.TestCase):
             [msg_from_gdcm, msg_from_numpy, msg_from_pillow]) + ")"
         with pytest.raises(AttributeError, match=msg):
             ds.pixel_array
+
+    def test_works_as_expected_within_numpy_array(self):
+        """Test Dataset within a numpy array"""
+        dataset = Dataset()
+        patient_name = 'MacDonald^George'
+
+        dataset.PatientName = patient_name
+
+        filepaths = [
+            DicomBytesIO()
+            for _ in range(2)
+        ]
+
+        for filepath in filepaths:
+            pydicom.dcmwrite(filepath, dataset)
+
+        array_of_datasets = np.array([
+            pydicom.dcmread(filepath, force=True)
+            for filepath in filepaths
+        ])
+
+        self.assertEqual(array_of_datasets[0].PatientName, patient_name)
 
     def test_attribute_error_in_property_correct_debug(self):
         """Test AttributeError in property raises correctly."""

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -82,15 +82,19 @@ class DatasetTests(unittest.TestCase):
             for _ in range(2)
         ]
 
-        for filepath in filepaths:
-            pydicom.dcmwrite(filepath, dataset)
+        try:
+            for filepath in filepaths:
+                pydicom.dcmwrite(filepath, dataset)
 
-        array_of_datasets = np.array([
-            pydicom.dcmread(filepath, force=True)
-            for filepath in filepaths
-        ])
+            array_of_datasets = np.array([
+                pydicom.dcmread(filepath, force=True)
+                for filepath in filepaths
+            ])
 
-        self.assertEqual(array_of_datasets[0].PatientName, patient_name)
+            self.assertEqual(array_of_datasets[0].PatientName, patient_name)
+        finally:
+            for filepath in filepaths:
+                filepath.close()
 
     def test_attribute_error_in_property_correct_debug(self):
         """Test AttributeError in property raises correctly."""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

##### Version 1.2.0

```python
Python 3.7.1 | packaged by conda-forge | (default, Feb 18 2019, 01:42:00) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.2.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import pydicom; from pydicom import Dataset; from pydicom.filebase im
   ...: port DicomBytesIO; import numpy as np                                

In [2]: pydicom.__version__                                                  
Out[2]: '1.2.0'

In [3]:         dataset = Dataset() 
   ...:         patient_name = 'MacDonald^George' 
   ...:  
   ...:         dataset.PatientName = patient_name 
   ...:  
   ...:         filepaths = [ 
   ...:             DicomBytesIO() 
   ...:             for _ in range(2) 
   ...:         ] 
   ...:  
   ...:         for filepath in filepaths: 
   ...:             pydicom.dcmwrite(filepath, dataset) 
   ...:  
   ...:         array_of_datasets = np.array([ 
   ...:             pydicom.dcmread(filepath, force=True) 
   ...:             for filepath in filepaths 
   ...:         ]) 
   ...:  
   ...:         array_of_datasets[0].PatientName == patient_name             
Out[3]: True

```

##### Version 1.2.1

```python
Python 3.7.1 | packaged by conda-forge | (default, Feb 18 2019, 01:42:00) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.2.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import pydicom; from pydicom import Dataset; from pydicom.filebase im
   ...: port DicomBytesIO; import numpy as np                                

In [2]: pydicom.__version__                                                  
Out[2]: '1.2.1'

In [3]:         dataset = Dataset() 
   ...:         patient_name = 'MacDonald^George' 
   ...:  
   ...:         dataset.PatientName = patient_name 
   ...:  
   ...:         filepaths = [ 
   ...:             DicomBytesIO() 
   ...:             for _ in range(2) 
   ...:         ] 
   ...:  
   ...:         for filepath in filepaths: 
   ...:             pydicom.dcmwrite(filepath, dataset) 
   ...:  
   ...:         array_of_datasets = np.array([ 
   ...:             pydicom.dcmread(filepath, force=True) 
   ...:             for filepath in filepaths 
   ...:         ]) 
   ...:  
   ...:         array_of_datasets[0].PatientName == patient_name             
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-3-a89d33fd229c> in <module>
     14 array_of_datasets = np.array([
     15     pydicom.dcmread(filepath, force=True)
---> 16     for filepath in filepaths
     17 ])
     18 

~/.miniconda/lib/python3.7/site-packages/pydicom/dataset.py in __getitem__(self, key)
    598         else:
    599             tag = Tag(key)
--> 600         data_elem = self.tags[tag]
    601 
    602         if isinstance(data_elem, DataElement):

KeyError: (0000, 0000)
```

This is actually a different error to what I saw with numpy originally, if the KeyError can pass, then there is also another issue with numpy itself, I'm just struggling to replicate it at the moment.



#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

This is just the test to show the issue.

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->

See related issues:

https://github.com/pydicom/pydicom/issues/765
https://github.com/pydicom/pydicom/pull/834
https://github.com/pydicom/pydicom/pull/835
https://github.com/pymedphys/pymedphys/issues/182

And 1.2.0 --> 1.2.1 diff:

https://github.com/pydicom/pydicom/compare/v1.2.0...v1.2.1