### PR TITLE
Deprecation warning for Python 2; pytest<5

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -77,7 +77,7 @@ Prerequisites
    * gdcm
    * jpeg_ls
    * jpeg2000
-   * pytest (if running pydicom's test suite)
+   * pytest (if running pydicom's test suite). pytest<5 if in Python 2.
 
 
 Installing pydicom
@@ -139,6 +139,8 @@ pydicom's setup.py file and::
 
 This will install `pytest <https://pytest.org>`_ if it is not 
 already installed.
+
+In v1.3 run under Python 2, if pytest is not found, please `python2 -m pip install "pytest<5"`
   
 Or, in linux you can also use::
 

--- a/pydicom/__init__.py
+++ b/pydicom/__init__.py
@@ -28,6 +28,7 @@ Quick Start
 
 """
 
+
 from pydicom.dataelem import DataElement
 from pydicom.dataset import Dataset, FileDataset
 from pydicom.filereader import dcmread, read_file
@@ -50,5 +51,5 @@ __all__ = ['DataElement',
 from pydicom.compat import in_py2
 if in_py2:
     import warnings
-    msg = 'Python 2 will no longer be supported after the pydicom v1.4 release.'
+    msg = 'Python 2 will no longer be supported after the pydicom v1.4 release'
     warnings.warn(msg, DeprecationWarning)

--- a/pydicom/__init__.py
+++ b/pydicom/__init__.py
@@ -28,7 +28,6 @@ Quick Start
 
 """
 
-
 from pydicom.dataelem import DataElement
 from pydicom.dataset import Dataset, FileDataset
 from pydicom.filereader import dcmread, read_file
@@ -47,3 +46,9 @@ __all__ = ['DataElement',
            'write_file',
            '__version__',
            '__version_info__']
+
+from pydicom.compat import in_py2
+if in_py2:
+    import warnings
+    msg = 'Python 2 will no longer be supported after the pydicom v1.4 release.'
+    warnings.warn(msg, DeprecationWarning)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ description = "Pure python package for DICOM medical file reading and writing"
 
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
-TESTS_REQUIRE = ['pytest<5'] if sys.version_info[0] == 2 else ['pytest'] # in_py2
+
+# in_py2 check in next line - pytest>=5 requires Python 3
+TESTS_REQUIRE = ['pytest<5'] if sys.version_info[0] == 2 else ['pytest']
 _py_modules = []
 if not have_dicom:
     _py_modules = ['dicom']

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ description = "Pure python package for DICOM medical file reading and writing"
 
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
+TESTS_REQUIRE = ['pytest<5'] if sys.version_info[0] == 2 else ['pytest'] # in_py2
 _py_modules = []
 if not have_dicom:
     _py_modules = ['dicom']
@@ -56,7 +57,6 @@ LICENSE = "MIT"
 VERSION = __version__
 REQUIRES = []
 SETUP_REQUIRES = pytest_runner
-TESTS_REQUIRE = ['pytest']
 
 # get long description from README.md
 BASE_PATH = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Deprecation warning for Python 2 support ending after v1.4.  Pytest<5 in setup.py if in Python2.

In my local setup, the `python setup.py test` did not work under Python 2.  It appeared to install pytest, but then later came up with an ImportError for pytest.  Tried many things, could not resolve, so added line to Testing section of Getting Started to instruct direct install of pytest<5 if needed.