### PR TITLE
[MRG] Fix Pillow handler converting YBR to RGB

### DIFF
--- a/doc/old/image_data_handlers.rst
+++ b/doc/old/image_data_handlers.rst
@@ -92,29 +92,3 @@ options:
    transfer syntax of the data set, but not the *Photometric Interpretation*.
    The *Photometric Interpretation* may not match the pixel data, depending on
    the used decompression handler.
-
-.. _colorspace:
-
-Color space
-...........
-
-When using :attr:`Dataset.pixel_array<pydicom.dataset.Dataset.pixel_array>`
-with *Pixel Data* that has an (0028,0002) *Samples per Pixel* value
-of ``3`` and a (0028,0004) *Photometric Interpretation* which is non-RGB (i.e.
-``YBR_FULL``, ``YBR_FULL_422``, etc) then the returned pixel data may be in
-a different color space depending on the package used to decompress the data.
-
-* For GDCM, the data will be in the color space listed in *Photometric
-  Interpretation*
-* For Pillow, YBR data will be converted automatically to RGB
-
-*pydicom* offers a limited ability to convert between 8-bits/channel RGB and
-YBR color spaces through the
-:func:`~pydicom.pixel_data_handlers.util.convert_color_space`
-function. When changing the color space you should also change the value
-of *Photometric Interpretation* to match.
-
-
-.. note:: See the DICOM Standard, Part 3,
-   :dcm:`Section C.7.6.3.1<part03/sect_C.7.6.3.html#sect_C.7.6.3.1>` for more
-   information about color spaces.

--- a/doc/old/working_with_pixel_data.rst
+++ b/doc/old/working_with_pixel_data.rst
@@ -92,6 +92,30 @@ an example.
 :attr:`~pydicom.dataset.Dataset.pixel_array` can also be used to pass image
 data to graphics libraries for viewing. See :doc:`viewing_images` for details.
 
+
+.. _colorspace:
+
+Color space
+...........
+
+When using :attr:`Dataset.pixel_array<pydicom.dataset.Dataset.pixel_array>`
+with *Pixel Data* that has an (0028,0002) *Samples per Pixel* value
+of ``3`` then the returned pixel data will be in the color space as given by
+(0028,0004) *Photometric Interpretation* (e.g. ``RGB``, ``YBR_FULL``,
+``YBR_FULL_422``, etc).
+
+*pydicom* offers a limited ability to convert between 8-bits/channel RGB and
+YBR color spaces through the
+:func:`~pydicom.pixel_data_handlers.util.convert_color_space`
+function. When changing the color space you should also change the value
+of *Photometric Interpretation* to match.
+
+
+.. note:: See the DICOM Standard, Part 3,
+   :dcm:`Section C.7.6.3.1<part03/sect_C.7.6.3.html#sect_C.7.6.3.1>` for more
+   information about color spaces.
+
+
 Palette Color
 -------------
 

--- a/doc/old/working_with_pixel_data.rst
+++ b/doc/old/working_with_pixel_data.rst
@@ -96,16 +96,16 @@ data to graphics libraries for viewing. See :doc:`viewing_images` for details.
 .. _colorspace:
 
 Color space
-...........
+-----------
 
-When using :attr:`Dataset.pixel_array<pydicom.dataset.Dataset.pixel_array>`
+When using :attr:`~pydicom.dataset.Dataset.pixel_array`
 with *Pixel Data* that has an (0028,0002) *Samples per Pixel* value
 of ``3`` then the returned pixel data will be in the color space as given by
 (0028,0004) *Photometric Interpretation* (e.g. ``RGB``, ``YBR_FULL``,
 ``YBR_FULL_422``, etc).
 
-*pydicom* offers a limited ability to convert between 8-bits/channel RGB and
-YBR color spaces through the
+*pydicom* offers a limited ability to convert between 8-bits/channel YBR and
+RGB color spaces through the
 :func:`~pydicom.pixel_data_handlers.util.convert_color_space`
 function. When changing the color space you should also change the value
 of *Photometric Interpretation* to match.

--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -22,6 +22,9 @@ Fixes
 * Fixed propagation of bulk data handler in Dataset.from_json (:issue:`971`)
 * Correctly handle  DICOMDIR files with records in reverse-hierarchical order
   (:issue:`822`)
+* *Pixel Data* encoded using JPEG2000 and decoded using the Pillow handler no
+  longer returns RGB data when the (0028,0004) *Photometric Interpretation* is
+  YBR_FULL or YBR_FULL_422. (:issue:`263`, :issue:`273`, :issue:`826`)
 
 Enhancements
 ............

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -150,13 +150,17 @@ def get_pixeldata(ds):
     if getattr(ds, 'NumberOfFrames', 1) > 1:
         # multiple compressed frames
         for frame in decode_data_sequence(ds.PixelData):
