### PR TITLE
Typo in test_data/README.txt test_SR.dcm -> test-SR.dcm

### DIFF
--- a/pydicom/data/test_files/README.txt
+++ b/pydicom/data/test_files/README.txt
@@ -93,7 +93,7 @@ chr*.dcm
   * from http://www.dclunie.com/images/charset/SCS*
   * downsized to 32x32 since pixel data is irrelevant for these (test pattern only)
 
-test_SR.dcm
+test-SR.dcm
   * from ftp://ftp.dcmtk.org/pub/dicom/offis/software/dscope/dscope360/support/srdoc103.zip, file "test.dcm"
   * Structured Reporting example, many levels of nesting
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The README.txt file in the test data directory lists `test_SR.dcm` as an example file, but in fact the file is called `test-SR.dcm` (NB hyphen vs underscore). This is a potential cause of minor confusion for users and developers.

This single-character change fixes this to make the README consistent with the actual filename

