### PR TITLE
[EXP] Optimise builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 sudo: true
 
 language: python
@@ -45,51 +45,46 @@ matrix:
     - name: "Python 3.7 with numpy"
       python: 3.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - name: "Python 3.7 with numpy and pillow (jpeg)"
-      python: 3.7
-      env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=jpeg29 JPEG_LS=false GDCM=false
 
     # PyPy builds" numpy
-    - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-      name: "PyPy 2.7 with numpy"
-    - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-      name: "PyPy 3.5 with numpy"
+    - name: "PyPy 2.7 with numpy"
+      env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - name: "PyPy 3.5 with numpy"
+      env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
 
     # Conda builds: numpy + pillow (both), numpy + JPEG-LS, numpy + GDCM
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-      name: "Python 2.7 with numpy and pillow (both)"
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
-      name: "Conda 2.7 with numpy and JPEG-LS"
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-      name: "Conda 2.7 with numpy and GDCM"
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-      name: "Python 3.4 with numpy and pillow (both)"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
-      name: "Conda 3.4 with numpy and JPEG-LS"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-      name: "Conda 3.4 with numpy and GDCM"
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-      name: "Python 3.5 with numpy and pillow (both)"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
-      name: "Conda 3.5 with numpy and JPEG-LS"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-      name: "Conda 3.5 with numpy and GDCM"
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-      name: "Python 3.6 with numpy and pillow (both)"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=true  GDCM=false
-      name: "Conda 3.6 with numpy and JPEG-LS"
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false  GDCM=true
-      name: "Conda 3.6 with numpy and GDCM"
+    - name: "Python 2.7 with numpy and pillow (both)"
+      env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - name: "Conda 2.7 with numpy and JPEG-LS"
+      env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
+    - name: "Conda 2.7 with numpy and GDCM"
+      env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+    - name: "Python 3.4 with numpy and pillow (both)"
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - name: "Conda 3.4 with numpy and JPEG-LS"
+      env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
+    - name: "Conda 3.4 with numpy and GDCM"
+      env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+    - name: "Python 3.5 with numpy and pillow (both)"
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - name: "Conda 3.5 with numpy and JPEG-LS"
+      env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
+    - name: "Conda 3.5 with numpy and GDCM"
+      env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+    - name: "Python 3.6 with numpy and pillow (both)"
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - name: "Conda 3.6 with numpy and JPEG-LS"
+      env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=true  GDCM=false
+    - name: "Conda 3.6 with numpy and GDCM"
+      env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false  GDCM=true
     # Test old version of GDCM for `HAVE_GDCM_IN_MEMORY_SUPPORT = False`, only for Python 3.6
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=old
-      name: "Conda 3.6 with numpy and GDCM 2.8.4"
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-      name: "Python 3.7 with numpy and pillow (both)"
+    - name: "Conda 3.6 with numpy and GDCM 2.8.4"
+      env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=old
+    - name: "Python 3.7 with numpy and pillow (jpeg)"
+      env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=jpeg29 JPEG_LS=false GDCM=false
     #- env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-      name: "Conda 3.7 with numpy and GDCM"
-
-
+    - name: "Conda 3.7 with numpy and GDCM"
+      env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
 
 install: source build_tools/travis/install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,59 @@ cache:
 
 matrix:
   include:
+    # Ubuntu builds: no numpy, numpy, numpy + pillow (both), numpy + pillow(jpeg)
+    - name: "Python 2.7"
+      python: 2.7
+      env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 2.7 with numpy"
+      python: 2.7
+      env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 2.7 with numpy and pillow (both)"
+      python: 2.7
+      env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - name: "Python 2.7 with numpy and pillow (jpeg)"
+      python: 2.7
+      env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
+    - name: "Python 3.4"
+      python: 3.4
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 3.4 with numpy"
+      python: 3.4
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 3.4 with numpy and pillow (both)"
+      python: 3.4
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - name: "Python 3.5"
+      python: 3.5
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 3.5 with numpy"
+      python: 3.5
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 3.5 with numpy and pillow (both)"
+      python: 3.5
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - name: "Python 3.6"
+      python: 3.6
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 3.6 with numpy"
+      python: 3.6
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 3.6 with numpy and pillow (both)"
+      python: 3.6
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - name: "Python 3.7"
+      python: 3.7
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 3.7 with numpy"
+      python: 3.7
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 3.7 with numpy and pillow (both)"
+      python: 3.7
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    # PyPy with numpy
     - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
     - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    # Tests for numpy + JPEGLS, numpy + GDCM
