### PR TITLE
[MRG] Added support for deferred reading in file-like objects

### DIFF
--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -19,4 +19,5 @@ Enhancements
 ............
 
 * Added support for converting (60xx,3000) *Overlay Data* to a numpy ndarray
-  using `Dataset.overlay_array()` (issue:`912`).
+  using `Dataset.overlay_array()` (issue:`912`)
+* Added support for deferred reading in file-like objects (:issue:`932`)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -2114,11 +2114,12 @@ class FileDataset(Dataset):
         self.file_meta = file_meta
         self.is_implicit_VR = is_implicit_VR
         self.is_little_endian = is_little_endian
+        filename = None
         if isinstance(filename_or_obj, compat.string_types):
-            self.filename = filename_or_obj
+            filename = filename_or_obj
             self.fileobj_type = open
         elif isinstance(filename_or_obj, io.BufferedReader):
-            self.filename = filename_or_obj.name
+            filename = filename_or_obj.name
             # This is the appropriate constructor for io.BufferedReader
             self.fileobj_type = open
         else:
@@ -2126,17 +2127,20 @@ class FileDataset(Dataset):
             # http://docs.python.org/reference/datamodel.html
             self.fileobj_type = filename_or_obj.__class__
             if getattr(filename_or_obj, "name", False):
-                self.filename = filename_or_obj.name
+                filename = filename_or_obj.name
             elif getattr(filename_or_obj, "filename",
                          False):  # gzip python <2.7?
-                self.filename = filename_or_obj.filename
+                filename = filename_or_obj.filename
             else:
                 # e.g. came from BytesIO or something file-like
-                self.filename = None
+                self.filename = filename_or_obj
+
         self.timestamp = None
-        if self.filename and os.path.exists(self.filename):
-            statinfo = os.stat(self.filename)
-            self.timestamp = statinfo.st_mtime
+        if filename:
+            self.filename = filename
+            if os.path.exists(filename):
+                statinfo = os.stat(filename)
+                self.timestamp = statinfo.st_mtime
 
     def __eq__(self, other):
         """Compare `self` and `other` for equality.

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -917,6 +917,11 @@ def read_deferred_data_element(fileobj_type, filename_or_obj, timestamp,
     """Read the previously deferred value from the file into memory
     and return a raw data element.
 
+    .. note:
+
+        This is called internally by pydicom and will normally not be
+        needed in user code.
+
     Parameters
     ----------
     fileobj_type : type
@@ -949,10 +954,10 @@ def read_deferred_data_element(fileobj_type, filename_or_obj, timestamp,
     if filename_or_obj is None:
         raise IOError("Deferred read -- original filename not stored. "
                       "Cannot re-open")
-    is_file = isinstance(filename_or_obj, compat.string_types)
+    is_filename = isinstance(filename_or_obj, compat.string_types)
 
     # Check that the file is the same as when originally read
-    if is_file and not os.path.exists(filename_or_obj):
+    if is_filename and not os.path.exists(filename_or_obj):
         raise IOError(u"Deferred read -- original file "
                       "{0:s} is missing".format(filename_or_obj))
     if timestamp is not None:
@@ -962,7 +967,8 @@ def read_deferred_data_element(fileobj_type, filename_or_obj, timestamp,
                           "has changed.")
 
     # Open the file, position to the right place
-    fp = fileobj_type(filename_or_obj, 'rb') if is_file else filename_or_obj
+    fp = (fileobj_type(filename_or_obj, 'rb')
+          if is_filename else filename_or_obj)
     is_implicit_VR = raw_data_elem.is_implicit_VR
     is_little_endian = raw_data_elem.is_little_endian
     offset = data_element_offset_to_value(is_implicit_VR, raw_data_elem.VR)

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -3,6 +3,7 @@
 """Unit tests for the pydicom.filereader module."""
 
 import gzip
+import io
 from io import BytesIO
 import os
 import shutil
@@ -917,6 +918,14 @@ class TestDeferredRead(object):
         # before the fix, this threw an error as file reading was not in
         # the right place, it was re-opened as a normal file, not a zip file
         ds.InstanceNumber
+
+    def test_filelike_deferred(self):
+        """Deferred values work with file-like objects."""
+        with open(ct_name, 'rb') as fp:
+            data = fp.read()
+        filelike = io.BytesIO(data)
+        dataset = pydicom.dcmread(filelike, defer_size=1024)
+        assert 32768 == len(dataset.PixelData)
 
 
 class TestReadTruncatedFile(object):


### PR DESCRIPTION
- closes #932

This is a small change, basically using the `filename` argument to pass the file-like to be able to use it for deferred reading.