### PR TITLE
[MRG] Remove deprecated functions

### DIFF
--- a/doc/reference/elem.dataelem.rst
+++ b/doc/reference/elem.dataelem.rst
@@ -12,4 +12,5 @@ Representation of DICOM data elements
 
    DataElement
    DataElement_from_raw
+   isMultiValue
    RawDataElement

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -729,7 +729,7 @@ def _handle_illegal_standalone_encodings(encodings, py_encodings):
     return py_encodings
 
 
-def decode(data_element, dicom_character_set):
+def decode_element(data_element, dicom_character_set):
     """Apply the DICOM character encoding to a data element
 
     Parameters
@@ -785,3 +785,27 @@ def decode(data_element, dicom_character_set):
                                                 TEXT_VR_DELIMS))
 
             data_element.value = output
+
+
+def decode(data_element, dicom_character_set):
+    """Apply the DICOM character encoding to a data element
+
+    .. deprecated:: 1.4
+       Will be removed in v1.5, use :func:`decode_element` instead.
+
+    Parameters
+    ----------
+    data_element : dataelem.DataElement
+        The :class:`DataElement<pydicom.dataelem.DataElement>` instance
+        containing an encoded byte string value to decode.
+    dicom_character_set : str or list of str or None
+        The value of (0008,0005) *Specific Character Set*, which may be a
+        single value, a multiple value (code extension), or may also be ``''``
+        or ``None``, in which case ``'ISO_IR 6'`` will be used.
+    """
+    warnings.warn(
+        "'charset.decode_element()' is deprecated and will be removed in "
+        "v1.5, use 'charset.decode_element()' instead",
+        DeprecationWarning
+    )
+    return decode_element(data_element, dicom_character_set)

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -804,7 +804,7 @@ def decode(data_element, dicom_character_set):
         or ``None``, in which case ``'ISO_IR 6'`` will be used.
     """
     warnings.warn(
-        "'charset.decode_element()' is deprecated and will be removed in "
+        "'charset.decode()' is deprecated and will be removed in "
         "v1.5, use 'charset.decode_element()' instead",
         DeprecationWarning
     )

--- a/pydicom/charset.py
+++ b/pydicom/charset.py
@@ -791,7 +791,7 @@ def decode(data_element, dicom_character_set):
     """Apply the DICOM character encoding to a data element
 
     .. deprecated:: 1.4
-       Will be removed in v1.5, use :func:`decode_element` instead.
+       This function is deprecated, use :func:`decode_element` instead.
 
     Parameters
     ----------

--- a/pydicom/datadict.py
+++ b/pydicom/datadict.py
@@ -11,7 +11,7 @@ from pydicom._dicom_dict import DicomDictionary
 # those with tags like "(50xx, 0005)"
 from pydicom._dicom_dict import RepeatersDictionary
 from pydicom._private_dict import private_dictionaries
-import warnings
+
 
 # Generate mask dict for checking repeating groups etc.
 # Map a true bitwise mask to the DICOM mask with "x"'s in it.
@@ -447,30 +447,6 @@ def tag_for_keyword(keyword):
         corresponding element's tag, otherwise returns ``None``.
     """
     return keyword_dict.get(keyword)
-
-
-def tag_for_name(name):
-    """Return the tag of the element corresponding to `name`.
-
-    Only performs the lookup for official DICOM elements.
-
-    **This function is deprecated and will be removed in v1.4.**
-
-    Parameters
-    ----------
-    name : str
-        The keyword for the element whose tag is being retrieved.
-
-    Returns
-    -------
-    int or None
-        If the element is in the DICOM data dictionary then returns the
-        corresponding element's tag, otherwise returns ``None``.
-    """
-    msg = "tag_for_name is deprecated.  Use tag_for_keyword instead"
-    warnings.warn(msg, DeprecationWarning)
-
-    return tag_for_keyword(name)
 
 
 def repeater_has_tag(tag):

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -35,22 +35,6 @@ if not in_py2:
     PersonName = PersonNameUnicode
 
 
-def isMultiValue(value):
-    """Return True if `value` is list-like (iterable), False otherwise.
-
-    **This function is deprecated and will be removed in v1.4**
-    """
-    msg = 'isMultiValue is deprecated.  Use DataElement.VM instead'
-    warnings.warn(msg, DeprecationWarning)
-    if isinstance(value, compat.char_types):
-        return False
-    try:
-        iter(value)
-    except TypeError:
-        return False
-    return True
-
-
 def _is_bytes(val):
     """Return True only in Python 3 if `val` is of type `bytes`."""
     return False if in_py2 else isinstance(val, bytes)

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -35,6 +35,24 @@ if not in_py2:
     PersonName = PersonNameUnicode
 
 
