### PR TITLE
[MRG] Fixed assigning of empty values to data elements

### DIFF
--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -12,4 +12,4 @@ Fixes
 * Fixed testing PN values for truthiness (:issue:`891`)
 * Fixed handling of data too large to written in explicit transfer syntax
 * Fixed handling of known tags with VR UN (:issue:`899`)
-
+* Fixed assigning of empty values to data elements (:issue:`896`)

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -751,14 +751,14 @@ def decode(data_element, dicom_character_set):
     # PN is special case as may have 3 components with different chr sets
     if data_element.VR == "PN":
         if not in_py2:
-            if data_element.VM == 1:
+            if data_element.VM <= 1:
                 data_element.value = data_element.value.decode(encodings)
             else:
                 data_element.value = [
                     val.decode(encodings) for val in data_element.value
                 ]
         else:
-            if data_element.VM == 1:
+            if data_element.VM <= 1:
                 data_element.value = PersonNameUnicode(data_element.value,
                                                        encodings)
             else:

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -742,6 +742,8 @@ def decode(data_element, dicom_character_set):
         single value, a multiple value (code extension), or may also be ``''``
         or ``None``, in which case ``'ISO_IR 6'`` will be used.
     """
+    if data_element.is_empty:
+        return config.empty_value
     if not dicom_character_set:
         dicom_character_set = ['ISO_IR 6']
 

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -743,7 +743,7 @@ def decode(data_element, dicom_character_set):
         or ``None``, in which case ``'ISO_IR 6'`` will be used.
     """
     if data_element.is_empty:
-        return config.empty_value
+        return data_element.empty_value
     if not dicom_character_set:
         dicom_character_set = ['ISO_IR 6']
 

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -86,9 +86,12 @@ TM to :class:`datetime.date`, :class:`datetime.datetime` and
 Default ``False``
 """
 
-empty_value = None
-"""Defines the value that an empty data element is set to
-after decoding."""
+use_none_as_empty_value = False
+""" If ``True``, the value of decoded empty data element is always ``None``.
+If ``False`` (the default), the value of an empty data element with 
+a text VR is an empty string, for all other VRs it is also ``None``.
+Note that the default of this value will change to ``True`` in version 1.5.
+"""
 
 # Logging system and debug function to change logging level
 logger = logging.getLogger('pydicom')

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -86,11 +86,11 @@ TM to :class:`datetime.date`, :class:`datetime.datetime` and
 Default ``False``
 """
 
-use_none_as_empty_value = False
+use_none_as_empty_text_VR_value = False
 """ If ``True``, the value of decoded empty data element is always ``None``.
-If ``False`` (the default), the value of an empty data element with 
+If ``False`` (the default), the value of an empty data element with
 a text VR is an empty string, for all other VRs it is also ``None``.
-Note that the default of this value will change to ``True`` in version 1.5.
+Note that the default of this value will change to ``True`` in version 2.0.
 """
 
 # Logging system and debug function to change logging level

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -86,6 +86,10 @@ TM to :class:`datetime.date`, :class:`datetime.datetime` and
 Default ``False``
 """
 
+empty_value = None
+"""Defines the value that an empty data element is set to
+after decoding."""
+
 # Logging system and debug function to change logging level
 logger = logging.getLogger('pydicom')
 logger.addHandler(logging.NullHandler())

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -66,11 +66,11 @@ def empty_value_for_VR(VR, raw=False):
 
     Returns
     -------
-    str or None
+    str or bytes or None
         The value a data element with `VR` is assigned on decoding
         if it is empty.
     """
-    if config.use_none_as_empty_value:
+    if config.use_none_as_empty_text_VR_value:
         return None
     if VR in ('AE', 'AS', 'CS', 'DA', 'DT', 'LO', 'LT',
               'PN', 'SH', 'ST', 'TM', 'UC', 'UI', 'UR', 'UT'):
@@ -528,8 +528,11 @@ class DataElement(object):
         return empty_value_for_VR(self.VR)
 
     def clear(self):
