### PR TITLE
[MRG] Do not raise on unneeded tags with ambiguous VR

### DIFF
--- a/doc/whatsnew/v1.3.0.rst
+++ b/doc/whatsnew/v1.3.0.rst
@@ -28,7 +28,9 @@ Enhancements
 
 Fixes
 .....
-
+* Do not raise while resolving an ambiguous VR dependent on
+  `PixelRepresentation` if both `PixelRepresentation` and `PixelData` are
+  not present (:issue:`838`)
 * Raise exception with specific message if value is too large to be written
   in explicit transfer syntax (:issue:`757`)
 * Do not derive `Dataset` from `dict` - fixes behavior in newer Python versions

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -72,7 +72,10 @@ def _correct_ambiguous_vr_element(elem, ds, is_little_endian):
         # PixelRepresentation is usually set in the root dataset
         while 'PixelRepresentation' not in ds and ds.parent:
             ds = ds.parent
-        if ds.PixelRepresentation == 0:
+        # if no pixel data is present, none if these tags is used,
+        # so we can just ignore a missing PixelRepresentation in this case
+        if ('PixelRepresentation' not in ds and 'PixelData' not in ds or
+                ds.PixelRepresentation == 0):
             elem.VR = 'US'
             byte_type = 'H'
         else:

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -671,9 +671,15 @@ class TestCorrectAmbiguousVR(object):
         assert 1 == ds.SmallestValidPixelValue
         assert 'SS' == ds[0x00280104].VR
 
-        # If no PixelRepresentation AttributeError shall be raised
+        # If no PixelRepresentation and no PixelData is present 'US' is set
         ref_ds = Dataset()
         ref_ds.SmallestValidPixelValue = b'\x00\x01'  # Big endian 1
+        ds = correct_ambiguous_vr(deepcopy(ref_ds), True)
+        assert 'US' == ds[0x00280104].VR
+
+        # If no PixelRepresentation but PixelData is present
+        # AttributeError shall be raised
+        ref_ds.PixelData = b'123'
         with pytest.raises(AttributeError,
                            match=r"Failed to resolve ambiguous VR for tag "
                                  r"\(0028, 0104\):.* 'PixelRepresentation'"):
@@ -697,9 +703,14 @@ class TestCorrectAmbiguousVR(object):
         assert [256, 1, 16] == ds.LUTDescriptor
         assert 'SS' == ds[0x00283002].VR
 
-        # If no PixelRepresentation AttributeError shall be raised
+        # If no PixelRepresentation and no PixelData is present 'US' is set
         ref_ds = Dataset()
         ref_ds.LUTDescriptor = b'\x01\x00\x00\x01\x00\x10'
+        ds = correct_ambiguous_vr(deepcopy(ref_ds), True)
+        assert 'US' == ds[0x00283002].VR
+
+        # If no PixelRepresentation AttributeError shall be raised
+        ref_ds.PixelData = b'123'
         with pytest.raises(AttributeError,
                            match=r"Failed to resolve ambiguous VR for tag "
                                  r"\(0028, 3002\):.* 'PixelRepresentation'"):
@@ -928,6 +939,13 @@ class TestCorrectAmbiguousVRElement(object):
         """Test correct ambiguous US/SS element"""
         ds = Dataset()
         ds.PixelPaddingValue = b'\xfe\xff'
+        out = correct_ambiguous_vr_element(ds[0x00280120], ds, True)
+        # assume US if PixelData is not set
+        assert 'US' == out.VR
+
+        ds = Dataset()
+        ds.PixelPaddingValue = b'\xfe\xff'
+        ds.PixelData = b'3456'
         with pytest.raises(AttributeError,
                            match=r"Failed to resolve ambiguous VR for tag "
                                  r"\(0028, 0120\):.* 'PixelRepresentation'"):


### PR DESCRIPTION
- do not raise while resolving an ambiguous VR
  dependent on `PixelRepresentation` if both `PixelRepresentation`
  and `PixelData` are not present
- closes #838

Note that I didn't issue a warning in this case intentionally, as the actual warning should be that the given tag is not used (or not expected) here. As we generally do not warn about this kind of situations (and this would come up only in the case of ImplicitVR) I think no warning is needed here.

#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
