### PR TITLE
[MRG] Added function to get the path of a single test data file

### DIFF
--- a/examples/input_output/plot_read_dicom_directory.py
+++ b/examples/input_output/plot_read_dicom_directory.py
@@ -14,11 +14,11 @@ from os.path import dirname, join
 from pprint import pprint
 
 import pydicom
-from pydicom.data import get_testdata_files
+from pydicom.data import get_testdata_file
 from pydicom.filereader import read_dicomdir
 
 # fetch the path to the test data
-filepath = get_testdata_files('DICOMDIR')[0]
+filepath = get_testdata_file('DICOMDIR')
 print('Path to the DICOM directory: {}'.format(filepath))
 # load the data
 dicom_dir = read_dicomdir(filepath)

--- a/pydicom/data/__init__.py
+++ b/pydicom/data/__init__.py
@@ -2,7 +2,9 @@
 """pydicom data manager"""
 
 from .data_manager import (
-    get_charset_files, get_testdata_files, get_palette_files, DATA_ROOT
+    get_charset_files, get_testdata_file, get_testdata_files,
+    get_palette_files, DATA_ROOT
 )
 
-__all__ = ['get_charset_files', 'get_testdata_files', 'get_palette_files']
+__all__ = ['get_charset_files', 'get_testdata_files', 'get_testdata_file',
+           'get_palette_files']

--- a/pydicom/data/data_manager.py
+++ b/pydicom/data/data_manager.py
@@ -1,9 +1,9 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """pydicom data manager"""
 
-from os import walk
-from os.path import abspath, dirname, join
 import fnmatch
+import os
+from os.path import abspath, dirname, join
 
 DATA_ROOT = abspath(dirname(__file__))
 
@@ -30,7 +30,7 @@ def get_files(base, pattern):
     pattern = "*" + pattern + "*"
 
     files = []
-    for root, dirnames, filenames in walk(base):
+    for root, _, filenames in os.walk(base):
         for filename in filenames:
             filename_filter = fnmatch.filter([join(root, filename)],
                                              pattern)
@@ -60,6 +60,28 @@ def get_palette_files(pattern="*"):
     files = [filename for filename in files if not filename.endswith('.py')]
 
     return files
+
+
+def get_testdata_file(name):
+    """Return the first test data file path with the given name found under
+    the pydicom test data root.
+
+    Parameters
+    ----------
+    name : str
+        The full file name (without path)
+
+    Returns
+    -------
+    str, None
+        The full path of the file if found, or None.
+
+    """
+    data_path = join(DATA_ROOT, 'test_files')
+    for root, _, filenames in os.walk(data_path):
+        for filename in filenames:
+            if filename == name:
+                return os.path.join(root, filename)
 
 
 def get_testdata_files(pattern="*"):

--- a/pydicom/tests/test_data_manager.py
+++ b/pydicom/tests/test_data_manager.py
@@ -9,7 +9,7 @@ import pytest
 from pydicom.data import (
     get_charset_files, get_testdata_files, get_palette_files
 )
-from pydicom.data.data_manager import DATA_ROOT
+from pydicom.data.data_manager import DATA_ROOT, get_testdata_file
 
 
 class TestGetData(object):
@@ -50,6 +50,12 @@ class TestGetData(object):
         pattern = 'chrX1'
         filename = get_charset_files(pattern)
         assert filename[0].endswith('chrX1.dcm')
+
+    def test_get_testdata_file(self):
+        """Test that file name is working properly."""
+        name = 'DICOMDIR'
+        filename = get_testdata_file(name)
+        assert filename and filename.endswith('DICOMDIR')
 
     def test_get_palette_files(self):
         """Test data_manager.get_palette_files."""

--- a/pydicom/tests/test_dicomdir.py
+++ b/pydicom/tests/test_dicomdir.py
@@ -3,14 +3,14 @@
 
 import pytest
 
-from pydicom.data import get_testdata_files
+from pydicom.data import get_testdata_file
 from pydicom.dicomdir import DicomDir
 from pydicom.errors import InvalidDicomError
 from pydicom import config, dcmread
 
-TEST_FILE = get_testdata_files('DICOMDIR')[0]
-IMPLICIT_TEST_FILE = get_testdata_files('DICOMDIR-implicit')[0]
-BIGENDIAN_TEST_FILE = get_testdata_files('DICOMDIR-bigEnd')[0]
+TEST_FILE = get_testdata_file('DICOMDIR')
+IMPLICIT_TEST_FILE = get_testdata_file('DICOMDIR-implicit')
+BIGENDIAN_TEST_FILE = get_testdata_file('DICOMDIR-bigEnd')
 
 
 class TestDicomDir(object):
@@ -26,7 +26,7 @@ class TestDicomDir(object):
 
     def test_invalid_sop_file_meta(self):
         """Test exception raised if SOP Class is not Media Storage Directory"""
-        ds = dcmread(get_testdata_files('CT_small.dcm')[0])
+        ds = dcmread(get_testdata_file('CT_small.dcm'))
         with pytest.raises(InvalidDicomError,
                            match=r"SOP Class is not Media Storage "
                                  r"Directory \(DICOMDIR\)"):
@@ -34,7 +34,7 @@ class TestDicomDir(object):
 
     def test_invalid_sop_no_file_meta(self):
         """Test exception raised if invalid sop class but no file_meta"""
-        ds = dcmread(get_testdata_files('CT_small.dcm')[0])
+        ds = dcmread(get_testdata_file('CT_small.dcm'))
         with pytest.raises(AttributeError,
                            match="'DicomDir' object has no attribute "
                                  "'DirectoryRecordSequence'"):


### PR DESCRIPTION
- convenience if you only need one file
- avoids problems with more than one file matching a pattern

This shall fix the Circle.CI problem, and I think it makes sense to have a function for a single test file, as this what we need in most cases.
I forgot that `get_testdata_files` puts an asterix around the pattern...