-        """Clears the value, e.g. sets it to `None`."""
-        self._value = None
+        """Clears the value, e.g. sets it to the configured empty value.
+
+        See :func:`empty_value_for_VR`.
+        """
+        self._value = self.empty_value
 
     def _convert_value(self, val):
         """Convert `val` to an appropriate type and return the result.

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -42,6 +42,42 @@ BINARY_VR_VALUES = [
 ]
 
 
+def empty_value_for_VR(VR, raw=False):
+    """Return the value for an empty element for `VR`.
+
+    The behavior of this property depends on the setting of
+    :attr:`config.use_none_as_empty_value`. If that is set to ``True``,
+    an empty value is always represented by ``None``, otherwise it depends
+    on `VR`. For text VRs (not including VRs that represent a number in
+    textual representation) an empty string is used as empty value
+    representation, for all other VRs, ``None``.
+    Note that this is used only if decoding the element - it is always
+    possible to set the value to another empty value representation,
+    which will be preserved during the element object lifetime.
+
+    Parameters
+    ----------
+    VR : str
+        The VR of the corresponding element.
+
+    raw : bool
+        If ``True``, returns the value for a :class:`RawDataElement`,
+        otherwise for a :class:`DataElement`
+
+    Returns
+    -------
+    str or None
+        The value a data element with `VR` is assigned on decoding
+        if it is empty.
+    """
+    if config.use_none_as_empty_value:
+        return None
+    if VR in ('AE', 'AS', 'CS', 'DA', 'DT', 'LO', 'LT',
+              'PN', 'SH', 'ST', 'TM', 'UC', 'UI', 'UR', 'UT'):
+        return b'' if raw else ''
+    return None
+
+
 def isMultiValue(value):
     """Return True if `value` is list-like (iterable), False otherwise.
 
@@ -477,6 +513,19 @@ class DataElement(object):
     def is_empty(self):
         """Return `True` if the element has no value."""
         return self.VM == 0
+
+    @property
+    def empty_value(self):
+        """Return the value for an empty element.
+
+        See :func:`empty_value_for_VR` for more information.
+
+        Returns
+        -------
+        str or None
+            The value this data element is assigned on decoding if it is empty.
+        """
+        return empty_value_for_VR(self.VR)
 
     def clear(self):
         """Clears the value, e.g. sets it to `None`."""

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -206,12 +206,7 @@ class DataElement(object):
                 pass
 
         self.VR = VR  # Note: you must set VR before setting value
-        if not value and (value is None or value in ([], ())) and VR != 'SQ':
-            if VR in BINARY_VR_VALUES:
-                self._value = None
-            else:
-                self._value = ''
-        elif already_converted:
+        if already_converted:
             self._value = value
         else:
             self.value = value  # calls property setter which will convert
@@ -463,14 +458,7 @@ class DataElement(object):
             except TypeError:
                 if _backslash_byte in val:
                     val = val.split(_backslash_byte)
-        # make sure empty values are represented by 0-length value
-        if not val and (val is None or val in ([], ())) and self.VR != 'SQ':
-            if self.VR in BINARY_VR_VALUES:
-                self._value = None
-            else:
-                self._value = ''
-        else:
-            self._value = self._convert_value(val)
+        self._value = self._convert_value(val)
 
     @property
     def VM(self):
@@ -536,7 +524,7 @@ class DataElement(object):
         elif self.VR == 'TM' and config.datetime_conversion:
             return pydicom.valuerep.TM(val)
         elif self.VR == "UI":
-            return UID(val if val else '')
+            return UID(val) if val is not None else None
         elif not in_py2 and self.VR == "PN":
             return PersonName(val)
         # Later may need this for PersonName as for UI,
@@ -581,7 +569,7 @@ class DataElement(object):
 
     def __str__(self):
         """Return :class:`str` representation of the element."""