+    # Conda with numpy + JPEGLS, numpy + GDCM
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
     - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
@@ -24,26 +74,10 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false  GDCM=true
     # Test old version of GDCM for `HAVE_GDCM_IN_MEMORY_SUPPORT = False`, only for Python 3.6
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=old
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
+    #- env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-    # Ubuntu builds: no numpy, numpy, numpy + pillow (both), numpy + pillow(jpeg)
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true PILLOW=both JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true PILLOW=both JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true PILLOW=both JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
-    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+
+
 
 install: source build_tools/travis/install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ matrix:
     - name: "Python 2.7 with numpy"
       python: 2.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - name: "Python 2.7 with numpy and pillow (both)"
-      python: 2.7
-      env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Python 2.7 with numpy and pillow (jpeg)"
       python: 2.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
@@ -30,36 +27,24 @@ matrix:
     - name: "Python 3.4 with numpy"
       python: 3.4
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - name: "Python 3.4 with numpy and pillow (both)"
-      python: 3.4
-      env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Python 3.5"
       python: 3.5
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - name: "Python 3.5 with numpy"
       python: 3.5
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - name: "Python 3.5 with numpy and pillow (both)"
-      python: 3.5
-      env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Python 3.6"
       python: 3.6
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - name: "Python 3.6 with numpy"
       python: 3.6
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - name: "Python 3.6 with numpy and pillow (both)"
-      python: 3.6
-      env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Python 3.7"
       python: 3.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - name: "Python 3.7 with numpy"
       python: 3.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - name: "Python 3.7 with numpy and pillow (both)"
-      python: 3.7
-      env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Python 3.7 with numpy and pillow (jpeg)"
       python: 3.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=jpeg29 JPEG_LS=false GDCM=false
@@ -70,19 +55,27 @@ matrix:
     - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
       name: "PyPy 3.5 with numpy"
 
-    # Conda builds: numpy + JPEG-LS, numpy + GDCM
+    # Conda builds: numpy + pillow (both), numpy + JPEG-LS, numpy + GDCM
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+      name: "Python 2.7 with numpy and pillow (both)"
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
       name: "Conda 2.7 with numpy and JPEG-LS"
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
       name: "Conda 2.7 with numpy and GDCM"
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+      name: "Python 3.4 with numpy and pillow (both)"
     - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
       name: "Conda 3.4 with numpy and JPEG-LS"
     - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
       name: "Conda 3.4 with numpy and GDCM"
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+      name: "Python 3.5 with numpy and pillow (both)"
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
       name: "Conda 3.5 with numpy and JPEG-LS"
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
       name: "Conda 3.5 with numpy and GDCM"
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+      name: "Python 3.6 with numpy and pillow (both)"
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=true  GDCM=false
       name: "Conda 3.6 with numpy and JPEG-LS"
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false  GDCM=true
@@ -90,6 +83,8 @@ matrix:
     # Test old version of GDCM for `HAVE_GDCM_IN_MEMORY_SUPPORT = False`, only for Python 3.6
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=old
       name: "Conda 3.6 with numpy and GDCM 2.8.4"
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+      name: "Python 3.7 with numpy and pillow (both)"
     #- env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
       name: "Conda 3.7 with numpy and GDCM"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,52 +11,39 @@ cache:
 
 matrix:
   include:
-    - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
+    # Tests for numpy + JPEGLS, numpy + GDCM
+    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
-
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
-
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
-
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=old
-
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
-    #- env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7.3" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7.3" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
-    #- env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
-
-    - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7.3" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
-
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=true  GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false  GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+    # Test old version of GDCM for `HAVE_GDCM_IN_MEMORY_SUPPORT = False`
+    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=old
+    # Ubuntu builds: no numpy, numpy, numpy + pillow (both), numpy + pillow(jpeg)
     - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true PILLOW=both JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true PILLOW=both JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true PILLOW=both JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
+    - env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
 
 install: source build_tools/travis/install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       python: 2.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
     - name: "Python 2.7 with numpy and pillow (both)"
-      python: 2.8
+      python: 2.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Python 3.4"
       python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=true  GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false  GDCM=true
