### PR TITLE
[MRG] add the capability of scrolling with mouse wheel

### DIFF
--- a/examples/dicomtree.py
+++ b/examples/dicomtree.py
@@ -39,9 +39,12 @@ def RunTree(w, filename):
     box.pack(side=tkinter_tix.BOTTOM, fill=tkinter_tix.X)
     top.pack(side=tkinter_tix.TOP, fill=tkinter_tix.BOTH, expand=1)
     # https://stackoverflow.com/questions/17355902/python-tkinter-binding-mousewheel-to-scrollbar
-    tree.bind_all('<MouseWheel>', lambda event: tree.hlist.yview_scroll(int(-1*event.delta/120.), "units"))  # Wheel in Windows
-    tree.bind_all('<Button-4>', lambda event: tree.hlist.yview_scroll(int(-1), "units"))  # Wheel up in Linux
-    tree.bind_all('<Button-5>', lambda event: tree.hlist.yview_scroll(int(+1), "units"))  # Wheel down in Linux
+    tree.bind_all('<MouseWheel>', lambda event: \
+                  tree.hlist.yview_scroll(int(-1*event.delta/120.), "units"))  # Wheel in Windows
+    tree.bind_all('<Button-4>', lambda event: \
+                  tree.hlist.yview_scroll(int(-1), "units"))  # Wheel up in Linux
+    tree.bind_all('<Button-5>', lambda event: \
+                  tree.hlist.yview_scroll(int(+1), "units"))  # Wheel down in Linux
 
     show_file(filename, tree)
 

--- a/examples/dicomtree.py
+++ b/examples/dicomtree.py
@@ -1,10 +1,12 @@
 """
+sudo apt install tix-dev
+sudo pip install -U pydicom
+python3 dicomtree.py file.dcm
+
 =========================================
 Show a dicom file using hierarchical tree
 =========================================
-
 Show a dicom file using a hierarchical tree in a graphical window.
-
 """
 
 # authors : Guillaume Lemaitre <g.lemaitre58@gmail.com>
@@ -38,6 +40,10 @@ def RunTree(w, filename):
     box.add('exit', text='Exit', underline=0, command=w.destroy, width=6)
     box.pack(side=tkinter_tix.BOTTOM, fill=tkinter_tix.X)
     top.pack(side=tkinter_tix.TOP, fill=tkinter_tix.BOTH, expand=1)
+    #https://stackoverflow.com/questions/17355902/python-tkinter-binding-mousewheel-to-scrollbar
+    tree.bind_all('<MouseWheel>', lambda event: tree.hlist.yview_scroll(int(-1*event.delta/120.), "units"))  # Wheel in Windows
+    tree.bind_all('<Button-4>', lambda event: tree.hlist.yview_scroll(int(-1), "units"))  # Wheel up in Linux
+    tree.bind_all('<Button-5>', lambda event: tree.hlist.yview_scroll(int(+1), "units"))  # Wheel down in Linux
 
     show_file(filename, tree)
 
@@ -79,7 +85,7 @@ if __name__ == '__main__':
         print(usage)
         sys.exit(-1)
     root = tkinter_tix.Tk()
-    root.geometry("{0:d}x{1:d}+{2:d}+{3:d}".format(800, 600, 0, 0))
+    root.geometry("{0:d}x{1:d}+{2:d}+{3:d}".format(1200, 900, 0, 0))
 
     RunTree(root, sys.argv[1])
     root.mainloop()

--- a/examples/dicomtree.py
+++ b/examples/dicomtree.py
@@ -39,12 +39,12 @@ def RunTree(w, filename):
     box.pack(side=tkinter_tix.BOTTOM, fill=tkinter_tix.X)
     top.pack(side=tkinter_tix.TOP, fill=tkinter_tix.BOTH, expand=1)
     # https://stackoverflow.com/questions/17355902/python-tkinter-binding-mousewheel-to-scrollbar
-    tree.bind_all('<MouseWheel>', lambda event: \
-                  tree.hlist.yview_scroll(int(-1*event.delta/120.), "units"))  # Wheel in Windows
-    tree.bind_all('<Button-4>', lambda event: \
-                  tree.hlist.yview_scroll(int(-1), "units"))  # Wheel up in Linux
-    tree.bind_all('<Button-5>', lambda event: \
-                  tree.hlist.yview_scroll(int(+1), "units"))  # Wheel down in Linux
+    tree.bind_all('<MouseWheel>', lambda event:  # Wheel in Windows
+                  tree.hlist.yview_scroll(int(-1*event.delta/120.), "units"))
+    tree.bind_all('<Button-4>', lambda event:  # Wheel up in Linux
+                  tree.hlist.yview_scroll(int(-1), "units"))
+    tree.bind_all('<Button-5>', lambda event:  # Wheel down in Linux
+                  tree.hlist.yview_scroll(int(+1), "units"))
 
     show_file(filename, tree)
 

--- a/examples/dicomtree.py
+++ b/examples/dicomtree.py
@@ -38,7 +38,7 @@ def RunTree(w, filename):
     box.add('exit', text='Exit', underline=0, command=w.destroy, width=6)
     box.pack(side=tkinter_tix.BOTTOM, fill=tkinter_tix.X)
     top.pack(side=tkinter_tix.TOP, fill=tkinter_tix.BOTH, expand=1)
-    #https://stackoverflow.com/questions/17355902/python-tkinter-binding-mousewheel-to-scrollbar
+    # https://stackoverflow.com/questions/17355902/python-tkinter-binding-mousewheel-to-scrollbar
     tree.bind_all('<MouseWheel>', lambda event: tree.hlist.yview_scroll(int(-1*event.delta/120.), "units"))  # Wheel in Windows
     tree.bind_all('<Button-4>', lambda event: tree.hlist.yview_scroll(int(-1), "units"))  # Wheel up in Linux
     tree.bind_all('<Button-5>', lambda event: tree.hlist.yview_scroll(int(+1), "units"))  # Wheel down in Linux

--- a/examples/dicomtree.py
+++ b/examples/dicomtree.py
@@ -1,3 +1,4 @@
+# Copyright pydicom authors 2019. See LICENSE file for details
 """
 sudo apt install tix-dev
 sudo pip install -U pydicom
@@ -8,9 +9,6 @@ Show a dicom file using hierarchical tree
 =========================================
 Show a dicom file using a hierarchical tree in a graphical window.
 """
-
-# authors : Guillaume Lemaitre <g.lemaitre58@gmail.com>
-# license : MIT
 
 from __future__ import print_function
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md#contributing-pull-requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Scrolling with the mouse wheel was not possible in the DICOM tree window. With a oneliner, this capability has been added. Window geometry has been also made slightly bigger.

#### Any other comments?
<!--
-->

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