-        repVal = self.repval
+        repVal = self.repval or ''
         if self.showVR:
             s = "%s %-*s %s: %s" % (str(self.tag), self.descripWidth,
                                     self.description()[:self.descripWidth],

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -861,7 +861,7 @@ class Dataset(dict):
             return data_elem
         elif isinstance(data_elem, tuple):
             # If a deferred read, then go get the value now
-            if data_elem.value is None:
+            if data_elem.value is None and data_elem.length != 0:
                 from pydicom.filereader import read_deferred_data_element
                 data_elem = read_deferred_data_element(
                     self.fileobj_type, self.filename, self.timestamp,

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1481,7 +1481,7 @@ class Dataset(dict):
                                getattr(data_element, x))
                               for x in dir(data_element)
                               if not x.startswith("_")
-                              and x not in ('from_json', 'to_json')])
+                              and x not in ('from_json', 'to_json', 'clear')])
             if data_element.VR == "SQ":
                 yield sequence_element_format % elem_dict
             else:

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -17,7 +17,7 @@ from pydicom.compat import in_py2
 from pydicom.config import logger
 from pydicom.datadict import dictionary_VR, tag_for_keyword
 from pydicom.dataelem import (DataElement, RawDataElement,
-                              DataElement_from_raw)
+                              DataElement_from_raw, empty_value_for_VR)
 from pydicom.dataset import (Dataset, FileDataset)
 from pydicom.dicomdir import DicomDir
 from pydicom.errors import InvalidDicomError
@@ -187,7 +187,8 @@ def data_element_generator(fp,
                              "Skipping forward to next data element.")
                 fp.seek(fp_tell() + length)
             else:
-                value = fp_read(length) if length > 0 else config.empty_value
+                value = (fp_read(length) if length > 0
+                         else empty_value_for_VR(VR, raw=True))
                 if debugging:
                     dotdot = "..." if length > 12 else "   "
                     displayed_value = value[:12] if value else b''

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -187,16 +187,13 @@ def data_element_generator(fp,
                              "Skipping forward to next data element.")
                 fp.seek(fp_tell() + length)
             else:
-                value = fp_read(length)
+                value = fp_read(length) if length > 0 else config.empty_value
                 if debugging:
-                    dotdot = "   "
-                    if length > 12:
-                        dotdot = "..."
-                    logger_debug("%08x: %-34s %s %r %s" % (value_tell,
-                                                           bytes2hex(
-                                                               value[:12]),
-                                                           dotdot,
-                                                           value[:12], dotdot))
+                    dotdot = "..." if length > 12 else "   "
+                    displayed_value = value[:12] if value else b''
+                    logger_debug("%08x: %-34s %s %r %s" %
+                                 (value_tell, bytes2hex(displayed_value),
+                                  dotdot, displayed_value, dotdot))
 
             # If the tag is (0008,0005) Specific Character Set, then store it
             if tag == BaseTag(0x00080005):

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -279,7 +279,7 @@ def write_PN(fp, data_element, encodings=None):
     else:
         val = data_element.value
 
-    if isinstance(val[0], compat.text_type) or not in_py2:
+    if val and isinstance(val[0], compat.text_type) or not in_py2:
         try:
             val = [elem.encode(encodings) for elem in val]
         except TypeError:
@@ -472,15 +472,16 @@ def write_data_element(fp, data_element, encodings=None):
         encodings = convert_encodings(encodings)
         writer_function, writer_param = writers[VR]
         is_undefined_length = data_element.is_undefined_length
-        if VR in text_VRs or VR in ('PN', 'SQ'):
-            writer_function(buffer, data_element, encodings=encodings)
-        else:
-            # Many numeric types use the same writer but with numeric format
-            # parameter
-            if writer_param is not None:
-                writer_function(buffer, data_element, writer_param)
+        if not data_element.is_empty:
+            if VR in text_VRs or VR in ('PN', 'SQ'):
+                writer_function(buffer, data_element, encodings=encodings)
             else:
-                writer_function(buffer, data_element)
+                # Many numeric types use the same writer but with
+                # numeric format parameter
+                if writer_param is not None:
+                    writer_function(buffer, data_element, writer_param)
+                else:
+                    writer_function(buffer, data_element)
 
     # valid pixel data with undefined length shall contain encapsulated
     # data, e.g. sequence items - raise ValueError otherwise (see #238)

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -34,10 +34,10 @@ class TestDataElement(object):
         self.data_elementCommand = DataElement(0x00000000, 'UL', 100)
         self.data_elementPrivate = DataElement(0x00090000, 'UL', 101)
         self.data_elementRetired = DataElement(0x00080010, 'SH', 102)