+    # Test old version of GDCM for `HAVE_GDCM_IN_MEMORY_SUPPORT = False`, only for Python 3.6
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=old
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-    # Test old version of GDCM for `HAVE_GDCM_IN_MEMORY_SUPPORT = False`
-    - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=old
     # Ubuntu builds: no numpy, numpy, numpy + pillow (both), numpy + pillow(jpeg)
     - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,22 +60,36 @@ matrix:
     - name: "Python 3.7 with numpy and pillow (both)"
       python: 3.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-    # PyPy with numpy
+
+    # PyPy builds" numpy
     - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+      name: "PyPy 2.7 with numpy"
     - env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
-    # Conda with numpy + JPEGLS, numpy + GDCM
+      name: "PyPy 3.5 with numpy"
+
+    # Conda builds: numpy + JPEG-LS, numpy + GDCM
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
+      name: "Conda 2.7 with numpy and JPEG-LS"
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+      name: "Conda 2.7 with numpy and GDCM"
     - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
+      name: "Conda 3.4 with numpy and JPEG-LS"
     - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+      name: "Conda 3.4 with numpy and GDCM"
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
+      name: "Conda 3.5 with numpy and JPEG-LS"
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+      name: "Conda 3.5 with numpy and GDCM"
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=true  GDCM=false
+      name: "Conda 3.6 with numpy and JPEG-LS"
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false  GDCM=true
+      name: "Conda 3.6 with numpy and GDCM"
     # Test old version of GDCM for `HAVE_GDCM_IN_MEMORY_SUPPORT = False`, only for Python 3.6
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=old
+      name: "Conda 3.6 with numpy and GDCM 2.8.4"
     #- env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+      name: "Conda 3.7 with numpy and GDCM"
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,9 @@ matrix:
     - name: "Python 3.7 with numpy and pillow (both)"
       python: 3.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - name: "Python 3.7 with numpy and pillow (jpeg)"
+      python: 3.7
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=jpeg29 JPEG_LS=false GDCM=false
 
     # PyPy builds" numpy
     - env: DISTRIB="pypy" PYTHON_VERSION="2.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: xenial
 sudo: true
 
 language: python
@@ -21,30 +21,48 @@ matrix:
     - name: "Python 2.7 with numpy and pillow (jpeg)"
       python: 2.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
+    - name: "Python 2.7 with numpy and pillow (both)"
+      python: 2.8
+      env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Python 3.4"
       python: 3.4
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - name: "Python 3.4 with numpy"
       python: 3.4
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 3.4 with numpy and pillow (both)"
+      python: 3.4
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Python 3.5"
       python: 3.5
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - name: "Python 3.5 with numpy"
       python: 3.5
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 3.5 with numpy and pillow (both)"
+      python: 3.5
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Python 3.6"
       python: 3.6
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - name: "Python 3.6 with numpy"
       python: 3.6
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 3.6 with numpy and pillow (both)"
+      python: 3.6
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Python 3.7"
       python: 3.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - name: "Python 3.7 with numpy"
       python: 3.7
       env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
+    - name: "Python 3.7 with numpy and pillow (jpeg)"
+      python: 3.7
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
+    - name: "Python 3.7 with numpy and pillow (both)"
+      python: 3.7
+      env: DISTRIB="ubuntu" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
 
     # PyPy builds" numpy
     - name: "PyPy 2.7 with numpy"
@@ -52,27 +70,19 @@ matrix:
     - name: "PyPy 3.5 with numpy"
       env: DISTRIB="pypy" PYTHON_VERSION="3.5" NUMPY=true PILLOW=false JPEG_LS=false GDCM=false
 
-    # Conda builds: numpy + pillow (both), numpy + JPEG-LS, numpy + GDCM
-    - name: "Python 2.7 with numpy and pillow (both)"
-      env: DISTRIB="ubuntu" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    # Conda builds: numpy + JPEG-LS, numpy + GDCM
     - name: "Conda 2.7 with numpy and JPEG-LS"
       env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
     - name: "Conda 2.7 with numpy and GDCM"
       env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-    - name: "Python 3.4 with numpy and pillow (both)"
-      env: DISTRIB="ubuntu" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Conda 3.4 with numpy and JPEG-LS"
       env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
     - name: "Conda 3.4 with numpy and GDCM"
       env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-    - name: "Python 3.5 with numpy and pillow (both)"
-      env: DISTRIB="ubuntu" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Conda 3.5 with numpy and JPEG-LS"
       env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
     - name: "Conda 3.5 with numpy and GDCM"
       env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-    - name: "Python 3.6 with numpy and pillow (both)"