+def isMultiValue(value):
+    """Return ``True`` if `value` is list-like (iterable).
+
+    .. deprecation:: 1.3
+       This function is deprecated, use :attr:`DataElement.VM` instead.
+
+    """
+    msg = 'isMultiValue is deprecated, use DataElement.VM instead'
+    warnings.warn(msg, DeprecationWarning)
+    if isinstance(value, compat.char_types):
+        return False
+    try:
+        iter(value)
+    except TypeError:
+        return False
+    return True
+
+
 def _is_bytes(val):
     """Return True only in Python 3 if `val` is of type `bytes`."""
     return False if in_py2 else isinstance(val, bytes)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -53,12 +53,6 @@ except ImportError:
     have_numpy = False
 
 
-class PropertyError(Exception):
-    """For AttributeErrors caught in a property, so do not go to __getattr__"""
-    #  http://docs.python.org/release/3.1.3/tutorial/errors.html#tut-userexceptions
-    pass
-
-
 class PrivateBlock(object):
     """Helper class for a private block in the :class:`Dataset`.
 
@@ -498,10 +492,10 @@ class Dataset(dict):
         dicom_character_set = self._character_set
 
         # Shortcut to the decode function in pydicom.charset
-        decode_data_element = pydicom.charset.decode
+        decode_data_element = pydicom.charset.decode_element
 
         # Callback for walk(), to decode the chr strings if necessary
-        # This simply calls the pydicom.charset.decode function
+        # This simply calls the pydicom.charset.decode_element function
         def decode_callback(ds, data_element):
             """Callback to decode `data_element`."""
             if data_element.VR == 'SQ':

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -134,12 +134,12 @@ class TestCharset(object):
         """Test bad charset defaults to ISO IR 6"""
         # Python 3: elem.value is PersonName3, Python 2: elem.value is str
         elem = DataElement(0x00100010, 'PN', 'CITIZEN')
-        pydicom.charset.decode(elem, ['ISO 2022 IR 126'])
+        pydicom.charset.decode_element(elem, ['ISO 2022 IR 126'])
         # After decode Python 2: elem.value is PersonNameUnicode
         assert 'iso_ir_126' in elem.value.encodings
         assert 'iso8859' not in elem.value.encodings
         # default encoding is iso8859
-        pydicom.charset.decode(elem, [])
+        pydicom.charset.decode_element(elem, [])
         assert 'iso8859' in elem.value.encodings
 
     def test_bad_encoded_single_encoding(self):
@@ -149,7 +149,7 @@ class TestCharset(object):
 
         with pytest.warns(UserWarning, match="Failed to decode byte string "
                                              "with encoding 'UTF8'"):
-            pydicom.charset.decode(elem, ['ISO_IR 192'])
+            pydicom.charset.decode_element(elem, ['ISO_IR 192'])
             assert u'���������' == elem.value
 
     def test_bad_encoded_single_encoding_enforce_standard(self):
@@ -161,7 +161,7 @@ class TestCharset(object):
         msg = ("'utf.?8' codec can't decode byte 0xc4 in position 0: "
                "invalid continuation byte")
         with pytest.raises(UnicodeDecodeError, match=msg):
-            pydicom.charset.decode(elem, ['ISO_IR 192'])
+            pydicom.charset.decode_element(elem, ['ISO_IR 192'])
 
     def test_code_extensions_not_allowed(self):
         """Test that UTF8 does not allow code extensions"""
@@ -171,7 +171,7 @@ class TestCharset(object):
                "allow code extensions, ignoring: ISO 2022 IR 100, "
                "ISO 2022 IR 144")
         with pytest.warns(UserWarning, match=msg):
-            pydicom.charset.decode(elem, ['ISO_IR 192', 'ISO 2022 IR 100',
+            pydicom.charset.decode_element(elem, ['ISO_IR 192', 'ISO 2022 IR 100',
                                           'ISO 2022 IR 144'])
             assert u'Buc^Jérôme' == elem.value
 
@@ -196,7 +196,7 @@ class TestCharset(object):
 
         with pytest.warns(UserWarning, match='Failed to decode byte string '
                                              'with encodings: iso-2022-jp'):
-            pydicom.charset.decode(elem, ['ISO 2022 IR 159'])
+            pydicom.charset.decode_element(elem, ['ISO 2022 IR 159'])
             assert u'����������' == elem.value
 
     def test_bad_decoded_multi_byte_encoding_enforce_standard(self):
@@ -208,7 +208,7 @@ class TestCharset(object):
         msg = ("'iso2022_jp' codec can't decode bytes in position 0-3: "
                "illegal multibyte sequence")
         with pytest.raises(UnicodeDecodeError, match=msg):
-            pydicom.charset.decode(elem, ['ISO 2022 IR 159'])
+            pydicom.charset.decode_element(elem, ['ISO 2022 IR 159'])
 
     def test_unknown_escape_sequence(self):
         """Test handling bad encoding for single encoding"""
@@ -217,7 +217,7 @@ class TestCharset(object):
 
         with pytest.warns(UserWarning, match='Found unknown escape sequence '
                                              'in encoded string value'):
-            pydicom.charset.decode(elem, ['ISO_IR 100'])
+            pydicom.charset.decode_element(elem, ['ISO_IR 100'])
             assert u'\x1b-FÄéïíõóéïò' == elem.value
 
     def test_unknown_escape_sequence_enforce_standard(self):
@@ -228,12 +228,12 @@ class TestCharset(object):
                            b'\x1b\x2d\x46\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
         with pytest.raises(ValueError, match='Found unknown escape sequence '
                                              'in encoded string value'):
-            pydicom.charset.decode(elem, ['ISO_IR 100'])
+            pydicom.charset.decode_element(elem, ['ISO_IR 100'])
 
     def test_patched_charset(self):
         """Test some commonly misspelled charset values"""
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xc3\xa9r\xc3\xb4me')
-        pydicom.charset.decode(elem, ['ISO_IR 192'])
+        pydicom.charset.decode_element(elem, ['ISO_IR 192'])
         # correct encoding
         assert u'Buc^Jérôme' == elem.value
 
@@ -242,14 +242,14 @@ class TestCharset(object):
         with pytest.warns(UserWarning,
                           match='Incorrect value for Specific Character Set '
                                 "'ISO IR 192' - assuming 'ISO_IR 192'"):
-            pydicom.charset.decode(elem, ['ISO IR 192'])
+            pydicom.charset.decode_element(elem, ['ISO IR 192'])
             assert u'Buc^Jérôme' == elem.value
 
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xe9r\xf4me')
         with pytest.warns(UserWarning,
                           match='Incorrect value for Specific Character Set '
                                 "'ISO-IR 144' - assuming 'ISO_IR 144'") as w:
-            pydicom.charset.decode(elem, ['ISO_IR 100', 'ISO-IR 144'])
+            pydicom.charset.decode_element(elem, ['ISO_IR 100', 'ISO-IR 144'])
             # make sure no warning is issued for the correct value
             assert 1 == len(w)
 
@@ -258,11 +258,11 @@ class TestCharset(object):
         with pytest.warns(UserWarning,
                           match=u"Unknown encoding 'ISOIR 192' - "
                                 u"using default encoding instead"):
-            pydicom.charset.decode(elem, ['ISOIR 192'])
+            pydicom.charset.decode_element(elem, ['ISOIR 192'])
 
         # Python encoding also can be used directly
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xc3\xa9r\xc3\xb4me')
-        pydicom.charset.decode(elem, ['utf8'])
+        pydicom.charset.decode_element(elem, ['utf8'])
         assert u'Buc^Jérôme' == elem.value
 
     def test_patched_code_extension_charset(self):
@@ -271,7 +271,7 @@ class TestCharset(object):
                            b'Dionysios=\x1b\x2d\x46'
                            b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
         # correct encoding
-        pydicom.charset.decode(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 126'])
+        pydicom.charset.decode_element(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 126'])
         assert u'Dionysios=Διονυσιος' == elem.value
 
         # patched encoding shall behave correctly, but a warning is issued
@@ -282,7 +282,7 @@ class TestCharset(object):
             elem = DataElement(0x00100010, 'PN',
                                b'Dionysios=\x1b\x2d\x46'
                                b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
-            pydicom.charset.decode(elem,
+            pydicom.charset.decode_element(elem,
                                    ['ISO_2022-IR 100', 'ISO 2022 IR 126'])
             assert u'Dionysios=Διονυσιος' == elem.value
 
@@ -293,7 +293,7 @@ class TestCharset(object):
             elem = DataElement(0x00100010, 'PN',
                                b'Dionysios=\x1b\x2d\x46'
                                b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
-            pydicom.charset.decode(elem,
+            pydicom.charset.decode_element(elem,
                                    ['ISO 2022 IR 100', 'ISO_2022_IR+126'])
             assert u'Dionysios=Διονυσιος' == elem.value
 
@@ -301,11 +301,11 @@ class TestCharset(object):
         """Test that the first value is used if no escape code is given"""
         # regression test for #707
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xe9r\xf4me')
-        pydicom.charset.decode(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 144'])
+        pydicom.charset.decode_element(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 144'])
         assert u'Buc^Jérôme' == elem.value
 
         elem = DataElement(0x00081039, 'LO', b'R\xf6ntgenaufnahme')
-        pydicom.charset.decode(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 144'])
+        pydicom.charset.decode_element(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 144'])
         assert u'Röntgenaufnahme' == elem.value
 
     def test_single_byte_multi_charset_personname(self):
@@ -313,7 +313,7 @@ class TestCharset(object):
         elem = DataElement(0x00100010, 'PN',
                            b'Dionysios=\x1b\x2d\x46'
                            b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
-        pydicom.charset.decode(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 126'])
+        pydicom.charset.decode_element(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 126'])
         assert u'Dionysios=Διονυσιος' == elem.value
 
         # multiple values with different encodings
@@ -322,7 +322,7 @@ class TestCharset(object):
                    b'\x1b\x2d\x4C'
                    b'\xbb\xee\xda\x63\x65\xdc\xd1\x79\x70\xd3')
         elem = DataElement(0x00100060, 'PN', encoded)
-        pydicom.charset.decode(elem, ['ISO 2022 IR 100',
+        pydicom.charset.decode_element(elem, ['ISO 2022 IR 100',
                                       'ISO 2022 IR 144',
                                       'ISO 2022 IR 126'])
         assert [u'Buc^Jérôme', u'Διονυσιος', u'Люкceмбypг'] == elem.value
@@ -332,7 +332,7 @@ class TestCharset(object):
         elem = DataElement(0x00081039, 'LO',
                            b'Dionysios is \x1b\x2d\x46'
                            b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
-        pydicom.charset.decode(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 126'])
+        pydicom.charset.decode_element(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 126'])
         assert u'Dionysios is Διονυσιος' == elem.value
 
         # multiple values with different encodings
@@ -341,7 +341,7 @@ class TestCharset(object):
                            b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2\\'
                            b'\x1b\x2d\x4C'
                            b'\xbb\xee\xda\x63\x65\xdc\xd1\x79\x70\xd3')
-        pydicom.charset.decode(elem, ['ISO 2022 IR 100',
+        pydicom.charset.decode_element(elem, ['ISO 2022 IR 100',
                                       'ISO 2022 IR 144',
                                       'ISO 2022 IR 126'])
         assert [u'Buc^Jérôme', u'Διονυσιος', u'Люкceмбypг'] == elem.value
@@ -350,7 +350,7 @@ class TestCharset(object):
     def test_single_byte_code_extensions(self, encoding, decoded, raw_data):
         # single-byte encoding as code extension
         elem = DataElement(0x00081039, 'LO', b'ASCII+' + raw_data)
-        pydicom.charset.decode(elem, ['', encoding])
+        pydicom.charset.decode_element(elem, ['', encoding])
         assert u'ASCII+' + decoded == elem.value
 
     @pytest.mark.parametrize('filename, patient_name', FILE_PATIENT_NAMES)
@@ -402,7 +402,7 @@ class TestCharset(object):
         with pytest.warns(UserWarning,
                           match=u"Unknown encoding 'ISO 2022 IR 146' "
                                 u"- using default encoding instead"):
-            pydicom.charset.decode(
+            pydicom.charset.decode_element(
                 elem, ['ISO 2022 IR 100', 'ISO 2022 IR 146'])
 
     def test_japanese_multi_byte_personname(self):
@@ -437,3 +437,11 @@ class TestCharset(object):
                                 u"s in encoded string"):
             encoded = pydicom.charset.encode_string(u'あaｱア', ['shift_jis'])
             assert b'?a??' == encoded
+
+    def test_deprecated_decode(self):
+        """Test we get a deprecation warning when using charset.decode()."""
+        # Python 3: elem.value is PersonName3, Python 2: elem.value is str
+        elem = DataElement(0x00100010, 'PN', 'CITIZEN')
+        msg = r"'charset.decode_element\(\)' is deprecated"
+        with pytest.warns(DeprecationWarning, match=msg):
+            pydicom.charset.decode(elem, ['ISO 2022 IR 126'])

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -454,6 +454,6 @@ class TestCharset(object):
         """Test we get a deprecation warning when using charset.decode()."""
         # Python 3: elem.value is PersonName3, Python 2: elem.value is str
         elem = DataElement(0x00100010, 'PN', 'CITIZEN')
-        msg = r"'charset.decode_element\(\)' is deprecated"
+        msg = r"'charset.decode\(\)' is deprecated"
         with pytest.warns(DeprecationWarning, match=msg):
             pydicom.charset.decode(elem, ['ISO 2022 IR 126'])

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -171,8 +171,10 @@ class TestCharset(object):
                "allow code extensions, ignoring: ISO 2022 IR 100, "
                "ISO 2022 IR 144")
         with pytest.warns(UserWarning, match=msg):
-            pydicom.charset.decode_element(elem, ['ISO_IR 192', 'ISO 2022 IR 100',
-                                          'ISO 2022 IR 144'])
+            pydicom.charset.decode_element(
+                elem,
+                ['ISO_IR 192', 'ISO 2022 IR 100', 'ISO 2022 IR 144']
+            )
             assert u'Buc^Jérôme' == elem.value
 
     def test_convert_encodings_warnings(self):
@@ -271,7 +273,9 @@ class TestCharset(object):
                            b'Dionysios=\x1b\x2d\x46'
                            b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
         # correct encoding
-        pydicom.charset.decode_element(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 126'])
+        pydicom.charset.decode_element(
+            elem, ['ISO 2022 IR 100', 'ISO 2022 IR 126']
+        )
         assert u'Dionysios=Διονυσιος' == elem.value
 
         # patched encoding shall behave correctly, but a warning is issued
@@ -301,11 +305,15 @@ class TestCharset(object):
         """Test that the first value is used if no escape code is given"""
         # regression test for #707
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xe9r\xf4me')
-        pydicom.charset.decode_element(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 144'])
+        pydicom.charset.decode_element(
+            elem, ['ISO 2022 IR 100', 'ISO 2022 IR 144']
+        )
         assert u'Buc^Jérôme' == elem.value
 
         elem = DataElement(0x00081039, 'LO', b'R\xf6ntgenaufnahme')
-        pydicom.charset.decode_element(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 144'])
+        pydicom.charset.decode_element(
+            elem, ['ISO 2022 IR 100', 'ISO 2022 IR 144']
+        )
         assert u'Röntgenaufnahme' == elem.value
 
     def test_single_byte_multi_charset_personname(self):
@@ -313,7 +321,9 @@ class TestCharset(object):
         elem = DataElement(0x00100010, 'PN',
                            b'Dionysios=\x1b\x2d\x46'
                            b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
-        pydicom.charset.decode_element(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 126'])
+        pydicom.charset.decode_element(
+            elem, ['ISO 2022 IR 100', 'ISO 2022 IR 126']
+        )
         assert u'Dionysios=Διονυσιος' == elem.value
 
         # multiple values with different encodings
@@ -332,7 +342,9 @@ class TestCharset(object):
         elem = DataElement(0x00081039, 'LO',
                            b'Dionysios is \x1b\x2d\x46'
                            b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
-        pydicom.charset.decode_element(elem, ['ISO 2022 IR 100', 'ISO 2022 IR 126'])
+        pydicom.charset.decode_element(
+            elem, ['ISO 2022 IR 100', 'ISO 2022 IR 126']
+        )
         assert u'Dionysios is Διονυσιος' == elem.value
 
         # multiple values with different encodings

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -425,12 +425,19 @@ class TestReader(object):
         long_specific_char_set_value = ['ISO 2022IR 100'] * 9
         ds.add(DataElement(0x00080005, 'CS', long_specific_char_set_value))
 
+        msg = (
+            r"Unknown encoding 'ISO 2022IR 100' - using default encoding "
+            r"instead"
+        )
+
         fp = BytesIO()
         file_ds = FileDataset(fp, ds)
-        file_ds.save_as(fp, write_like_original=True)
+        with pytest.warns(UserWarning, match=msg):
+            file_ds.save_as(fp, write_like_original=True)
 
-        ds = dcmread(fp, defer_size=65, force=True)
-        assert long_specific_char_set_value == ds[0x00080005].value
+        with pytest.warns(UserWarning, match=msg):
+            ds = dcmread(fp, defer_size=65, force=True)
+            assert long_specific_char_set_value == ds[0x00080005].value
 
     def test_no_preamble_file_meta_dataset(self):
         """Test correct read of group 2 elements with no preamble."""


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
* Removes deprecated functions `dataelem.isMultiValue()` and `datadict.tag_for_name()`
* Removed `dataset.PropertyError` which hasn't been used [since 2017](https://github.com/pydicom/pydicom/commit/428ec344d1110da7a336cc412f6bd8a3d2af591e)
* Renamed `charset.decode()` to `decode_element()` and deprecated `charset.decode()` for removal in v1.5
* Changed a filereader test to capture the character set warning.