### PR TITLE
[MRG] Added Python 3.8 to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,6 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
 
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
-    - env: DISTRIB="conda" PYTHON_VERSION="3.4" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
-
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.5" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
@@ -51,6 +44,13 @@ matrix:
     - env: DISTRIB="conda" PYTHON_VERSION="3.7.3" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.7.3" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
     #- env: DISTRIB="conda" PYTHON_VERSION="3.7" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
+
+    - env: DISTRIB="conda" PYTHON_VERSION="3.8" NUMPY=false PILLOW=false JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.8" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=false
+#    - env: DISTRIB="conda" PYTHON_VERSION="3.8" NUMPY=true  PILLOW=false JPEG_LS=false GDCM=true
+    - env: DISTRIB="conda" PYTHON_VERSION="3.8" NUMPY=true  PILLOW=both JPEG_LS=false GDCM=false
+    - env: DISTRIB="conda" PYTHON_VERSION="3.8" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=false
+#    - env: DISTRIB="conda" PYTHON_VERSION="3.8" NUMPY=true  PILLOW=both JPEG_LS=true  GDCM=true
 
     - env: DISTRIB="conda" PYTHON_VERSION="2.7" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false
     - env: DISTRIB="conda" PYTHON_VERSION="3.7.3" NUMPY=true  PILLOW=jpeg JPEG_LS=false GDCM=false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,16 +9,16 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Miniconda34-x64"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Miniconda37-x64"
+      PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
 
 install:


### PR DESCRIPTION
- added Python 3.7 to Appveyor builds
- removed Python 3.4 from both builds

I did this actually to reproduce #973, but it ~seems not to be reproducible with the CI test system~ is already fixed in master.
Thought it makes sense to merge this anyway, as 3.8 is out and we don't support 3.4 in the next pydicom version. Note that there is no gdcm version for this yet.