### PR TITLE
[MRG] Improve codecov upload robustness

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -25,14 +25,4 @@ ignore:
   - "pydicom/benchmarks"
 
 # Pull request comments, use `comment: off` to disable
-comment:
-  # header: default message header?, diff: the coverage diff of the PR
-  layout: "header, diff"
-  # update the PR comment if it exists, otherwise post a new comment
-  behavior: default
-  # Always post a comment even if the coverage doesn't change
-  require_changes: no
-  # Post comment even if no coverage report for head exists
-  require_head: no
-  # Post comment even if no coverage report for base exists
-  require_base: no
+comment: off

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -36,7 +36,3 @@ comment:
   require_head: no
   # Post comment even if no coverage report for base exists
   require_base: no
-
-fixes:
-  # codecov needs to match the repo files to the path in the coverage report
-  - "::/home/travis/build/pydicom/"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,24 +1,42 @@
-comment: off
-
 coverage:
+  # number of digits after decimal point
+  precision: 2
+  # round coverage value down to `precision`
+  round: down
+
   status:
+    # master coverage
     project:
       default:
-        # Commits pushed to master should not make the overall
-        # project coverage decrease by more than 1%:
+        # auto: use coverage from base commit
         target: auto
+        # Allow coverage to drop by the following and still be success
         threshold: 1%
+
+    # PR coverage
     patch:
       default:
-        # Be tolerant on slight code coverage diff on PRs to limit
-        # noisy red coverage status on github PRs.
-        # Note The coverage stats are still uploaded
-        # to codecov so that PR reviewers can see uncovered lines
-        # in the github diff if they install the codecov browser
-        # extension:
-        # https://github.com/codecov/browser-extension
         target: auto
         threshold: 1%
+
+# Ignore these paths when calculating the coverage
 ignore:
   - "pydicom/tests"
   - "pydicom/benchmarks"
+
+# Pull request comments, use `comment: off` to disable
+comment:
+  # header: default message header?, diff: the coverage diff of the PR
+  layout: "header, diff"
+  # update the PR comment if it exists, otherwise post a new comment
+  behavior: default
+  # Always post a comment even if the coverage doesn't change
+  require_changes: no
+  # Post comment even if no coverage report for head exists
+  require_head: no
+  # Post comment even if no coverage report for base exists
+  require_base: no
+
+fixes:
+  # codecov needs to match the repo files to the path in the coverage report
+  - "::/home/travis/build/pydicom/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,5 +65,5 @@ script:
 
 after_success:
   # curl times out sometimes, so drop the connection timeout but retry more often
-  - bash <(curl --connect-timeout 30 --retry 10 --retry-max-time 0 https://codecov.io/bash) ||
-    (sleep 30 && bash <(curl --connect-timeout 30 --retry 10 --retry-max-time 0 https://codecov.io/bash))
+  - bash <(curl --connect-timeout 10 --retry 10 --retry-max-time 0 https://codecov.io/bash) ||
+    (sleep 30 && bash <(curl --connect-timeout 10 --retry 10 --retry-max-time 0 https://codecov.io/bash))

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,6 @@ script:
   - py.test --cov=pydicom -r sx --pyargs pydicom
 
 after_success:
-  # curl times out sometimes, so try try again... ugly but it works
-  - bash <(curl -s https://codecov.io/bash) ||
-    (sleep 30 && bash <(curl -s https://codecov.io/bash)) || 
-    (sleep 30 && bash <(curl -s https://codecov.io/bash)) ||
-    (sleep 30 && bash <(curl -s https://codecov.io/bash))
+  # curl times out sometimes, so drop the connection timeout but retry more often
+  - bash <(curl --connect-timeout 30 --retry 10 --retry-max-time 0 https://codecov.io/bash) ||
+    (sleep 30 && bash <(curl --connect-timeout 30 --retry 10 --retry-max-time 0 https://codecov.io/bash)) ||

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,4 +66,4 @@ script:
 after_success:
   # curl times out sometimes, so drop the connection timeout but retry more often
   - bash <(curl --connect-timeout 30 --retry 10 --retry-max-time 0 https://codecov.io/bash) ||
-    (sleep 30 && bash <(curl --connect-timeout 30 --retry 10 --retry-max-time 0 https://codecov.io/bash)) ||
+    (sleep 30 && bash <(curl --connect-timeout 30 --retry 10 --retry-max-time 0 https://codecov.io/bash))

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,7 @@ script:
 
 after_success:
   # curl times out sometimes, so try try again... ugly but it works
-  - bash <(curl -s https://codecov.io/bash) || (sleep 5 && bash <(curl -s https://codecov.io/bash)) || (sleep 5 && bash <(curl -s https://codecov.io/bash))
+  - bash <(curl -s https://codecov.io/bash) ||
+    (sleep 30 && bash <(curl -s https://codecov.io/bash)) || 
+    (sleep 30 && bash <(curl -s https://codecov.io/bash)) ||
+    (sleep 30 && bash <(curl -s https://codecov.io/bash))


### PR DESCRIPTION
Still getting about 1-2 upload failures every 74 builds due to failure to download the codecov bash script (curl timeout).

#### Later that day...
OK, 0 upload failures in 148 builds... now have to figure out why the reports [aren't being merged properly](https://codecov.io/gh/pydicom/pydicom/src/2c65dc6b0189bc7598105dbfc6a371f38c0a9569/pydicom/__init__.py#L51)

* Drops the curl timeout to 10 s from 120 s so timeouts trigger a retry faster
* Add 10 (x2) retry attempts