### PR TITLE
Workaround for build problems with conda 4.7.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
 
   # Installed prebuilt dependencies from conda
   - "conda install pip numpy nose wheel pytest matplotlib -y -q"
-  - "conda install -y -q setuptools"
+  - "conda --version"
   - "pip install nose-timer nose-exclude"
 
   # Install other pydicom dependencies

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -32,7 +32,8 @@ if [[ "$DISTRIB" == "conda" ]]; then
     MINICONDA_PATH=/home/travis/miniconda
     chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
     export PATH=$MINICONDA_PATH/bin:$PATH
-    conda update --yes conda
+    conda --version
+    # conda update --yes conda
 
     # Configure the conda environment and put it in the path using the
     # provided versions


### PR DESCRIPTION
- do not upgrade conda in Travis.CI build
- do not upgrade installed setuptools in the AppVeyor build
- see #871

Note: I did not find the root cause of the problems, so this is only a workaround.
I reported [an issue](https://github.com/conda/conda/issues/8859), though I'm not sure if it's a problem with conda itself, or a packaging problem with miniconda/anaconda.