### PR TITLE
[MRG] Changed handling of invalid encodings for multi-value encodings

### DIFF
--- a/doc/whatsnew/v1.3.0.rst
+++ b/doc/whatsnew/v1.3.0.rst
@@ -29,6 +29,8 @@ Enhancements
 
 Fixes
 .....
+* Correctly handle encoding errors where not the first encoding is invalid
+  (:issue:`850`)
 * Do not raise while resolving an ambiguous VR dependent on
   `PixelRepresentation` if both `PixelRepresentation` and `PixelData` are
   not present (:issue:`838`)

--- a/doc/whatsnew/v1.3.0.rst
+++ b/doc/whatsnew/v1.3.0.rst
@@ -29,8 +29,8 @@ Enhancements
 
 Fixes
 .....
-* Correctly handle encoding errors where not the first encoding is invalid
-  (:issue:`850`)
+* Correctly handle encoding errors when any of the encodings are invalid
+  (not just the first) (:issue:`850`)
 * Do not raise while resolving an ambiguous VR dependent on
   `PixelRepresentation` if both `PixelRepresentation` and `PixelData` are
   not present (:issue:`838`)


### PR DESCRIPTION
- the encodings are checked and replaced one by one
- invalid encodings are not handled as Python encodings,
  if they are not valid encodings
- all invalid encodings are replaced by standard encoding
  if config.enforce_valid_values is not set
- see #850

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
<!--
Please summarize the key points of the reference issue, problem or contribution
to facilitate reviewing task. Of course reviewers can always refer to the
original issue but facilitating the reviewing process is much appreciated.
-->

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
