### PR TITLE
[WIP] Display file_meta data elements in repr(dataset)

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1430,7 +1430,10 @@ class Dataset(dict):
         str
             A string representation of the Dataset.
         """
-        strings = []
+        if hasattr(self, "file_meta"):
+            strings = [self.file_meta._pretty_str()]
+        else:
+            strings = []
         indent_str = self.indent_chars * indent
         nextindent_str = self.indent_chars * (indent + 1)
         for data_element in self:

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1591,6 +1591,21 @@ class FileDatasetTests(unittest.TestCase):
         expected_diff = {'__class__', '__doc__', '__hash__'}
         assert expected_diff == set(dir(di)) - set(dir(ds))
 
+    def test_repr_shows_group2(self):
+        """Starting in v1.4, Dataset.__repr__ shows file meta"""
+        ds = Dataset()
+        ds.file_meta = Dataset()
+        ds.file_meta.FileMetaInformationVersion = b'\x00\x01'
+        ds.file_meta.SourceApplicationEntityTitle = "test"
+
+        ds.PatientName = "Test this"
+        s = repr(ds)
+        print(s)
+        lines = s.splitlines()
+        assert lines[0].startswith("(0002, 0001) File Meta Information Vers")
+        assert lines[1].startswith("(0002, 0016) Source Application Entity")
+        assert lines[2].startswith("(0010, 0010) Patient's Name")
+
 
 class BadRepr(object):
     def __repr__(self):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Closes #881

#### What does this implement/fix? Explain your changes.
Addes file_meta information back into dataset display, and transparently allows setting/getting file_meta data elements directly from the parent dataset.
