### PR TITLE
[MRG] Added optional handler argument to Dataset.decompress()

### DIFF
--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -43,4 +43,5 @@ Enhancements
   unexpected transfer syntax (:issue:`848`)
 * Handle missing offset tags in DICOMDIR (:issue:`981`)
 * Added optional `handler` argument to
-  :func:`~pydicom.dataset.Dataset.decompress` (:issue:`537`)
+  :func:`~pydicom.dataset.Dataset.decompress`. This lets you specify a
+  particular handler, rather than following pydicom's default order (:issue:`537`)

--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -42,3 +42,5 @@ Enhancements
 * Added user warning, or exception in strict mode, if a DICOMDIR has an
   unexpected transfer syntax (:issue:`848`)
 * Handle missing offset tags in DICOMDIR (:issue:`981`)
+* Added optional `handler` argument to
+  :func:`~pydicom.dataset.Dataset.decompress` (:issue:`537`)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1276,9 +1276,8 @@ class Dataset(dict):
         ----------
         handler_name: str
             The (optional) name of the pixel handler that shall be used to
-            decode the data. This lets you specify a particular handler, rather
-            than following pydicom's default order. Currently supported
-            handler names are: 'gdcm', 'pillow', 'jpeg_ls', 'rle' and 'numpy'.
+            decode the data. Currently supported handler names are: 'gdcm',
+            'pillow', 'jpeg_ls', 'rle' and 'numpy'.
             If empty (the default), a matching handler is used from the
             handlers configured in :attr:`~pydicom.config.pixel_data_handlers`.
 
@@ -1458,11 +1457,9 @@ class Dataset(dict):
 
         Parameters
         ----------
-        handler_name: str
             The (optional) name of the pixel handler that shall be used to
-            decode the data. This lets you specify a particular handler, rather
-            than following pydicom's default order. Currently supported
-            handler names are: 'gdcm', 'pillow', 'jpeg_ls', 'rle' and 'numpy'.
+            decode the data. Currently supported handler names are: 'gdcm',
+            'pillow', 'jpeg_ls', 'rle' and 'numpy'.
             If empty (the default), a matching handler is used from the
             handlers configured in :attr:`~pydicom.config.pixel_data_handlers`.
 

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1319,7 +1319,7 @@ class Dataset(dict):
             self._convert_pixel_data_without_handler()
 
     def _convert_pixel_data_using_handler(self, name):
