### PR TITLE
Allow missing padding byte in pixel data

### DIFF
--- a/doc/whatsnew/v1.3.0.rst
+++ b/doc/whatsnew/v1.3.0.rst
@@ -26,6 +26,8 @@ Enhancements
 * Added possibility to get and add private tags without adding them to the
   private dictionary
 * Added possibility to use a ``Dataset`` in a ``NumPy`` array
+* Allow missing padding byte in Pixel Data, issue a warning in this case
+  (:issue:`864`)
 
 Fixes
 .....

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -254,7 +254,7 @@ def get_pixeldata(ds, read_only=False):
                 "doesn't match the expected length ({} bytes). "
                 "The dataset may be corrupted or there may be an issue "
                 "with the pixel data handler."
-                    .format(actual_length, padded_expected_len)
+                .format(actual_length, padded_expected_len)
             )
     elif actual_length > padded_expected_len:
         # PS 3.5, Section 8.1.1

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -242,14 +242,20 @@ def get_pixeldata(ds, read_only=False):
     # Check that the actual length of the pixel data is as expected
     actual_length = len(ds.PixelData)
     # Correct for the trailing NULL byte padding for odd length data
+
     padded_expected_len = expected_len + expected_len % 2
     if actual_length < padded_expected_len:
-        raise ValueError(
-            "The length of the pixel data in the dataset doesn't match the "
-            "expected amount ({0} vs. {1} bytes). The dataset may be "
-            "corrupted or there may be an issue with the pixel data handler."
-            .format(actual_length, padded_expected_len)
-        )
+        if actual_length == expected_len:
+            warnings.warn(
+                "The pixel data length is odd and misses a padding byte.")
+        else:
+            raise ValueError(
+                "The length of the pixel data in the dataset doesn't match "
+                "the expected amount ({0} vs. {1} bytes). "
+                "The dataset may be corrupted or there may be an issue "
+                "with the pixel data handler."
+                .format(actual_length, padded_expected_len)
+            )
     elif actual_length > padded_expected_len:
         # PS 3.5, Section 8.1.1
         msg = (

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -250,11 +250,11 @@ def get_pixeldata(ds, read_only=False):
                 "The pixel data length is odd and misses a padding byte.")
         else:
             raise ValueError(
-                "The length of the pixel data in the dataset doesn't match "
-                "the expected amount ({0} vs. {1} bytes). "
+                "The length of the pixel data in the dataset ({} bytes) "
+                "doesn't match the expected length ({} bytes). "
                 "The dataset may be corrupted or there may be an issue "
                 "with the pixel data handler."
-                .format(actual_length, padded_expected_len)
+                    .format(actual_length, padded_expected_len)
             )
     elif actual_length > padded_expected_len:
         # PS 3.5, Section 8.1.1

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -993,6 +993,15 @@ class TestNumpy_GetPixelData(object):
         with pytest.raises(ValueError, match=msg):
             get_pixeldata(ds)
 
+    def test_missing_padding_warns(self):
+        """A warning shall be issued if the padding for odd data is missing."""
+        ds = dcmread(EXPL_8_3_1F_ODD)
+        # remove the padding byte
+        ds.PixelData = ds.PixelData[:-1]
+        msg = "The pixel data length is odd and misses a padding byte."
+        with pytest.warns(UserWarning, match=msg):
+            get_pixeldata(ds)
+
     def test_change_photometric_interpretation(self):
         """Test get_pixeldata changes PhotometricInterpretation if required."""
         def to_rgb(ds):

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -986,9 +986,10 @@ class TestNumpy_GetPixelData(object):
         # Too short
         ds.PixelData = ds.PixelData[:-1]
         msg = (
-            r"The length of the pixel data in the dataset doesn't match the "
-            r"expected amount \(479999 vs. 480000 bytes\). The dataset may be "
-            r"corrupted or there may be an issue with the pixel data handler."
+            r"The length of the pixel data in the dataset \(479999 bytes\) "
+            r"doesn't match the expected length \(480000 bytes\). "
+            r"The dataset may be corrupted or there may be an issue "
+            r"with the pixel data handler."
         )
         with pytest.raises(ValueError, match=msg):
             get_pixeldata(ds)


### PR DESCRIPTION
- issue a warning if padding is missing
- closes #864
