### PR TITLE
[MRG] Compatibility fix for Python3.8

### DIFF
--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -90,7 +90,6 @@ class TestDA(object):
 
 class TestDS(object):
     """Unit tests for DS values"""
-
     def test_empty_value(self):
         assert DS(None) is None
         assert '' == DS('')
@@ -106,7 +105,6 @@ class TestDS(object):
 
 class TestDSfloat(object):
     """Unit tests for pickling DSfloat"""
-
     def test_pickling(self):
         # Check that a pickled DSFloat is read back properly
         x = pydicom.valuerep.DSfloat(9.0)
@@ -116,10 +114,25 @@ class TestDSfloat(object):
         assert x.real == x2.real
         assert x.original_string == x2.original_string
 
+    def test_str(self):
+        """Test DSfloat.__str__()."""
+        val = pydicom.valuerep.DSfloat(1.1)
+        assert '1.1' == str(val)
+
+        val = pydicom.valuerep.DSfloat('1.1')
+        assert '1.1' == str(val)
+
+    def test_repr(self):
+        """Test DSfloat.__repr__()."""
+        val = pydicom.valuerep.DSfloat(1.1)
+        assert '"1.1"' == repr(val)
+
+        val = pydicom.valuerep.DSfloat('1.1')
+        assert '"1.1"' == repr(val)
+
 
 class TestDSdecimal(object):
     """Unit tests for pickling DSdecimal"""
-
     def test_pickling(self):
         # Check that a pickled DSdecimal is read back properly
         # DSdecimal actually prefers original_string when
@@ -142,7 +155,6 @@ class TestDSdecimal(object):
 
 class TestIS(object):
     """Unit tests for IS"""
-
     def test_empty_value(self):
         assert IS(None) is None
         assert '' == IS('')
@@ -181,6 +193,22 @@ class TestIS(object):
         with pytest.raises(OverflowError, match="Value exceeds DICOM limits*"):
             pydicom.valuerep.IS(3103050000)
         config.enforce_valid_values = original_flag
+
+    def test_str(self):
+        """Test IS.__str__()."""
+        val = pydicom.valuerep.IS(1)
+        assert '1' == str(val)
+
+        val = pydicom.valuerep.IS('1')
+        assert '1' == str(val)
+
+    def test_repr(self):
+        """Test IS.__repr__()."""
+        val = pydicom.valuerep.IS(1)
+        assert '"1"' == repr(val)
+
+        val = pydicom.valuerep.IS('1')
+        assert '"1"' == repr(val)
 
 
 class TestBadValueRead(object):

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -346,8 +346,9 @@ class DSfloat(float):
     def __str__(self):
         if hasattr(self, 'original_string'):
             return self.original_string
-        else:
-            return super(DSfloat, self).__str__()
+
+        # Issue #937 (Python 3.8 compatibility)
+        return str(float(self))
 
     def __repr__(self):
         return "\"" + str(self) + "\""
@@ -513,11 +514,15 @@ class IS(int):
         elif isinstance(val, IS) and hasattr(val, 'original_string'):
             self.original_string = val.original_string
 
-    def __repr__(self):
+    def __str__(self):
         if hasattr(self, 'original_string'):
-            return "\"" + self.original_string + "\""
-        else:
-            return "\"" + int.__str__(self) + "\""
+            return self.original_string
+
+        # Issue #937 (Python 3.8 compatibility)
+        return str(int(self))
+
+    def __repr__(self):
+        return "\"" + str(self) + "\""
 
 
 def MultiString(val, valtype=str):

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -348,10 +348,10 @@ class DSfloat(float):
             return self.original_string
 
         # Issue #937 (Python 3.8 compatibility)
-        return str(float(self))
+        return repr(self)[1:-1]
 
     def __repr__(self):
-        return "\"" + str(self) + "\""
+        return '"{}"'.format(super(DSfloat, self).__repr__())
 
 
 class DSdecimal(Decimal):
@@ -519,10 +519,10 @@ class IS(int):
             return self.original_string
 
         # Issue #937 (Python 3.8 compatibility)
-        return str(int(self))
+        return repr(self)[1:-1]
 
     def __repr__(self):
-        return "\"" + str(self) + "\""
+        return '"{}"'.format(super(IS, self).__repr__())
 
 
 def MultiString(val, valtype=str):


### PR DESCRIPTION
#### Reference Issue
Closes #937

#### What does this implement/fix? Explain your changes.
Python 3.8 removes `__str__()` from `int` and `float` which instead now call `object.__str__()` which itself defaults to `object.__repr__()`.

`DSfloat.__str__()`, `DSfloat.__repr__()` and `IS.__repr__()` all call the parent class' `__str__()` which calls the subclass' `__repr__()` method and so on, which causes a recursion error.

This PR:
* Fixes `DSfloat.__str__()` by creating a calling repr() instead and removing the `"` marks.
* Fixes `DSfloat.__repr__()` by calling the parent class' `__repr__()` instead of `str()`
* Fixes `IS.__repr__()` by implementing `IS.__str__()` in a similar manner to `DSfloat.__str__()` and making `IS.__repr__()` symmetric with `DSfloat.__repr__()`

See also: https://bugs.python.org/issue36793