### PR TITLE
[MRG] Fix pickling modified datasets

### DIFF
--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -15,6 +15,7 @@ Fixes
 * Fixed handling of known tags with VR UN (:issue:`899`)
 * Fixed assigning of empty values to data elements (:issue:`896`)
 * Fixed error in unpickling dataset (:issue:`947`)
+* Fixed error in pickling modified datasets (:issue:`951`)
 
 Enhancements
 ............

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -430,7 +430,6 @@ class DataElement(object):
         return dump_handler(
             self.to_json_dict(bulk_data_threshold, bulk_data_element_handler))
 
-
     @property
     def value(self):
         """Return the element's value."""
@@ -511,11 +510,10 @@ class DataElement(object):
         except AttributeError:  # not a list
             return self._convert(val)
         else:
-            return MultiValue(lambda x: self._convert(x), val)
+            return MultiValue(self._convert, val)
 
     def _convert(self, val):
         """Convert `val` to an appropriate type for the element's VR."""
-
         # If the value is a byte string and has a VR that can only be encoded
         # using the default character repertoire, we convert it to a string
         # here to allow for byte string input in these cases

--- a/pydicom/multival.py
+++ b/pydicom/multival.py
@@ -26,7 +26,7 @@ class MultiValue(MutableSequence):
 
     def __init__(self, type_constructor, iterable):
         """Initialize the list of values
-        
+
         Parameters
         ----------
         type_constructor : type

--- a/pydicom/multival.py
+++ b/pydicom/multival.py
@@ -26,7 +26,6 @@ class MultiValue(MutableSequence):
 
     def __init__(self, type_constructor, iterable):
         """Initialize the list of values
-
         Parameters
         ----------
         type_constructor : type
@@ -48,6 +47,12 @@ class MultiValue(MutableSequence):
             type_constructor = number_string_type_constructor
         for x in iterable:
             self._list.append(type_constructor(x))
+
+    def __getstate__(self):
+        # TODO: Workaround for #951, to be removed when Python 2 not supported
+        state = self.__dict__.copy()
+        del state['type_constructor']
+        return state
 
     def insert(self, position, val):
         self._list.insert(position, self.type_constructor(val))

--- a/pydicom/multival.py
+++ b/pydicom/multival.py
@@ -49,11 +49,12 @@ class MultiValue(MutableSequence):
         for x in iterable:
             self._list.append(type_constructor(x))
 
-    def __getstate__(self):
-        # TODO: Workaround for #951, to be removed when Python 2 not supported
-        state = self.__dict__.copy()
-        del state['type_constructor']
-        return state
+    # TODO: Workaround for #951, to be removed when Python 2 not supported
+    if compat.in_py2:
+        def __getstate__(self):
+            state = self.__dict__.copy()
+            del state['type_constructor']
+            return state
 
     def insert(self, position, val):
         self._list.insert(position, self.type_constructor(val))

--- a/pydicom/multival.py
+++ b/pydicom/multival.py
@@ -26,6 +26,7 @@ class MultiValue(MutableSequence):
 
     def __init__(self, type_constructor, iterable):
         """Initialize the list of values
+        
         Parameters
         ----------
         type_constructor : type

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1400,6 +1400,13 @@ class TestFileDataset(object):
         assert ds == ds1
         assert ds1.PixelSpacing == [1.0, 1.0]
 
+        # Test workaround for python 2
+        if compat.in_py2:
+            ds1.PixelSpacing = ds1.PixelSpacing
+
+        ds1.PixelSpacing.insert(1, 2)
+        assert [1, 2, 1] == ds1.PixelSpacing
+
     def test_equality_file_meta(self):
         """Dataset: equality returns correct value if with metadata"""
         d = dcmread(self.test_file)

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1390,6 +1390,16 @@ class TestFileDataset(object):
         assert ds == ds1
         assert ds1.Modality == 'CT'
 
+    def test_pickle_modified(self):
+        """Test pickling a modified dataset."""
+        ds = pydicom.dcmread(self.test_file)
+        ds.PixelSpacing = [1.0, 1.0]
+        import pickle
+        s = pickle.dumps({'ds': ds})
+        ds1 = pickle.loads(s)['ds']
+        assert ds == ds1
+        assert ds1.PixelSpacing == [1.0, 1.0]
+
     def test_equality_file_meta(self):
         """Dataset: equality returns correct value if with metadata"""
         d = dcmread(self.test_file)


### PR DESCRIPTION
#### Describe the changes
Mostly fixes #951 by passing the conversion function directly to `MultiValue` instead of a lambda function.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better

#### Issues
* Updating an unpickled multivalued element in Python 2 will raise an AttributeError due to `MultiValue.type_constructor` being missing. Can be worked around by doing `ds.Keyword = ds.Keyword` first. This only affects elements with VM > 1 ~that have been modified prior to pickling~.
```python
ds = dcmread(...)
ds.PixelSpacing = [1, 1]
pickle.dumps(ds, ...)
ds = pickle.load(...)
# raises AttributeError in Python 2
ds.PixelSpacing.insert(1, 2)
# need to do this first
ds.PixelSpacing = ds.PixelSpacing
```