### PR TITLE
[MRG] Fix incorrect first value for LUT elements

### DIFF
--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -16,13 +16,15 @@ Fixes
 * Fixed assigning of empty values to data elements (:issue:`896`)
 * Fixed error in unpickling dataset (:issue:`947`)
 * Fixed error in pickling modified datasets (:issue:`951`)
+* Fixed improper conversion of the first (and third) values of the *LUT
+  Descriptor* elements (0028,1101-1103) and (0028,3002) (:issue:`942`)
 
 Enhancements
 ............
 
 * Added support for converting (60xx,3000) *Overlay Data* to a numpy ndarray
   using :meth:`Dataset.overlay_array()
-  <pydicom.dataset.Dataset.overlay_array>` (issue:`912`)
+  <pydicom.dataset.Dataset.overlay_array>` (:issue:`912`)
 * Added support for deferred reading in file-like objects (:issue:`932`)
 * Tolerate values with multiple and/or incorrect padding bytes (:issue:`940`)
 * Added support for uncompressed pixel data with (0028,0004) *Photometric

--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -16,7 +16,7 @@ Fixes
 * Fixed assigning of empty values to data elements (:issue:`896`)
 * Fixed error in unpickling dataset (:issue:`947`)
 * Fixed error in pickling modified datasets (:issue:`951`)
-* Fixed improper conversion of the first (and third) values of the *LUT
+* Fixed improper conversion of the first value of the *LUT
   Descriptor* elements (0028,1101-1103) and (0028,3002) (:issue:`942`)
 
 Enhancements

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -687,7 +687,7 @@ RawDataElement.is_raw = True
 
 
 # The first and third values of the following elements are always US
-#   even if the VR is SS (PS3.3 C.7.6.3.1.5, C.11.1, C.11.2, C).
+#   even if the VR is SS (PS3.3 C.7.6.3.1.5, C.11.1, C.11.2).
 # (0028,1101-1103) RGB Palette Color LUT Descriptor
 # (0028,3002) LUT Descriptor
 _LUT_DESCRIPTOR_TAGS = (0x00281101, 0x00281102, 0x00281103, 0x00283002)

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -686,6 +686,13 @@ RawDataElement = namedtuple('RawDataElement', msg)
 RawDataElement.is_raw = True
 
 
+# The first and third values of the following elements are always US
+#   even if the VR is SS (PS3.3 C.7.6.3.1.5, C.11.1, C.11.2, C).
+# (0028,1101-1103) RGB Palette Color LUT Descriptor
+# (0028,3002) LUT Descriptor
+_LUT_DESCRIPTOR_TAGS = (0x00281101, 0x00281102, 0x00281103, 0x00283002)
+
+
 def DataElement_from_raw(raw_data_element, encoding=None):
     """Return a :class:`DataElement` created from `raw_data_element`.
 
@@ -738,5 +745,10 @@ def DataElement_from_raw(raw_data_element, encoding=None):
         value = convert_value(VR, raw, encoding)
     except NotImplementedError as e:
         raise NotImplementedError("{0:s} in tag {1!r}".format(str(e), raw.tag))
+
+    if raw.tag in _LUT_DESCRIPTOR_TAGS and value[0] < 0:
+        # We only fix the first value as the third value is 8 or 16
+        value[0] += 65536
+
     return DataElement(raw.tag, VR, value, raw.value_tell,
                        raw.length == 0xFFFFFFFF, already_converted=True)

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -115,9 +115,6 @@ def apply_color_lut(arr, ds=None, palette=None):
     lut_desc = ds.RedPaletteColorLookupTableDescriptor
     # A value of 0 = 2^16 entries
     nr_entries = lut_desc[0] or 2**16
-    # Workaround for #942: first value is always unsigned
-    if nr_entries < 0:
-        nr_entries += 2**16
 
     # May be negative if Pixel Representation is 1
     first_map = lut_desc[1]
@@ -217,9 +214,6 @@ def apply_modality_lut(arr, ds):
     if hasattr(ds, 'ModalityLUTSequence'):
         item = ds.ModalityLUTSequence[0]
         nr_entries = item.LUTDescriptor[0] or 2**16
-        # Workaround for #942: first value is always unsigned
-        if nr_entries < 0:
-            nr_entries += 2**16
         first_map = item.LUTDescriptor[1]
         nominal_depth = item.LUTDescriptor[2]
 

--- a/pydicom/tests/test_handler_util.py
+++ b/pydicom/tests/test_handler_util.py
@@ -841,18 +841,6 @@ class TestNumpy_ModalityLUT(object):
         out = apply_modality_lut(arr, ds)
         assert [0, 0, 0, 1] == list(out)
 
-    def test_lut_sequence_entries_negative(self):
-        """Test workaround for #942: SS VR should give uint nr entries."""
-        ds = dcmread(MOD_16_SEQ)
-        seq = ds.ModalityLUTSequence[0]
-        seq.LUTDescriptor = [-32767, 0, 16]  # 32769
-        seq.LUTData = [0] * 32768 + [1]
-        arr = np.asarray([-10, 0, 32767, 32768, 32769])
-        out = apply_modality_lut(arr, ds)
-        # IV < index 0 -> 0
-        # IV > index 32768 -> 32768
-        assert [0, 0, 0, 1, 1] == list(out)
-
     def test_unchanged(self):
         """Test no modality LUT transform."""
         ds = dcmread(MOD_16)
@@ -1153,26 +1141,6 @@ class TestNumpy_PaletteColor(object):
         assert ([33280, 61952, 65280] == rgb[arr == 60]).all()
         assert [60160, 25600, 37376] == list(rgb[arr == 130][0])
         assert ([60160, 25600, 37376] == rgb[arr == 130]).all()
-
-    def test_nr_entries_negative(self):
-        """Test workaround for #942: SS VR should give uint nr entries."""
-        ds = dcmread(PAL_08_200_0_16_1F, force=True)
-        ds.file_meta = Dataset()
-        ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
-        ds.RedPaletteColorLookupTableDescriptor[0] = -32767  # 32769
-        # 16-bit entries, 32769 entries per LUT
-        ds.RedPaletteColorLookupTableData = b'\x00\x00' * 32768 + b'\xff\xff'
-        ds.GreenPaletteColorLookupTableData = b'\x00\x00' * 32768 + b'\xff\xff'
-        ds.BluePaletteColorLookupTableData = b'\x00\x00' * 32768 + b'\xff\xff'
-        # IV < index 0 -> 0
-        # IV > index 32768 -> 32768
-        arr = np.asarray([-10, 0, 32767, 32768, 32769])
-        rgb = apply_color_lut(arr, ds)
-        assert [0, 0, 0] == list(rgb[0])
-        assert [0, 0, 0] == list(rgb[1])
-        assert [0, 0, 0] == list(rgb[2])
-        assert [65535, 65535, 65535] == list(rgb[3])
-        assert [65535, 65535, 65535] == list(rgb[4])
 
 
 @pytest.mark.skipif(not HAVE_NP, reason="Numpy is not available")


### PR DESCRIPTION
#### Describe the changes
Closes #942 by updating the value of the related elements during conversion to `DataElement` for values read from file.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