-        """Convert the pixel data using handler with thw given name.
+        """Convert the pixel data using handler with the given name.
         See :meth:`~Dataset.convert_pixel_data` for more information.
         """
         # handle some variations in name

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1369,7 +1369,7 @@ class Dataset(dict):
                 "'{0}' ({1}) as there are no pixel data handlers "
                 "available that support it. Please see the pydicom "
                 "documentation for information on supported transfer syntaxes "
-                    .format(transfer_syntax, transfer_syntax.name)
+                .format(transfer_syntax, transfer_syntax.name)
             )
 
         # Handlers that both support the transfer syntax and have their
@@ -1395,7 +1395,7 @@ class Dataset(dict):
                 names = [hh_deps[name][1] for name in missing]
                 pkg_msg.append(
                     "{} (req. {})"
-                        .format(hh.HANDLER_NAME, ', '.join(names))
+                    .format(hh.HANDLER_NAME, ', '.join(names))
                 )
 
             raise RuntimeError(msg + ', '.join(pkg_msg))
@@ -1421,7 +1421,7 @@ class Dataset(dict):
             "Please see the list of supported Transfer Syntaxes in the "
             "pydicom documentation for alternative packages that might "
             "be able to decode the data"
-                .format(", ".join([str(hh) for hh in available_handlers]))
+            .format(", ".join([str(hh) for hh in available_handlers]))
         )
         raise last_exception
 

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1328,6 +1328,10 @@ class Dataset(dict):
             handler_name += '_handler'
         if handler_name == 'numpy_handler':
             handler_name = 'np_handler'
+        if handler_name == 'jpeg_ls_handler':
+            # the name in config differs from the actual handler name
+            # we allow both
+            handler_name = 'jpegls_handler'
         if not hasattr(pydicom.config, handler_name):
             raise ValueError("'{}' is not a known handler name".format(name))
         handler = getattr(pydicom.config, handler_name)

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -489,10 +489,10 @@ class TestsWithGDCM(object):
         assert a.mean() == b.mean()
         assert a.flags.writeable
 
-    def test_decompress_using_gdcm(self):
-        self.jpeg_2k_lossless.decompress(handler_name='gdcm')
-        a = self.jpeg_2k_lossless.pixel_array
-        b = self.mr_small.pixel_array
+    def test_decompress_using_gdcm(self, jpeg_2k_lossless, mr_small):
+        jpeg_2k_lossless.decompress(handler_name='gdcm')
+        a = jpeg_2k_lossless.pixel_array
+        b = mr_small.pixel_array
         assert a.mean() == b.mean()
 
     def test_emri_JPEG2000PixelArray(self, emri_jpeg_2k_lossless, emri_small):

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -489,6 +489,12 @@ class TestsWithGDCM(object):
         assert a.mean() == b.mean()
         assert a.flags.writeable
 
+    def test_decompress_using_gdcm(self):
+        self.jpeg_2k_lossless.decompress(handler_name='gdcm')
+        a = self.jpeg_2k_lossless.pixel_array
+        b = self.mr_small.pixel_array
+        assert a.mean() == b.mean()
+
     def test_emri_JPEG2000PixelArray(self, emri_jpeg_2k_lossless, emri_small):
         a = emri_jpeg_2k_lossless.pixel_array
         b = emri_small.pixel_array

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -63,6 +63,9 @@ color_3d_jpeg_baseline = get_testdata_files(
 dir_name = os.path.dirname(sys.argv[0])
 save_dir = os.getcwd()
 
+SUPPORTED_HANDLER_NAMES = (
+    'jpegls', 'jpeg_ls', 'JPEG_LS', 'jpegls_handler', 'JPEG_LS_Handler'
+)
 
 class TestJPEGLS_no_jpeg_ls(object):
     def setup(self):
@@ -183,8 +186,9 @@ class TestJPEGLS_JPEG_LS_with_jpeg_ls(object):
         assert b.mean() == a.mean()
         assert a.flags.writeable
 
-    def test_decompress_using_jpeg_ls(self):
-        self.emri_jpeg_ls_lossless.decompress(handler_name='jpeg_ls')
+    @pytest.mark.parametrize("handler_name", SUPPORTED_HANDLER_NAMES)
+    def test_decompress_using_handler(self, handler_name):
+        self.emri_jpeg_ls_lossless.decompress(handler_name=handler_name)
         a = self.emri_jpeg_ls_lossless.pixel_array
         b = self.emri_small.pixel_array
         assert b.mean() == a.mean()

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -183,6 +183,12 @@ class TestJPEGLS_JPEG_LS_with_jpeg_ls(object):
         assert b.mean() == a.mean()
         assert a.flags.writeable
 
+    def test_decompress_using_jpeg_ls(self):
+        self.emri_jpeg_ls_lossless.decompress(handler_name='jpeg_ls')
+        a = self.emri_jpeg_ls_lossless.pixel_array
+        b = self.emri_small.pixel_array
+        assert b.mean() == a.mean()
+
 
 @pytest.mark.skipif(not test_jpeg_ls_decoder, reason=jpeg_ls_missing_message)
 class TestJPEGLS_JPEG2000_with_jpeg_ls(object):

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -304,6 +304,13 @@ class Test_JPEG2000Tests_with_pillow(object):
 
         assert a.flags.writeable
 
+    def test_decompress_using_pillow(self):
+        """Test decompressing JPEG2K with pillow handler succeeds."""
+        self.jpeg_2k_lossless.decompress(handler_name='pillow')
+        a = self.jpeg_2k_lossless.pixel_array
+        b = self.mr_small.pixel_array
+        assert np.array_equal(a, b)
+
     def test_emri_JPEG2000PixelArray(self):
         """Test decoding JPEG2K with pillow handler succeeds."""
         a = self.emri_jpeg_2k_lossless.pixel_array

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -364,7 +364,7 @@ class TestNumpy_RLEHandler(object):
             with pytest.raises(NotImplementedError, match=exc_msg):
                 ds.pixel_array
             with pytest.raises(NotImplementedError, match=exc_msg):
-                ds.decompress(handler=RLE_HANDLER)
+                ds.decompress(handler_name='rle')
 
     @pytest.mark.parametrize("fpath,data", REFERENCE_DATA_UNSUPPORTED)
     def test_can_access_unsupported_dataset(self, fpath, data):
@@ -418,9 +418,12 @@ class TestNumpy_RLEHandler(object):
     def test_decompress_with_handler(self):
         """Test that decompress works with the correct handler."""
         ds = dcmread(RLE_8_1_1F)
+        with pytest.raises(ValueError,
+                           match="'zip' is not a known handler name"):
+            ds.decompress(handler_name='zip')
         with pytest.raises(NotImplementedError, match='Unable to decode*'):
-            ds.decompress(handler=NP_HANDLER)
-        ds.decompress(handler=RLE_HANDLER)
+            ds.decompress(handler_name='numpy')
+        ds.decompress(handler_name='rle')
         assert hasattr(ds, '_pixel_array')
         arr = ds.pixel_array
         assert (600, 800) == arr.shape


### PR DESCRIPTION
- also added it to Dataset.convert_pixel_data()
- see #537

Note: 
- I added a couple of tests only to one handler (the RLE handler), just to test the new argument. The actual functionality is already tested with each handler tests.
- you can only set one handler, not a list - I think this is sufficient
- no special error handling has been added if that handler fails, it uses the same messages as for the default handlers - not sure if this is sufficient

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
