### PR TITLE
[MRG] Fix issues with coverage report uploading failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,4 +64,5 @@ script:
   - py.test --cov=pydicom -r sx --pyargs pydicom
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash --connect-timeout 240)
+  # curl times out sometimes, so try try again...
+  - bash <(curl -s https://codecov.io/bash) || (sleep 5 && bash <(curl -s https://codecov.io/bash))

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,4 +64,4 @@ script:
   - py.test --cov=pydicom -r sx --pyargs pydicom
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash --connect-timeout 240)

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,5 +64,5 @@ script:
   - py.test --cov=pydicom -r sx --pyargs pydicom
 
 after_success:
-  # curl times out sometimes, so try try again...
-  - bash <(curl -s https://codecov.io/bash) || (sleep 5 && bash <(curl -s https://codecov.io/bash))
+  # curl times out sometimes, so try try again... ugly but it works
+  - bash <(curl -s https://codecov.io/bash) || (sleep 5 && bash <(curl -s https://codecov.io/bash)) || (sleep 5 && bash <(curl -s https://codecov.io/bash))

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,4 +64,4 @@ script:
   - py.test --cov=pydicom -r sx --pyargs pydicom
 
 after_success:
-  - codecov
+  - bash <(curl -s https://codecov.io/bash)

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -43,6 +43,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
     conda create -n testenv --yes python=$PYTHON_VERSION pip
     source activate testenv
     conda install --yes nose pytest pytest-cov setuptools
+    conda list
     if [[ "$NUMPY" == "true" ]]; then
         conda install --yes numpy
     fi

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -43,7 +43,6 @@ if [[ "$DISTRIB" == "conda" ]]; then
     conda create -n testenv --yes python=$PYTHON_VERSION pip
     source activate testenv
     conda install --yes nose pytest pytest-cov setuptools
-    conda list
     if [[ "$NUMPY" == "true" ]]; then
         conda install --yes numpy
     fi

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -67,7 +67,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
         conda install --yes -c conda-forge gdcm=2.8.4
     fi
     # Install nose-timer via pip
-    pip install nose-timer codecov
+    pip install nose-timer
 
 elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # At the time of writing numpy 1.9.1 is included in the travis
@@ -77,7 +77,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # Create a new virtualenv using system site packages for python, numpy
     virtualenv --system-site-packages testvenv
     source testvenv/bin/activate
-    pip install nose nose-timer pytest pytest-cov codecov setuptools
+    pip install nose nose-timer pytest pytest-cov setuptools
     if [[ "$NUMPY" == "true" ]]; then
         pip install --upgrade --force-reinstall numpy
     fi
@@ -109,7 +109,7 @@ elif [[ "$DISTRIB" == "pypy" ]]; then
         # see #794 - avoid PyPy bug with newer NumPy versions
         python -m pip install cython numpy==1.15.4
     fi
-    python -m pip install nose nose-timer pytest pytest-cov codecov setuptools
+    python -m pip install nose nose-timer pytest pytest-cov setuptools
 fi
 
 python --version


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
After successful builds the codecov upload intermittently fails.

This PR switches from using the codecov python uploader to the [bash one](https://docs.codecov.io/docs/about-the-codecov-bash-uploader) as recommended [here](https://community.codecov.io/t/unreliable-coverage-report-uploads/322/3)

Upload failures seem to have gone from about 5/37 to 0