-      env: DISTRIB="ubuntu" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - name: "Conda 3.6 with numpy and JPEG-LS"
       env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=true  GDCM=false
     - name: "Conda 3.6 with numpy and GDCM"
@@ -80,8 +90,6 @@ matrix:
     # Test old version of GDCM for `HAVE_GDCM_IN_MEMORY_SUPPORT = False`, only for Python 3.6
     - name: "Conda 3.6 with numpy and GDCM 2.8.4"
       env: DISTRIB="conda" PYTHON_VERSION="3.6" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=old
-    - name: "Python 3.7 with numpy and pillow (jpeg)"
-      env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=jpeg29 JPEG_LS=false GDCM=false
     #- env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=true GDCM=false
     - name: "Conda 3.7 with numpy and GDCM"
       env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -68,7 +68,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     #virtualenv --system-site-packages testvenv
     #source testvenv/bin/activate
     pip install --upgrade pytest
-    pip uninstall numpy
+    pip uninstall -y numpy
     pip install nose nose-timer pytest-cov setuptools
     if [[ "$NUMPY" == "true" ]]; then
         pip install --upgrade --force-reinstall numpy

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -76,7 +76,8 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
         pip uninstall -y numpy
     fi
     if [[ "$PILLOW" == "both" ]]; then
-        sudo apt install -y libopenjp2-7
+        sudo apt-get update
+        sudo apt-get install -y libopenjp2-7
         pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
         python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
         python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -67,12 +67,13 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # Create a new virtualenv using system site packages for python, numpy
     #virtualenv --system-site-packages testvenv
     #source testvenv/bin/activate
-    pip install nose nose-timer coverage pytest pytest-cov setuptools
+    pip install --upgrade pytest
+    pip install nose nose-timer pytest-cov setuptools
     if [[ "$NUMPY" == "true" ]]; then
         pip install --upgrade --force-reinstall numpy
     fi
     if [[ "$PILLOW" == "both" ]]; then
-        sudo apt install libopenjp2-7
+        sudo apt install libopenjpeg2
         pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
         python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
         python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -68,12 +68,13 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     #virtualenv --system-site-packages testvenv
     #source testvenv/bin/activate
     pip install --upgrade pytest
+    pip uninstall numpy
     pip install nose nose-timer pytest-cov setuptools
     if [[ "$NUMPY" == "true" ]]; then
         pip install --upgrade --force-reinstall numpy
     fi
     if [[ "$PILLOW" == "both" ]]; then
-        sudo apt install libopenjpeg2
+        sudo apt install libopenjpeg
         pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
         python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
         python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -63,16 +63,16 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # At the time of writing numpy 1.9.1 is included in the travis
     # virtualenv but we want to use the numpy installed through apt-get
     # install.
-    deactivate
+    #deactivate
     # Create a new virtualenv using system site packages for python, numpy
-    virtualenv --system-site-packages testvenv
-    source testvenv/bin/activate
+    #virtualenv --system-site-packages testvenv
+    #source testvenv/bin/activate
     pip install nose nose-timer pytest pytest-cov setuptools
     if [[ "$NUMPY" == "true" ]]; then
         pip install --upgrade --force-reinstall numpy
     fi
     if [[ "$PILLOW" == "both" ]]; then
-        apt install openjpeg
+        sudo apt install openjpeg
         pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
         python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
         python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -72,6 +72,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
         pip install --upgrade --force-reinstall numpy
     fi
     if [[ "$PILLOW" == "both" ]]; then
+        apt install openjpeg
         pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
         python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
         python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -46,6 +46,16 @@ if [[ "$DISTRIB" == "conda" ]]; then
     if [[ "$NUMPY" == "true" ]]; then
         conda install --yes numpy
     fi
+    if [[ "$PILLOW" == "both" ]]; then
+        conda install --yes -c conda-forge openjpeg jpeg
+        pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
+        python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
+        python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"
+    elif [[ "$PILLOW" == "jpeg" ]]; then
+        pip install pillow --global-option="build_ext" --global-option="--disable-jpeg2000"
+        python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
+        python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"
+    fi
     if [[ "$JPEG_LS" == "true" ]]; then
         conda install --yes cython
         export MSCV=False

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -46,16 +46,6 @@ if [[ "$DISTRIB" == "conda" ]]; then
     if [[ "$NUMPY" == "true" ]]; then
         conda install --yes numpy
     fi
