### PR TITLE
[MRG] Correcly handle known tags with VR UN

### DIFF
--- a/doc/whatsnew/v1.4.0.rst
+++ b/doc/whatsnew/v1.4.0.rst
@@ -10,3 +10,4 @@ Fixes
 * Prevent exception if assigning `None` to UI element (:issue:`894`)
 * Fixed print output for numeric multi-value elements (:issue:`892`)
 * Fixed testing PN values for truthiness (:issue:`891`)
+* Fixed handling of known tags with VR UN (:issue:`899`)

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -165,15 +165,18 @@ class DataElement(object):
         if not isinstance(tag, BaseTag):
             tag = Tag(tag)
         self.tag = tag
-        self.VR = VR  # Note!: you must set VR before setting value
-        self.VR = VR
-        if self.VR == 'UN':
+
+        # a known tag shall only have the VR 'UN' if it has a length that
+        # exceeds the size that can be encoded in 16 bit - all other cases
+        # can be seen as an encoding error and can be corrected
+        if VR == 'UN' and (is_undefined_length or value is None or
+                           len(value) < 0xffff):
             try:
-                self.VR = dictionary_VR(tag)
+                VR = dictionary_VR(tag)
             except KeyError:
                 pass
 
-        # Note: you must set VR before setting value
+        self.VR = VR  # Note!: you must set VR before setting value
         if already_converted:
             self._value = value
         else:

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -166,6 +166,14 @@ class DataElement(object):
             tag = Tag(tag)
         self.tag = tag
         self.VR = VR  # Note!: you must set VR before setting value
+        self.VR = VR
+        if self.VR == 'UN':
+            try:
+                self.VR = dictionary_VR(tag)
+            except KeyError:
+                pass
+
+        # Note: you must set VR before setting value
         if already_converted:
             self._value = value
         else:

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -392,8 +392,8 @@ class TestDataElement(object):
         single_value = b'123456.789012345'
         large_value = b'\\'.join([single_value] * 4500)
         ds[0x30040058] = DataElement(0x30040058, 'UN',
-                                 large_value,
-                                 is_undefined_length=False)
+                                     large_value,
+                                     is_undefined_length=False)
         ds.decode()
         assert 'UN' == ds[0x30040058].VR
 

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -359,6 +359,8 @@ class TestDataElement(object):
         ds[0x00100010] = DataElement(0x00100010, 'UN',
                                      u'Διονυσιος'.encode('iso_ir_126'))
         ds.decode()
+        assert 'CS' == ds[0x00080005].VR
+        assert 'PN' == ds[0x00100010].VR
         assert u'Διονυσιος' == ds[0x00100010].value
 
         ds = Dataset()
@@ -368,6 +370,8 @@ class TestDataElement(object):
                                      b'Dionysios=\x1b\x2d\x46'
                                      + u'Διονυσιος'.encode('iso_ir_126'))
         ds.decode()
+        assert 'CS' == ds[0x00080005].VR
+        assert 'PN' == ds[0x00100010].VR
         assert u'Dionysios=Διονυσιος' == ds[0x00100010].value
 
     def test_unknown_tags_with_UN_VR(self):
@@ -377,24 +381,21 @@ class TestDataElement(object):
         ds[0x00111010] = DataElement(0x00111010, 'UN',
                                      u'Διονυσιος'.encode('iso_ir_126'))
         ds.decode()
+        assert 'UN' == ds[0x00111010].VR
         assert u'Διονυσιος'.encode('iso_ir_126') == ds[0x00111010].value
 
-    def test_patient_name_with_UN_VR(self):
+    def test_tag_with_long_value_UN_VR(self):
+        """Tag with length > 64kb with VR UN is not changed."""
         ds = Dataset()
         ds[0x00080005] = DataElement(0x00080005, 'CS', b'ISO_IR 126')
-        ds[0x00100010] = DataElement(0x00100010, 'UN',
-                                     u'Διονυσιος'.encode('iso_ir_126'))
-        ds.decode()
-        assert u'Διονυσιος' == ds[0x00100010].value
 
-        ds = Dataset()
-        ds[0x00080005] = DataElement(0x00080005, 'CS',
-                                     b'ISO 2022 IR 100\\ISO 2022 IR 126')
-        ds[0x00100010] = DataElement(0x00100010, 'UN',
-                                     b'Dionysios=\x1b\x2d\x46'
-                                     + u'Διονυσιος'.encode('iso_ir_126'))
+        single_value = b'123456.789012345'
+        large_value = b'\\'.join([single_value] * 4500)
+        ds[0x30040058] = DataElement(0x30040058, 'UN',
+                                 large_value,
+                                 is_undefined_length=False)
         ds.decode()
-        assert u'Dionysios=Διονυσιος' == ds[0x00100010].value
+        assert 'UN' == ds[0x30040058].VR
 
     def test_empty_text_values(self):
         """Test that assigning an empty value behaves as expected."""


### PR DESCRIPTION
- fixes #899

This is a small fix which only targets known tags with VR UN - I didn't wante it to have any other impact. 
If the tag has another non-standard VR, it will be used as before. 
