### PR TITLE
[MRG] Propagate bulk data handler to data element

### DIFF
--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -19,6 +19,7 @@ Fixes
 * Fixed improper conversion of the first value of the *LUT
   Descriptor* elements (0028,1101-1103) and (0028,3002) (:issue:`942`)
 * Fixed handling of ISO IR 159 encoding (:issue: `917`)
+* Fixed propagation of bulk data handler in Dataset.from_json (:issue:`971`)
 
 Enhancements
 ............

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1986,7 +1986,7 @@ class Dataset(dict):
                 value_key = unique_value_keys[0]
                 value = mapping[value_key]
             data_element = DataElement.from_json(
-                cls, tag, vr, value, value_key
+                cls, tag, vr, value, value_key, bulk_data_uri_handler
             )
             dataset.add(data_element)
         return dataset

--- a/pydicom/tests/test_json.py
+++ b/pydicom/tests/test_json.py
@@ -329,3 +329,14 @@ class TestBinary(object):
         ds_json = '{"00091002": {"vr": "OB", "BulkDataURI": [42]}}'
         with pytest.raises(TypeError, match=msg):
             Dataset.from_json(ds_json)
+
+    def test_bulk_data_reader_is_called(self):
+        def bulk_data_reader(_):
+            return b'xyzzy'
+
+        json_data = {
+            "00091002": {"vr": "OB", "BulkDataURI": "https://a.dummy.url"}
+        }
+        ds = Dataset().from_json(json.dumps(json_data), bulk_data_reader)
+
+        assert b'xyzzy' == ds[0x00091002].value


### PR DESCRIPTION
- Dataset.from_json had ignored the bulk_data_element argument
- see #971

The issue will be closed only after it is clarified if we need some additional handling.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
