### PR TITLE
[MRG] Minor consolidation of json conversion code

### DIFF
--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -10,6 +10,7 @@ A DataElement has a tag,
 from __future__ import absolute_import
 
 import base64
+import json
 import warnings
 from collections import namedtuple
 
@@ -181,6 +182,8 @@ class DataElement(object):
 
         Parameters
         ----------
+        dataset_class: Dataset derived class
+            class used to create sequence items
         tag: pydicom.tag.Tag
             data element tag
         vr: str
@@ -287,20 +290,115 @@ class DataElement(object):
             logger.warning('missing value for data element "{}"'.format(tag))
             elem_value = ''
 
-        elem_value = jsonrep._convert_to_python_number(elem_value, vr)
+        elem_value = jsonrep.convert_to_python_number(elem_value, vr)
 
         try:
             if compat.in_py2 and vr == "PN":
-
                 elem_value = PersonNameUnicode(elem_value, 'UTF8')
             return DataElement(tag=tag, value=elem_value, VR=vr)
         except Exception:
-            raise
             raise ValueError(
                 'Data element "{}" could not be loaded from JSON: {}'.format(
                     tag, elem_value
                     )
             )
+
+    def to_json(self, bulk_data_element_handler,
+                bulk_data_threshold, dump_handler):
+        """Converts a DataElement to JSON representation.
+
+        Parameters
+        ----------
+        bulk_data_element_handler: Union[Callable, None]
+            callable that accepts a bulk data element and returns the
+            "BulkDataURI" for retrieving the value of the data element
+            via DICOMweb WADO-RS
+        bulk_data_threshold: int
+            size of base64 encoded data element above which a value will be
+            provided in form of a "BulkDataURI" rather than "InlineBinary"
+
+        Returns
+        -------
+        dict
+            mapping representing a JSON encoded data element
+
+        Raises
+        ------
+        TypeError
+            when size of encoded data element exceeds `bulk_data_threshold`
+            but `bulk_data_element_handler` is ``None`` and hence not callable
+
+        """
+        # TODO: Determine whether more VRs need to be converted to strings
+        _VRs_TO_QUOTE = ['AT', ]
+        json_element = {'vr': self.VR, }
+        if self.VR in jsonrep.BINARY_VR_VALUES:
+            if self.value is not None:
+                binary_value = self.value
+                encoded_value = base64.b64encode(binary_value).decode('utf-8')
+                if len(encoded_value) > bulk_data_threshold:
+                    if bulk_data_element_handler is None:
+                        raise TypeError(
+                            'No bulk data element handler provided to '
+                            'generate URL for value of data element "{}".'
+                            .format(self.name)
+                        )
+                    json_element['BulkDataURI'] = bulk_data_element_handler(
+                        self
+                    )
+                else:
+                    logger.info(
+                        'encode bulk data element "{}" inline'.format(
+                            self.name
+                        )
+                    )
+                    json_element['InlineBinary'] = encoded_value
+        elif self.VR == 'SQ':
+            # recursive call to co-routine to format sequence contents
+            value = [
+                json.loads(e.to_json(
+                    bulk_data_element_handler=bulk_data_element_handler,
+                    bulk_data_threshold=bulk_data_threshold,
+                    dump_handler=dump_handler
+                ))
+                for e in self
+            ]
+            json_element['Value'] = value
+        elif self.VR == 'PN':
+            elem_value = self.value
+            if elem_value is not None:
+                if compat.in_py2:
+                    elem_value = PersonNameUnicode(elem_value, 'UTF8')
+                if len(elem_value.components) > 2:
+                    json_element['Value'] = [
+                        {'Phonetic': elem_value.components[2], },
+                    ]
+                elif len(elem_value.components) > 1:
+                    json_element['Value'] = [
+                        {'Ideographic': elem_value.components[1], },
+                    ]
+                else:
+                    json_element['Value'] = [
+                        {'Alphabetic': elem_value.components[0], },
+                    ]
+        else:
+            if self.value is not None:
+                is_multivalue = isinstance(self.value, MultiValue)
+                if self.VM > 1 or is_multivalue:
+                    value = self.value
+                else:
+                    value = [self.value]
+                # ensure it's a list and not another iterable
+                # (e.g. tuple), which would not be JSON serializable
+                if self.VR in _VRs_TO_QUOTE:
+                    json_element['Value'] = [str(v) for v in value]
+                else:
+                    json_element['Value'] = [v for v in value]
+        if hasattr(json_element, 'Value'):
+            json_element['Value'] = jsonrep.convert_to_python_number(
+                json_element['Value'], self.VR
+            )
+        return json_element
 
     @property
     def value(self):

--- a/pydicom/jsonrep.py
+++ b/pydicom/jsonrep.py
@@ -2,11 +2,15 @@
 """Methods for converting Datasets and DataElements to/from json"""
 
 # Order of keys is significant!
-JSON_VALUE_KEYS = ('Value', 'BulkDataURI', 'InlineBinary', )
-VRs_TO_BE_FLOATS = ["DS", "FL", "FD", ]
-VRs_TO_BE_INTS = ["IS", "SL", "SS", "UL", "US", ]
+JSON_VALUE_KEYS = ('Value', 'BulkDataURI', 'InlineBinary',)
 
-def _convert_to_python_number(value, vr):
+BINARY_VR_VALUES = ['OW', 'OB', 'OD', 'OF', 'OL', 'UN',
+                    'OB or OW', 'US or OW', 'US or SS or OW']
+VRs_TO_BE_FLOATS = ['DS', 'FL', 'FD', ]
+VRs_TO_BE_INTS = ['IS', 'SL', 'SS', 'UL', 'US', 'US or SS']
+
+
+def convert_to_python_number(value, vr):
     """Makes sure that values are either ints or floats
     based on their value representation.
 
@@ -30,7 +34,7 @@ def _convert_to_python_number(value, vr):
     if vr in VRs_TO_BE_FLOATS:
         number_type = float
     if number_type is not None:
-        if isinstance(value, (list, tuple, )):
+        if isinstance(value, (list, tuple,)):
             value = [number_type(e) for e in value]
         else:
             value = number_type(value)


### PR DESCRIPTION
- removed duplicate constants and methods
- moved Dataset._data_element_to_json to DataElement.to_json
- closes #889

Note that this is only a minor restructuring, I didn't change anything or add any tests. I noticed that there are several todos left, also some arguments not used yet.

@pieper - could you please review these changes, and maybe write a new issue with the tasks that still remain to do?