### PR TITLE
[MRG] Tolerate text values ending with multiple blanks or zero bytes

### DIFF
--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -21,3 +21,4 @@ Enhancements
 * Added support for converting (60xx,3000) *Overlay Data* to a numpy ndarray
   using `Dataset.overlay_array()` (issue:`912`)
 * Added support for deferred reading in file-like objects (:issue:`932`)
+* Tolerate values with multiple and/or incorrect padding bytes (:issue:`940`)

--- a/pydicom/tests/test_values.py
+++ b/pydicom/tests/test_values.py
@@ -86,6 +86,21 @@ class TestConvertText(object):
         expected = u'Διονυσιος\r\nJérôme/Люкceмбypг\tJérôme'
         assert expected == convert_single_string(bytestring, encodings)
 
+    def test_value_ending_with_padding(self):
+        bytestring = b'Value ending with spaces   '
+        assert 'Value ending with spaces' == convert_single_string(bytestring)
+        assert 'Value ending with spaces' == convert_text(bytestring)
+
+        bytestring = b'Values  \\with spaces   '
+        assert ['Values', 'with spaces'] == convert_text(bytestring)
+
+        bytestring = b'Value ending with zeros\0\0\0'
+        assert 'Value ending with zeros' == convert_single_string(bytestring)
+        assert 'Value ending with zeros' == convert_text(bytestring)
+
+        bytestring = b'Values\0\0\\with zeros\0'
+        assert ['Values', 'with zeros'] == convert_text(bytestring)
+
 
 class TestConvertAT(object):
     def test_big_endian(self):

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -545,7 +545,7 @@ def MultiString(val, valtype=str):
     # 2005.05.25: also check for trailing 0, error made
     # in PET files we are converting
 
-    if val and (val.endswith(' ') or val.endswith('\x00')):
+    while val and (val.endswith(' ') or val.endswith('\x00')):
         val = val[:-1]
     splitup = val.split("\\")
 

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -407,7 +407,7 @@ def convert_single_string(byte_string, encodings=None):
     """
     encodings = encodings or [default_encoding]
     value = decode_string(byte_string, encodings, TEXT_VR_DELIMS)
-    if value and value.endswith(' '):
+    while value and (value.endswith(' ') or value.endswith('\0')):
         value = value[:-1]
     return value
 


### PR DESCRIPTION
- closes #940

#### Describe the changes
A trailing zero had been tolerated for multi-values before, but not for single text values.
Now both single and multi-values tolerate multiple blank or zero endings without a warning (no warning was issued before - I left this for simplicity and to avoid more checks).

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