-            decompressed_image = Image.open(io.BytesIO(frame))
-            pixel_bytes.extend(decompressed_image.tobytes())
+            im = Image.open(io.BytesIO(frame))
+            if 'YBR' in ds.PhotometricInterpretation:
+                im.draft('YCbCr', (ds.Rows, ds.Columns))
+            pixel_bytes.extend(im.tobytes())
     else:
         # single compressed frame
         pixel_data = defragment_data(ds.PixelData)
-        decompressed_image = Image.open(io.BytesIO(pixel_data))
-        pixel_bytes.extend(decompressed_image.tobytes())
+        im = Image.open(io.BytesIO(pixel_data))
+        if 'YBR' in ds.PhotometricInterpretation:
+            im.draft('YCbCr', (ds.Rows, ds.Columns))
+        pixel_bytes.extend(im.tobytes())
 
     logger.debug("Successfully read %s pixel bytes", len(pixel_bytes))
 
@@ -165,6 +169,8 @@ def get_pixeldata(ds):
     if (transfer_syntax in PillowJPEG2000TransferSyntaxes and
             ds.BitsStored == 16):
         # WHY IS THIS EVEN NECESSARY??
+        # Pillow doesn't support 16-bit data types and instead uses a
+        #   32-bit signed int
         arr &= 0x7FFF
 
     if should_change_PhotometricInterpretation_to_RGB(ds):

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -169,8 +169,6 @@ def get_pixeldata(ds):
     if (transfer_syntax in PillowJPEG2000TransferSyntaxes and
             ds.BitsStored == 16):
         # WHY IS THIS EVEN NECESSARY??
-        # Pillow doesn't support 16-bit data types and instead uses a
-        #   32-bit signed int
         arr &= 0x7FFF
 
     if should_change_PhotometricInterpretation_to_RGB(ds):

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -325,6 +325,16 @@ class Test_JPEG2000Tests_with_pillow(object):
         with pytest.raises(NotImplementedError):
             self.sc_rgb_jpeg2k_gdcm_KY.pixel_array
 
+    def test_ybr_conversion_shape(self):
+        """Test RGB->YBR has correct size."""
+        ds = self.jpeg_2k_lossless
+        ds.PhotometricInterpretation = 'YBR_FULL'
+        ds.Rows = 32
+        ds.Columns = 128
+        ds.decompress(handler_name='pillow')
+        a = self.jpeg_2k_lossless.pixel_array
+        assert (32, 128) == a.shape
+
 
 @pytest.mark.skipif(
     not TEST_JPEG,

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -9,6 +9,7 @@ import pydicom
 from pydicom.filereader import dcmread
 from pydicom.data import get_testdata_files
 from pydicom.tag import Tag
+from pydicom.pixel_data_handlers.util import convert_color_space
 
 # Python 3.4 pytest does not have pytest.param?
 have_pytest_param = hasattr(pytest, 'param')
@@ -367,8 +368,8 @@ class Test_JPEGlossyTests_with_pillow(object):
         a = self.color_3d_jpeg.pixel_array
 
         assert a.flags.writeable
-
         assert (120, 480, 640, 3) == a.shape
+        a = convert_color_space(a, 'YBR_FULL_422', 'RGB')
         # this test points were manually identified in Osirix viewer
         assert (41, 41, 41) == tuple(a[3, 159, 290, :])
         assert (57, 57, 57) == tuple(a[3, 169, 290, :])
@@ -406,7 +407,7 @@ if have_pytest_param:
              (64, 64, 64),
              (192, 192, 192),
              (255, 255, 255),
-         ], ground_truth_sc_rgb_jpeg_dcmtk_RGB),
+         ], ground_truth_sc_rgb_jpeg_dcmtk_RGB, False),
         pytest.param(
             sc_rgb_jpeg_dcmtk_411_YBR_FULL,
             "YBR_FULL",
@@ -422,7 +423,7 @@ if have_pytest_param:
                 (192, 192, 192),
                 (255, 255, 255),
             ],
-            ground_truth_sc_rgb_jpeg_dcmtk_411_YBR_FULL,
+            ground_truth_sc_rgb_jpeg_dcmtk_411_YBR_FULL, True,
             marks=pytest.mark.xfail(
                 reason="Pillow does not support "
                 "non default jpeg lossy colorspaces")),
@@ -441,7 +442,7 @@ if have_pytest_param:
                 (192, 192, 192),
                 (255, 255, 255),
             ],