-        config.use_none_as_empty_value = False
+        config.use_none_as_empty_text_VR_value = False
 
     def teardown(self):
-        config.use_none_as_empty_value = False
+        config.use_none_as_empty_text_VR_value = False
 
     def test_VM_1(self):
         """DataElement: return correct value multiplicity for VM > 1"""
@@ -435,7 +435,7 @@ class TestDataElement(object):
             'UR': 'CodingSchemeURL',
             'UT': 'StrainAdditionalInformation',
         }
-        config.use_none_as_empty_value = use_none
+        config.use_none_as_empty_text_VR_value = use_none
         ds = Dataset()
         ds.is_little_endian = True
         # set value to new element

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -8,6 +8,7 @@ import sys
 
 import pytest
 
+from pydicom import in_py2
 from pydicom.charset import default_encoding
 from pydicom.dataelem import (
     DataElement,
@@ -403,6 +404,11 @@ class TestDataElement(object):
             setattr(ds, tag_name, value)
             elem = ds[tag_name]
             assert bool(elem.value) is False
+            assert 0 == elem.VM
+            if in_py2:
+                assert str(elem.value) in ('', b'')
+            else:
+                assert elem.value in ('', b'')
 
         text_vrs = {
             'AE': 'Receiver',
@@ -451,6 +457,8 @@ class TestDataElement(object):
             setattr(ds, tag_name, value)
             elem = ds[tag_name]
             assert bool(elem.value) is False
+            assert 0 == elem.VM
+            assert elem.value is None
 
         non_text_vrs = {
             'SL': 'RationalNumeratorValue',

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -93,17 +93,16 @@ save_dir = os.getcwd()
 
 class TestReader(object):
     def test_empty_numbers_tag(self):
-        """Tests that an empty tag with a number VR (FL, UL, SL, US,
-        SS, FL, FD, OF) reads as the default empty value"""
+        """Test that an empty tag with a number VR (FL, UL, SL, US,
+        SS, FL, FD, OF) reads as ``None``."""
         empty_number_tags_ds = dcmread(empty_number_tags_name)
-        expected = config.empty_value
-        assert expected == empty_number_tags_ds.ExaminedBodyThickness
-        assert expected == empty_number_tags_ds.SimpleFrameList
-        assert expected == empty_number_tags_ds.ReferencePixelX0
-        assert expected == empty_number_tags_ds.PhysicalUnitsXDirection
-        assert expected == empty_number_tags_ds.TagAngleSecondAxis
-        assert expected == empty_number_tags_ds.TagSpacingSecondDimension
-        assert expected == empty_number_tags_ds.VectorGridData
+        assert empty_number_tags_ds.ExaminedBodyThickness is None
+        assert empty_number_tags_ds.SimpleFrameList is None
+        assert empty_number_tags_ds.ReferencePixelX0 is None
+        assert empty_number_tags_ds.PhysicalUnitsXDirection is None
+        assert empty_number_tags_ds.TagAngleSecondAxis is None
+        assert empty_number_tags_ds.TagSpacingSecondDimension is None
+        assert empty_number_tags_ds.VectorGridData is None
 
     def test_UTF8_filename(self):
         utf8_filename = os.path.join(tempfile.gettempdir(), "ДИКОМ.dcm")

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -94,15 +94,16 @@ save_dir = os.getcwd()
 class TestReader(object):
     def test_empty_numbers_tag(self):
         """Tests that an empty tag with a number VR (FL, UL, SL, US,
-        SS, FL, FD, OF) reads as an empty string"""
+        SS, FL, FD, OF) reads as the default empty value"""
         empty_number_tags_ds = dcmread(empty_number_tags_name)
-        assert '' == empty_number_tags_ds.ExaminedBodyThickness
-        assert '' == empty_number_tags_ds.SimpleFrameList
-        assert '' == empty_number_tags_ds.ReferencePixelX0
-        assert '' == empty_number_tags_ds.PhysicalUnitsXDirection
-        assert '' == empty_number_tags_ds.TagAngleSecondAxis
-        assert '' == empty_number_tags_ds.TagSpacingSecondDimension
-        assert '' == empty_number_tags_ds.VectorGridData
+        expected = config.empty_value
+        assert expected == empty_number_tags_ds.ExaminedBodyThickness
+        assert expected == empty_number_tags_ds.SimpleFrameList
+        assert expected == empty_number_tags_ds.ReferencePixelX0
+        assert expected == empty_number_tags_ds.PhysicalUnitsXDirection
+        assert expected == empty_number_tags_ds.TagAngleSecondAxis
+        assert expected == empty_number_tags_ds.TagSpacingSecondDimension
+        assert expected == empty_number_tags_ds.VectorGridData
 
     def test_UTF8_filename(self):
         utf8_filename = os.path.join(tempfile.gettempdir(), "ДИКОМ.dcm")

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -168,7 +168,7 @@ REFERENCE_DATA_UNSUPPORTED = [
     (JPEG_LOSSLESS_14_1, ('1.2.840.10008.1.2.4.70', 'Lestrade^G')),
     (JPEG_LS_LOSSLESS, ('1.2.840.10008.1.2.4.80', 'CompressedSamples^MR1')),
     # (JPEG_LS_LOSSY, ('1.2.840.10008.1.2.4.81')),  # No dataset available
-    (JPEG_2K_LOSSLESS, ('1.2.840.10008.1.2.4.90', config.empty_value)),
+    (JPEG_2K_LOSSLESS, ('1.2.840.10008.1.2.4.90', '')),
     (JPEG_2K, ('1.2.840.10008.1.2.4.91', 'CompressedSamples^NM1')),
     (RLE, ('1.2.840.10008.1.2.5', 'CompressedSamples^MR1')),
 ]

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -31,6 +31,7 @@ from sys import byteorder
 import pytest
 
 import pydicom
+from pydicom import config
 from pydicom.data import get_testdata_files
 from pydicom.dataset import Dataset
 from pydicom.filereader import dcmread
@@ -167,7 +168,7 @@ REFERENCE_DATA_UNSUPPORTED = [
     (JPEG_LOSSLESS_14_1, ('1.2.840.10008.1.2.4.70', 'Lestrade^G')),
     (JPEG_LS_LOSSLESS, ('1.2.840.10008.1.2.4.80', 'CompressedSamples^MR1')),
     # (JPEG_LS_LOSSY, ('1.2.840.10008.1.2.4.81')),  # No dataset available
-    (JPEG_2K_LOSSLESS, ('1.2.840.10008.1.2.4.90', '')),
+    (JPEG_2K_LOSSLESS, ('1.2.840.10008.1.2.4.90', config.empty_value)),
     (JPEG_2K, ('1.2.840.10008.1.2.4.91', 'CompressedSamples^NM1')),
     (RLE, ('1.2.840.10008.1.2.5', 'CompressedSamples^MR1')),
 ]

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -181,7 +181,7 @@ REFERENCE_DATA_UNSUPPORTED = [
     (JPEG_LOSSLESS_14_1, ('1.2.840.10008.1.2.4.70', 'Lestrade^G')),
     (JPEG_LS_LOSSLESS, ('1.2.840.10008.1.2.4.80', 'CompressedSamples^MR1')),
     # (JPEG_LS_LOSSY, ('1.2.840.10008.1.2.4.81')),  # No dataset available
-    (JPEG_2K_LOSSLESS, ('1.2.840.10008.1.2.4.90', config.empty_value)),
+    (JPEG_2K_LOSSLESS, ('1.2.840.10008.1.2.4.90', '')),
     (JPEG_2K, ('1.2.840.10008.1.2.4.91', 'CompressedSamples^NM1')),
 ]
 

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -27,7 +27,7 @@ import sys
 
 import pytest
 
-from pydicom import dcmread, Dataset
+from pydicom import dcmread, Dataset, config
 import pydicom.config
 from pydicom.data import get_testdata_files
 from pydicom.encaps import defragment_data
@@ -181,7 +181,7 @@ REFERENCE_DATA_UNSUPPORTED = [
     (JPEG_LOSSLESS_14_1, ('1.2.840.10008.1.2.4.70', 'Lestrade^G')),
     (JPEG_LS_LOSSLESS, ('1.2.840.10008.1.2.4.80', 'CompressedSamples^MR1')),
     # (JPEG_LS_LOSSY, ('1.2.840.10008.1.2.4.81')),  # No dataset available
-    (JPEG_2K_LOSSLESS, ('1.2.840.10008.1.2.4.90', '')),
+    (JPEG_2K_LOSSLESS, ('1.2.840.10008.1.2.4.90', config.empty_value)),
     (JPEG_2K, ('1.2.840.10008.1.2.4.91', 'CompressedSamples^NM1')),
 ]
 

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -92,7 +92,7 @@ class TestDS(object):
     """Unit tests for DS values"""
 
     def test_empty_value(self):
-        assert '' == DS(None)
+        assert DS(None) is None
         assert '' == DS('')
 
     def test_float_values(self):
@@ -144,7 +144,7 @@ class TestIS(object):
     """Unit tests for IS"""
 
     def test_empty_value(self):
-        assert '' == IS(None)
+        assert IS(None) is None
         assert '' == IS('')
 
     def test_valid_value(self):
@@ -196,6 +196,7 @@ class TestBadValueRead(object):
         self.tag.is_little_endian = True
         self.tag.is_implicit_VR = False
         self.tag.tag = Tag(0x0010, 0x0020)
+        self.tag.length = 2
         self.default_retry_order = pydicom.values.convert_retry_VR_order
 
     def teardown(self):

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -455,7 +455,7 @@ def DS(val):
     if isinstance(val, (str, compat.text_type)):
         val = val.strip()
     if val == '' or val is None:
-        return ''
+        return val
     return DSclass(val)
 
 
@@ -483,7 +483,7 @@ class IS(int):
     def __new__(cls, val):
         """Create instance if new integer string"""
         if val is None:
-            return ''
+            return val
         if isinstance(val, (str, compat.text_type)) and val.strip() == '':
             return ''
         # Overflow error in Python 2 for integers too large
@@ -624,6 +624,12 @@ def _encode_personname(components, encodings):
 
 
 class PersonName3(object):
+    def __new__(cls, *args, **kwargs):
+        # Handle None value by returning None instead of a PersonName3 object
+        if len(args) and args[0] is None:
+            return None
+        return super(PersonName3, cls).__new__(cls)
+
     def __init__(self, val, encodings=None, original_string=None):
         if isinstance(val, PersonName3):
             encodings = val.encodings
@@ -762,6 +768,10 @@ class PersonName3(object):
         # the encoding was unknown or incorrect - create a new
         # PersonName object with the changed encoding
         encodings = _verify_encodings(encodings)
+        if self.original_string is None:
+            # if the original encoding was not set, we set it now
+            self.original_string = _encode_personname(
+                self.components, self.encodings or [default_encoding])
         return PersonName3(self.original_string, encodings)
 
     def encode(self, encodings=None):

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -12,6 +12,7 @@ from pydicom import compat
 from pydicom.compat import in_py2
 from pydicom.charset import (default_encoding, text_VRs, decode_string)
 from pydicom.config import logger
+from pydicom.dataelem import empty_value_for_VR
 from pydicom.filereader import read_sequence
 from pydicom.multival import MultiValue
 from pydicom.tag import (Tag, TupleTag)
@@ -564,7 +565,7 @@ def convert_value(VR, raw_data_element, encodings=None):
         raise NotImplementedError(message)
 
     if raw_data_element.length == 0:
-        return config.empty_value
+        return empty_value_for_VR(VR)
 
     # Look up the function to convert that VR
     # Dispatch two cases: a plain converter,

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -563,6 +563,9 @@ def convert_value(VR, raw_data_element, encodings=None):
         message = "Unknown Value Representation '{}'".format(VR)
         raise NotImplementedError(message)
 
+    if raw_data_element.length == 0:
+        return config.empty_value
+
     # Look up the function to convert that VR
     # Dispatch two cases: a plain converter,
     # or a number one which needs a format string


### PR DESCRIPTION
- setting a value to None or an empty string now always results
  in an empty tag (VM = 0); see #896

This was a bit more tricky than I thought, and I'm not sure if this is the best way to implement this.
Also I'm not sure if this may cause some compatibility issues...
Anyway, I'm posting this as a discussion base, maybe someone has some better ideas.

Ping @scaramallion, @darcymason 