### PR TITLE
[MRG] Fix jis-x-0201 characters encoding (#856)

### DIFF
--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -250,9 +250,10 @@ def _get_escape_sequence_for_encoding(encoding, encoded=None):
         if encoded is None:
             return ESC_ISO_IR_14
 
-        first_byte = encoded[0]
-        if isinstance(encoded, str):
-            first_byte = ord(first_byte)
+        if not in_py2:
+            first_byte = encoded[0]
+        else:
+            first_byte = ord(encoded[0])
         if 0x80 <= first_byte:
             return ESC_ISO_IR_13
 
@@ -537,7 +538,8 @@ def _encode_string_parts(value, encodings):
                     best_encoding = encoding
         # none of the given encodings can encode the first character - give up
         if max_index == 0:
-            raise ValueError()
+            raise ValueError("None of the given encodings can encode the "
+                             "first character")
 
         # encode the part that can be encoded with the found encoding
         encoded_part = _encode_string_impl(unencoded_part[:max_index],

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -168,8 +168,12 @@ def _encode_to_jis_x_0208(value, errors='strict'):
         If errors is set to 'strict' and `value` could not be encoded with
         JIX X 0208.
     """
+
     encoded = value.encode('iso2022_jp', errors=errors)
-    if encoded[-3:] == ENCODINGS_TO_CODES[default_encoding]:
+
+    # If errors is not strict, this function is used in fallback.
+    # So keep the tail escape sequence of encoded for backward compatibility.
+    if encoded[-3:] == ENCODINGS_TO_CODES[default_encoding] and errors == 'strict':
         encoded = encoded[:-3]
     return encoded
 

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -140,7 +140,12 @@ def _encode_to_jis_x_0201(value, errors='strict'):
 
     msb = ord(encoded) & 0x80
     for i, c in enumerate(value[1:], 1):
-        b = encoder.encode(c)
+        try:
+            b = encoder.encode(c)
+        except UnicodeEncodeError as e:
+            e.start = i
+            e.end = len(value)
+            raise e
         if len(b) != 1 or ((ord(b) & 0x80) ^ msb) != 0:
             character_set = 'ISO IR 14' if msb == 0 else 'ISO IR 13'
             msg = 'Given character is out of {}'.format(character_set)
@@ -193,7 +198,12 @@ def _encode_to_jis_x_0208(value, errors='strict'):
             'Given character is out of ISO IR 87')
 
     for i, c in enumerate(value[1:], 1):
-        b = encoder.encode(c)
+        try:
+            b = encoder.encode(c)
+        except UnicodeEncodeError as e:
+            e.start = i
+            e.end = len(value)
+            raise e
         if b[:3] == ENCODINGS_TO_CODES['iso8859']:
             raise UnicodeEncodeError(
                 'iso2022_jp', value, i, len(value),

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -109,7 +109,8 @@ def _encode_to_jis_x_0201(input, errors='strict'):
             encoded = b'?'
         buf += encoded
     if start < len(input) and 0 < end and errors == 'strict':
-        raise UnicodeEncodeError('shift_jis', input, start, end, 'illegal multibyte sequence')
+        raise UnicodeEncodeError(
+            'shift_jis', input, start, end, 'illegal multibyte sequence')
     return buf
 
 

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -405,8 +405,9 @@ class TestCharset(object):
             pydicom.charset.decode(
                 elem, ['ISO 2022 IR 100', 'ISO 2022 IR 146'])
 
-    def test_japanese_multi_byte_encoding(self):
-        """Test japanese multi byte strings are correctly encoded."""
+    def test_japanese_multi_byte_personname(self):
+        """Test japanese person name which has multi byte strings are
+        correctly encoded."""
         file_path = get_charset_files('chrH32.dcm')[0]
         ds = dcmread(file_path)
         ds.decode()
@@ -421,3 +422,9 @@ class TestCharset(object):
             fp.seek(0)
             ds_out = dcmread(fp)
             assert original_string == ds_out.PatientName.original_string
+
+    def test_japanese_multi_byte_encoding(self):
+        """Test japanese multi byte strings are correctly encoded."""
+        encoded = pydicom.charset.encode_string('あaｱア',
+                                                ['shift_jis', 'iso2022_jp'])
+        assert encoded == b'\x1b$B$"\x1b(Ja\x1b)I\xb1\x1b$B%"\x1b(J'

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -404,3 +404,19 @@ class TestCharset(object):
                                 u"- using default encoding instead"):
             pydicom.charset.decode(
                 elem, ['ISO 2022 IR 100', 'ISO 2022 IR 146'])
+
+    def test_japanese_multi_byte_encoding(self):
+        """Test japanese multi byte strings are correctly encoded."""
+        file_path = get_charset_files('chrH32.dcm')[0]
+        ds = dcmread(file_path)
+        ds.decode()
+
+        original_string = ds.PatientName.original_string
+        ds.PatientName.original_string = None
+        fp = DicomBytesIO()
+        fp.is_implicit_VR = False
+        fp.is_little_endian = True
+        ds.save_as(fp, write_like_original=False)
+        fp.seek(0)
+        ds_out = dcmread(fp)
+        assert original_string == ds_out.PatientName.original_string

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -428,3 +428,8 @@ class TestCharset(object):
         encoded = pydicom.charset.encode_string(u'あaｱア',
                                                 ['shift_jis', 'iso2022_jp'])
         assert encoded == b'\x1b$B$"\x1b(Ja\x1b)I\xb1\x1b$B%"\x1b(J'
+
+    def test_bad_japanese_encoding(self):
+        """Test japanese multi byte strings are not correctly encoded."""
+        encoded = pydicom.charset.encode_string(u'あaｱア', ['shift_jis'])
+        assert encoded == b'?a??'

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -411,12 +411,13 @@ class TestCharset(object):
         ds = dcmread(file_path)
         ds.decode()
 
-        original_string = ds.PatientName.original_string
-        ds.PatientName.original_string = None
-        fp = DicomBytesIO()
-        fp.is_implicit_VR = False
-        fp.is_little_endian = True
-        ds.save_as(fp, write_like_original=False)
-        fp.seek(0)
-        ds_out = dcmread(fp)
-        assert original_string == ds_out.PatientName.original_string
+        if hasattr(ds.PatientName, 'original_string'):
+            original_string = ds.PatientName.original_string
+            ds.PatientName.original_string = None
+            fp = DicomBytesIO()
+            fp.is_implicit_VR = False
+            fp.is_little_endian = True
+            ds.save_as(fp, write_like_original=False)
+            fp.seek(0)
+            ds_out = dcmread(fp)
+            assert original_string == ds_out.PatientName.original_string

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -431,5 +431,9 @@ class TestCharset(object):
 
     def test_bad_japanese_encoding(self):
         """Test japanese multi byte strings are not correctly encoded."""
-        encoded = pydicom.charset.encode_string(u'あaｱア', ['shift_jis'])
-        assert encoded == b'?a??'
+        with pytest.warns(UserWarning,
+                          match=u"Failed to encode value with encodings"
+                                u": shift_jis - using replacement character"
+                                u"s in encoded string"):
+            encoded = pydicom.charset.encode_string(u'あaｱア', ['shift_jis'])
+            assert encoded == b'?a??'

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -425,6 +425,6 @@ class TestCharset(object):
 
     def test_japanese_multi_byte_encoding(self):
         """Test japanese multi byte strings are correctly encoded."""
-        encoded = pydicom.charset.encode_string('あaｱア',
+        encoded = pydicom.charset.encode_string(u'あaｱア',
                                                 ['shift_jis', 'iso2022_jp'])
         assert encoded == b'\x1b$B$"\x1b(Ja\x1b)I\xb1\x1b$B%"\x1b(J'

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -427,7 +427,7 @@ class TestCharset(object):
         """Test japanese multi byte strings are correctly encoded."""
         encoded = pydicom.charset.encode_string(u'あaｱア',
                                                 ['shift_jis', 'iso2022_jp'])
-        assert encoded == b'\x1b$B$"\x1b(Ja\x1b)I\xb1\x1b$B%"\x1b(J'
+        assert b'\x1b$B$"\x1b(Ja\x1b)I\xb1\x1b$B%"\x1b(J' == encoded
 
     def test_bad_japanese_encoding(self):
         """Test japanese multi byte strings are not correctly encoded."""
@@ -436,4 +436,4 @@ class TestCharset(object):
                                 u": shift_jis - using replacement character"
                                 u"s in encoded string"):
             encoded = pydicom.charset.encode_string(u'あaｱア', ['shift_jis'])
-            assert encoded == b'?a??'
+            assert b'?a??' == encoded


### PR DESCRIPTION
In the original implementation, Pydicom use handled encoders such as shift_jis and iso-2022-jp if Japanese characters are given. But I found two issues as followings.

* shift_jis encoding doesn’t raise UnicodeError when characters which are out of JIS X 0201 are given.

* The escape sequence of starting ASCII code in iso-2022-jp encoding is fixed to ESC(B. But it should depend on value 1 of SpecificCharacterSet. For example, If ISO 2022 IR 13 is assigned to value 1 of SpecificCharacterSet, we should use ESC(J as an escape sequence of starting ASCII.

#### Reference Issue
<!-- Example: Fixes #1234 -->
Closes #856

#### What does this implement/fix? Explain your changes.
* Use custom encoders if ISO 2022 IR 13 and ISO 2022 IR 87 are given in SpecificCharacterSet.
* Use single byte output of shift_jis encoder to encode to jis-x-0201 in a custom encoder for ISO 2022 IR 13.
* Trim a tail escape sequence of iso-2022-jp encoded value to choose correct escape sequence which depends on value 1 of SpecificCharacterSet in a custom encoder for ISO 2022 IR 87.

#### Any other comments?
<!--
-->
I added a test whose name is  test_japanese_multibyte_encoding for this PR.
In fact, this test is almost similar to test_charset_patient_names. But the original test case cannot detect this issue because of a lack of comparing its original_string. 

I have poor English, So please let me know if you meet any incomprehensible English.
<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->