### PR TITLE
[MRG] Fixed handling of data too large to be written in explicit transfer syntax

### DIFF
--- a/doc/whatsnew/v1.4.0.rst
+++ b/doc/whatsnew/v1.4.0.rst
@@ -10,3 +10,5 @@ Fixes
 * Prevent exception if assigning `None` to UI element (:issue:`894`)
 * Fixed print output for numeric multi-value elements (:issue:`892`)
 * Fixed testing PN values for truthiness (:issue:`891`)
+* Fixed handling of data too large to written in explicit transfer syntax
+  (:issue:`757`)

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import
 
-import struct
+import warnings
 from struct import pack
 
 from pydicom import compat
@@ -439,26 +439,18 @@ def write_data_element(fp, data_element, encodings=None):
     # Write element's tag
     fp.write_tag(data_element.tag)
 
-    # If explicit VR, write the VR
-    VR = data_element.VR
-    if not fp.is_implicit_VR:
-        if len(VR) != 2:
-            msg = ("Cannot write ambiguous VR of '{}' for data element with "
-                   "tag {}.\nSet the correct VR before writing, or use an "
-                   "implicit VR transfer syntax".format(
-                       VR, repr(data_element.tag)))
-            raise ValueError(msg)
-        if not in_py2:
-            fp.write(bytes(VR, default_encoding))
-        else:
-            fp.write(VR)
-        if VR in extra_length_VRs:
-            fp.write_US(0)  # reserved 2 bytes
-
     # write into a buffer to avoid seeking back which can be expansive
     buffer = DicomBytesIO()
     buffer.is_little_endian = fp.is_little_endian
     buffer.is_implicit_VR = fp.is_implicit_VR
+
+    VR = data_element.VR
+    if not fp.is_implicit_VR and len(VR) != 2:
+        msg = ("Cannot write ambiguous VR of '{}' for data element with "
+               "tag {}.\nSet the correct VR before writing, or use an "
+               "implicit VR transfer syntax".format(
+                   VR, repr(data_element.tag)))
+        raise ValueError(msg)
 
     if data_element.is_raw:
         # raw data element values can be written as they are
@@ -497,17 +489,28 @@ def write_data_element(fp, data_element, encodings=None):
 
     value_length = buffer.tell()
     if (not fp.is_implicit_VR and VR not in extra_length_VRs and
+            not is_undefined_length and value_length > 0xffff):
+        # see PS 3.5, section 6.2.2 for handling of this case
+        msg = ('The value for the data element {} exceeds the size '
+               'of 64 kByte and cannot be written in an explicit transfer '
+               'syntax. The data element VR is changed from "{}" to "UN" '
+               'to allow saving the data.'
+               .format(data_element.tag, VR))
+        warnings.warn(msg)
+        VR = 'UN'
+
+    # write the VR for explicit transfer syntax
+    if not fp.is_implicit_VR:
+        if not in_py2:
+            fp.write(bytes(VR, default_encoding))
+        else:
+            fp.write(VR)
+        if VR in extra_length_VRs:
+            fp.write_US(0)  # reserved 2 bytes
+
+    if (not fp.is_implicit_VR and VR not in extra_length_VRs and
             not is_undefined_length):
-        try:
-            fp.write_US(value_length)  # Explicit VR length field is 2 bytes
-        except struct.error:
-            msg = ('The value for the data element {} exceeds the size '
-                   'of 64 kByte and cannot be written in an explicit transfer '
-                   'syntax. You can save it using Implicit Little Endian '
-                   'transfer syntax, or you have to truncate the value to not '
-                   'exceed the maximum size of 64 kByte.'
-                   .format(data_element.tag))
-            raise ValueError(msg)
+        fp.write_US(value_length)  # Explicit VR length field is 2 bytes
     else:
         # write the proper length of the data_element in the length slot,
         # unless is SQ with undefined length.

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -2513,20 +2513,31 @@ class TestWriteUndefinedLengthPixelData(object):
                                  large_value,
                                  is_undefined_length=False)
         write_data_element(self.fp, pixel_data)
+        self.fp.seek(0)
+        ds = read_dataset(self.fp, True, True)
+        assert 'DS' == ds[0x30040058].VR
 
         self.fp = DicomBytesIO()
         self.fp.is_little_endian = True
         self.fp.is_implicit_VR = False
-        # shall raise if trying to write it with explicit transfer syntax,
-        # where the length field is 2 bytes long
-        expected_message = (r'The value for the data element \(3004, 0058\) '
-                            r'exceeds the size of 64 kByte ')
-        with pytest.raises(ValueError, match=expected_message):
-            write_data_element(self.fp, pixel_data)
 
+        msg = (r'The value for the data element \(3004, 0058\) exceeds the '
+               r'size of 64 kByte and cannot be written in an explicit '
+               r'transfer syntax. The data element VR is changed from '
+               r'"DS" to "UN" to allow saving the data.')
+
+        with pytest.warns(UserWarning, match=msg):
+            write_data_element(self.fp, pixel_data)
+        self.fp.seek(0)
+        ds = read_dataset(self.fp, False, True)
+        assert 'UN' == ds[0x30040058].VR
+
+        # we expect the same behavior in Big Endian transfer syntax
         self.fp = DicomBytesIO()
         self.fp.is_little_endian = False
         self.fp.is_implicit_VR = False
-        # we expect the same behavior in Big Endian transfer syntax
-        with pytest.raises(ValueError, match=expected_message):
+        with pytest.warns(UserWarning, match=msg):
             write_data_element(self.fp, pixel_data)
+        self.fp.seek(0)
+        ds = read_dataset(self.fp, False, False)
+        assert 'UN' == ds[0x30040058].VR


### PR DESCRIPTION
- VR is replaced by UN in this case, as defined in PS3.5, 6.2.2
- fixes #757

See [discussion](https://github.com/pydicom/pydicom/pull/900#issuecomment-515681882) in #900.