### PR TITLE
[MRG] Represent empty sequence as empty list instead of None

### DIFF
--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -87,9 +87,10 @@ Default ``False``
 """
 
 use_none_as_empty_text_VR_value = False
-""" If ``True``, the value of decoded empty data element is always ``None``.
-If ``False`` (the default), the value of an empty data element with
-a text VR is an empty string, for all other VRs it is also ``None``.
+""" If ``True``, the value of a decoded empty data element with
+a text VR is ``None``, otherwise (the default), it is is an empty string. 
+For all other VRs the behavior does not change - the value is en empty 
+list for VR 'SQ' and ``None`` for all other VRs.
 Note that the default of this value will change to ``True`` in version 2.0.
 """
 

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -88,8 +88,8 @@ Default ``False``
 
 use_none_as_empty_text_VR_value = False
 """ If ``True``, the value of a decoded empty data element with
-a text VR is ``None``, otherwise (the default), it is is an empty string. 
-For all other VRs the behavior does not change - the value is en empty 
+a text VR is ``None``, otherwise (the default), it is is an empty string.
+For all other VRs the behavior does not change - the value is en empty
 list for VR 'SQ' and ``None`` for all other VRs.
 Note that the default of this value will change to ``True`` in version 2.0.
 """

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -48,10 +48,12 @@ def empty_value_for_VR(VR, raw=False):
 
     The behavior of this property depends on the setting of
     :attr:`config.use_none_as_empty_value`. If that is set to ``True``,
-    an empty value is always represented by ``None``, otherwise it depends
-    on `VR`. For text VRs (this includes 'AE', 'AS', 'CS', 'DA', 'DT', 'LO',
-    'LT', 'PN', 'SH', 'ST', 'TM', 'UC', 'UI', 'UR' and 'UT') an empty string
-    is used as empty value representation, for all other VRs, ``None``.
+    an empty value is represented by ``None`` (except for VR 'SQ'), otherwise
+    it depends on `VR`. For text VRs (this includes 'AE', 'AS', 'CS', 'DA',
+    'DT', 'LO', 'LT', 'PN', 'SH', 'ST', 'TM', 'UC', 'UI', 'UR' and 'UT') an
+    empty string is used as empty value representation, for all other VRs
+    except 'SQ', ``None``. For empty sequence values (VR 'SQ') an empty list
+    is used in all cases.
     Note that this is used only if decoding the element - it is always
     possible to set the value to another empty value representation,
     which will be preserved during the element object lifetime.
@@ -67,10 +69,12 @@ def empty_value_for_VR(VR, raw=False):
 
     Returns
     -------
-    str or bytes or None
+    str or bytes or None or list
         The value a data element with `VR` is assigned on decoding
         if it is empty.
     """
+    if VR == 'SQ':
+        return []
     if config.use_none_as_empty_text_VR_value:
         return None
     if VR in ('AE', 'AS', 'CS', 'DA', 'DT', 'LO', 'LT',

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -503,6 +503,23 @@ class TestDataElement(object):
             check_empty_binary_element(MultiValue(int, []))
             check_empty_binary_element(None)
 
+    def test_empty_sequence_is_handled_as_array(self):
+        ds = Dataset()
+        ds.AcquisitionContextSequence = []
+        elem = ds['AcquisitionContextSequence']
+        assert bool(elem.value) is False
+        assert 0 == elem.VM
+        assert elem.value == []
+
+        fp = DicomBytesIO()
+        fp.is_little_endian = True
+        fp.is_implicit_VR = True
+        filewriter.write_dataset(fp, ds)
+        ds_read = dcmread(fp, force=True)
+        elem = ds_read['AcquisitionContextSequence']
+        assert 0 == elem.VM
+        assert elem.value == []
+
 
 class TestRawDataElement(object):
     """Tests for dataelem.RawDataElement."""


### PR DESCRIPTION
- fixes #964, see #896

This changes the behavior of empty values for sequence tags (using `[]` instead of `None`), which had been discussed in #896, though with no clear conclusion, as far as I can see.
Please check if this is the wanted behavior.
Note that I didn't add an entry in the release notes, as this is probably covered by the entry for #896.

- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