-            ground_truth_sc_rgb_jpeg_dcmtk_411_YBR_FULL_422,
+            ground_truth_sc_rgb_jpeg_dcmtk_411_YBR_FULL_422, True,
             marks=pytest.mark.xfail(
                 reason="Pillow does not support "
                 "non default jpeg lossy colorspaces")),
@@ -457,7 +458,7 @@ if have_pytest_param:
              (64, 64, 64),
              (192, 192, 192),
              (255, 255, 255),
-         ], ground_truth_sc_rgb_jpeg_dcmtk_422_YBR_FULL),
+         ], ground_truth_sc_rgb_jpeg_dcmtk_422_YBR_FULL, True),
         (sc_rgb_jpeg_dcmtk_422_YBR_FULL_422, "YBR_FULL_422",
          [
              (254, 0, 0),
@@ -470,7 +471,7 @@ if have_pytest_param:
              (64, 64, 64),
              (192, 192, 192),
              (255, 255, 255),
-         ], ground_truth_sc_rgb_jpeg_dcmtk_422_YBR_FULL_422),
+         ], ground_truth_sc_rgb_jpeg_dcmtk_422_YBR_FULL_422, True),
         (sc_rgb_jpeg_dcmtk_444_YBR_FULL, "YBR_FULL",
          [
              (254, 0, 0),
@@ -483,7 +484,7 @@ if have_pytest_param:
              (64, 64, 64),
              (192, 192, 192),
              (255, 255, 255),
-         ], ground_truth_sc_rgb_jpeg_dcmtk_444_YBR_FULL), ]
+         ], ground_truth_sc_rgb_jpeg_dcmtk_444_YBR_FULL, True), ]
 else:
     test_ids = [
         "JPEG_RGB_RGB",
@@ -517,7 +518,7 @@ else:
              (64, 64, 64),
              (192, 192, 192),
              (255, 255, 255),
-         ], ground_truth_sc_rgb_jpeg_dcmtk_422_YBR_FULL),
+         ], ground_truth_sc_rgb_jpeg_dcmtk_422_YBR_FULL, True),
         (sc_rgb_jpeg_dcmtk_422_YBR_FULL_422, "YBR_FULL_422",
          [
              (254, 0, 0),
@@ -530,7 +531,7 @@ else:
              (64, 64, 64),
              (192, 192, 192),
              (255, 255, 255),
-         ], ground_truth_sc_rgb_jpeg_dcmtk_422_YBR_FULL_422),
+         ], ground_truth_sc_rgb_jpeg_dcmtk_422_YBR_FULL_422, True),
         (sc_rgb_jpeg_dcmtk_444_YBR_FULL, "YBR_FULL",
          [
              (254, 0, 0),
@@ -543,21 +544,22 @@ else:
              (64, 64, 64),
              (192, 192, 192),
              (255, 255, 255),
-         ], ground_truth_sc_rgb_jpeg_dcmtk_444_YBR_FULL), ]
+         ], ground_truth_sc_rgb_jpeg_dcmtk_444_YBR_FULL, True), ]
 
 
 @pytest.mark.skipif(
     not TEST_JPEG,
     reason=pillow_missing_message)
 @pytest.mark.parametrize(
-    "image,PhotometricInterpretation,results,ground_truth",
+    "image,PhotometricInterpretation,results,ground_truth,convert_yuv_to_rgb",
     testdata,
     ids=test_ids)
 def test_PI_RGB(test_with_pillow,
                 image,
                 PhotometricInterpretation,
                 results,
-                ground_truth):
+                ground_truth,
+                convert_yuv_to_rgb):
     t = dcmread(image)
     assert t.PhotometricInterpretation == PhotometricInterpretation
     a = t.pixel_array
@@ -574,6 +576,8 @@ def test_PI_RGB(test_with_pillow,
         for y in range(100):
             assert tuple(a[x, y]) == tuple(b[x, y])
     """
+    if convert_yuv_to_rgb:
+        a = convert_color_space(a, t.PhotometricInterpretation, 'RGB')
     # this test points are from the ImageComments tag
     assert tuple(a[5, 50, :]) == results[0]
     assert tuple(a[15, 50, :]) == results[1]


### PR DESCRIPTION
#### Describe the changes
* Pixel data with Photometric Interpretation of YBR_FULL and YBR_FULL_422 no longer decoded as RGB (closes #273, closes #263)

Docs for [Image.draft()](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.draft)

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [x] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better

Documentation preview [here](https://1708-14006067-gh.circle-artifacts.com/0/home/circleci/project/doc/_build/html/index.html)