-    if [[ "$PILLOW" == "both" ]]; then
-        conda install --yes -c conda-forge openjpeg jpeg
-        pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
-        python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
-        python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"
-    elif [[ "$PILLOW" == "jpeg" ]]; then
-        pip install pillow --global-option="build_ext" --global-option="--disable-jpeg2000"
-        python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
-        python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"
-    fi
     if [[ "$JPEG_LS" == "true" ]]; then
         conda install --yes cython
         export MSCV=False
@@ -84,7 +74,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
         pip install --upgrade --force-reinstall numpy
     fi
     if [[ "$PILLOW" == "both" ]]; then
-        sudo apt install libopenjpeg
+        sudo apt install libopenjp2-7
         pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
         python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
         python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -77,7 +77,7 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     fi
     if [[ "$PILLOW" == "both" ]]; then
         sudo apt-get update
-        sudo apt-get install -y libopenjp2-7
+        sudo apt-get install -y libopenjp2-7 libopenjp2-7-dev
         pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
         python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
         python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -68,13 +68,15 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     #virtualenv --system-site-packages testvenv
     #source testvenv/bin/activate
     pip install --upgrade pytest
-    pip uninstall -y numpy
+
     pip install nose nose-timer pytest-cov setuptools
     if [[ "$NUMPY" == "true" ]]; then
         pip install --upgrade --force-reinstall numpy
+    else
+        pip uninstall -y numpy
     fi
     if [[ "$PILLOW" == "both" ]]; then
-        sudo apt install libopenjp2-7
+        sudo apt install -y libopenjp2-7
         pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
         python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
         python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -46,16 +46,6 @@ if [[ "$DISTRIB" == "conda" ]]; then
     if [[ "$NUMPY" == "true" ]]; then
         conda install --yes numpy
     fi
-    if [[ "$PILLOW" == "both" ]]; then
-        conda install --yes -c conda-forge openjpeg jpeg
-        pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
-        python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
-        python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"
-    elif [[ "$PILLOW" == "jpeg" ]]; then
-        pip install pillow --global-option="build_ext" --global-option="--disable-jpeg2000"
-        python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
-        python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"
-    fi
     if [[ "$JPEG_LS" == "true" ]]; then
         conda install --yes cython
         export MSCV=False
@@ -80,6 +70,15 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     pip install nose nose-timer pytest pytest-cov setuptools
     if [[ "$NUMPY" == "true" ]]; then
         pip install --upgrade --force-reinstall numpy
+    fi
+    if [[ "$PILLOW" == "both" ]]; then
+        pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
+        python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
+        python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"
+    elif [[ "$PILLOW" == "jpeg" ]]; then
+        pip install pillow --global-option="build_ext" --global-option="--disable-jpeg2000"
+        python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
+        python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"
     fi
 
 elif [[ "$DISTRIB" == "pypy" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -67,12 +67,12 @@ elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # Create a new virtualenv using system site packages for python, numpy
     #virtualenv --system-site-packages testvenv
     #source testvenv/bin/activate
-    pip install nose nose-timer pytest pytest-cov setuptools
+    pip install nose nose-timer coverage pytest pytest-cov setuptools
     if [[ "$NUMPY" == "true" ]]; then
         pip install --upgrade --force-reinstall numpy
     fi
     if [[ "$PILLOW" == "both" ]]; then
-        sudo apt install openjpeg
+        sudo apt install libopenjp2-7
         pip install pillow --global-option="build_ext" --global-option="--enable-jpeg2000"
         python -c "from PIL.features import check_codec; print('JPEG plugin:', check_codec('jpg'))"
         python -c "from PIL.features import check_codec; print('JPEG2k plugin:', check_codec('jpg_2000'))"


### PR DESCRIPTION
#### Reference Issue
Experimental PR for testing Travis build optimisation, related to #928


#### What does this implement/fix? Explain your changes.
Python 2.7, 3.4, 3.5, 3.6, 3.7

Ubuntu Xenial used to build:
* no numpy
* numpy
* numpy + pillow (both)
* numpy + pillow (jpeg only)

Conda used to build:
* numpy + jpeg-ls
* numpy + gdcm

PyPy used to build:
* numpy

Builds reduced from 37 to 29 (including adding build for GDCM + Python 3.7)
Total run time reduced from [20 min 29 s](https://travis-ci.org/pydicom/pydicom/builds/570669535?utm_source=github_status&utm_medium=notification) to [14 min 14 s](https://travis-ci.org/pydicom/pydicom/builds/570713597)
