### PR TITLE
[MRG] Avoid reference cycle in sequences

### DIFF
--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -20,11 +20,12 @@ Fixes
   Descriptor* elements (0028,1101-1103) and (0028,3002) (:issue:`942`)
 * Fixed handling of ISO IR 159 encoding (:issue: `917`)
 * Fixed propagation of bulk data handler in Dataset.from_json (:issue:`971`)
-* Correctly handle  DICOMDIR files with records in reverse-hierarchical order
+* Correctly handle DICOMDIR files with records in reverse-hierarchical order
   (:issue:`822`)
 * *Pixel Data* encoded using JPEG2000 and decoded using the Pillow handler no
   longer returns RGB data when the (0028,0004) *Photometric Interpretation* is
   YBR_FULL or YBR_FULL_422. (:issue:`263`, :issue:`273`, :issue:`826`)
+* Avoid possible high memory usage while reading sequences (:issue:`994`)
 
 Enhancements
 ............

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -769,9 +769,7 @@ class Dataset(dict):
         if tag is not None:  # `name` isn't a DICOM element keyword
             tag = Tag(tag)
             if tag in self._dict:  # DICOM DataElement not in the Dataset
-                data_elem = self[tag]
-                value = data_elem.value
-                return value
+                return self[tag].value
 
         # no tag or tag not contained in the dataset
         if name == '_dict':
@@ -1289,7 +1287,7 @@ class Dataset(dict):
         Raises
         ------
         ValueError
-            If `name` is not a valid handler name.
+            If `handler_name` is not a valid handler name.
         NotImplementedError
             If the given handler or any handler, if none given, is able to
             decompress pixel data with the current transfer syntax

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -771,10 +771,6 @@ class Dataset(dict):
             if tag in self._dict:  # DICOM DataElement not in the Dataset
                 data_elem = self[tag]
                 value = data_elem.value
-                if data_elem.VR == 'SQ':
-                    # let a sequence know its parent dataset, as sequence items
-                    # may need parent dataset tags to resolve ambiguous tags
-                    value.parent = self
                 return value
 
         # no tag or tag not contained in the dataset
@@ -854,6 +850,10 @@ class Dataset(dict):
         data_elem = self._dict[tag]
 
         if isinstance(data_elem, DataElement):
+            if data_elem.VR == 'SQ' and data_elem.value:
+                # let a sequence know its parent dataset, as sequence items
+                # may need parent dataset tags to resolve ambiguous tags
+                data_elem.value.parent = self
             return data_elem
         elif isinstance(data_elem, tuple):
             # If a deferred read, then go get the value now

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -70,8 +70,8 @@ def _correct_ambiguous_vr_element(elem, ds, is_little_endian):
         #   For references, see the list at
         #   https://github.com/darcymason/pydicom/pull/298
         # PixelRepresentation is usually set in the root dataset
-        while 'PixelRepresentation' not in ds and ds.parent:
-            ds = ds.parent
+        while 'PixelRepresentation' not in ds and ds.parent and ds.parent():
+            ds = ds.parent()
         # if no pixel data is present, none if these tags is used,
         # so we can just ignore a missing PixelRepresentation in this case
         if ('PixelRepresentation' not in ds and 'PixelData' not in ds or

--- a/pydicom/sequence.py
+++ b/pydicom/sequence.py
@@ -58,7 +58,8 @@ class Sequence(MultiValue):
 
     @property
     def parent(self):
-        """Return the parent :class:`~pydicom.dataset.Dataset`."""
+        """Return a weak reference to the parent
+        :class:`~pydicom.dataset.Dataset`."""
         return self._parent
 
     @parent.setter

--- a/pydicom/sequence.py
+++ b/pydicom/sequence.py
@@ -3,6 +3,7 @@
 
 Sequence is a list of pydicom Dataset objects.
 """
+import weakref
 
 from pydicom.dataset import Dataset
 from pydicom.multival import MultiValue
@@ -66,7 +67,7 @@ class Sequence(MultiValue):
         :class:`Sequence` items.
         """
         if value != self._parent:
-            self._parent = value
+            self._parent = weakref.ref(value)
             for item in self._list:
                 item.parent = self._parent
 

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -875,46 +875,89 @@ class TestCorrectAmbiguousVR(object):
         assert ds[0x00283002].VR == 'US'
         assert ds.LUTDescriptor == [1, 0]
 
-    def test_ambiguous_element_in_sequence_explicit(self):
-        """Test that writing a sequence with an ambiguous element
-        as explicit transfer syntax works."""
-        # regression test for #804
+    def dataset_with_modality_lut_sequence(self, pixel_repr):
         ds = Dataset()
-        ds.PixelRepresentation = 0
+        ds.PixelRepresentation = pixel_repr
         ds.ModalityLUTSequence = [Dataset()]
         ds.ModalityLUTSequence[0].LUTDescriptor = [0, 0, 16]
         ds.ModalityLUTSequence[0].LUTExplanation = None
         ds.ModalityLUTSequence[0].ModalityLUTType = 'US'  # US = unspecified
         ds.ModalityLUTSequence[0].LUTData = b'\x0000\x149a\x1f1c\xc2637'
-
         ds.is_little_endian = True
+        return ds
+
+    def test_ambiguous_element_in_sequence_explicit_using_attribute(self):
+        """Test that writing a sequence with an ambiguous element
+        as explicit transfer syntax works if accessing the tag via keyword."""
+        # regression test for #804
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=0)
         ds.is_implicit_VR = False
         fp = BytesIO()
         ds.save_as(fp, write_like_original=True)
-
         ds = dcmread(fp, force=True)
         assert 'US' == ds.ModalityLUTSequence[0][0x00283002].VR
 
-    def test_ambiguous_element_in_sequence_implicit(self):
-        """Test that reading a sequence with an ambiguous element
-        from a file with implicit transfer syntax works."""
-        # regression test for #804
-        ds = Dataset()
-        ds.PixelRepresentation = 0
-        ds.ModalityLUTSequence = [Dataset()]
-        ds.ModalityLUTSequence[0].LUTDescriptor = [0, 0, 16]
-        ds.ModalityLUTSequence[0].LUTExplanation = None
-        ds.ModalityLUTSequence[0].ModalityLUTType = 'US'  # US = unspecified
-        ds.ModalityLUTSequence[0].LUTData = b'\x0000\x149a\x1f1c\xc2637'
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=1)
+        ds.is_implicit_VR = False
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        assert 'SS' == ds.ModalityLUTSequence[0][0x00283002].VR
 
-        ds.is_little_endian = True
+    def test_ambiguous_element_in_sequence_explicit_using_index(self):
+        """Test that writing a sequence with an ambiguous element
+        as explicit transfer syntax works if accessing the tag
+        via the tag number."""
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=0)
+        ds.is_implicit_VR = False
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        assert 'US' == ds[0x00283000][0][0x00283002].VR
+
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=1)
+        ds.is_implicit_VR = False
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        assert 'SS' == ds[0x00283000][0][0x00283002].VR
+
+    def test_ambiguous_element_in_sequence_implicit_using_attribute(self):
+        """Test that reading a sequence with an ambiguous element
+        from a file with implicit transfer syntax works if accessing the
+        tag via keyword."""
+        # regression test for #804
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=0)
         ds.is_implicit_VR = True
         fp = BytesIO()
         ds.save_as(fp, write_like_original=True)
         ds = dcmread(fp, force=True)
-        # we first have to access the value to trigger correcting the VR
-        assert 16 == ds.ModalityLUTSequence[0].LUTDescriptor[2]
         assert 'US' == ds.ModalityLUTSequence[0][0x00283002].VR
+
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=1)
+        ds.is_implicit_VR = True
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        assert 'SS' == ds.ModalityLUTSequence[0][0x00283002].VR
+
+    def test_ambiguous_element_in_sequence_implicit_using_index(self):
+        """Test that reading a sequence with an ambiguous element
+        from a file with implicit transfer syntax works if accessing the tag
+        via the tag number."""
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=0)
+        ds.is_implicit_VR = True
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        assert 'US' == ds[0x00283000][0][0x00283002].VR
+
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=1)
+        ds.is_implicit_VR = True
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        assert 'SS' == ds[0x00283000][0][0x00283002].VR
 
 
 class TestCorrectAmbiguousVRElement(object):


### PR DESCRIPTION
- use a weakref as backlink to the dataset
- moved setting parent to `__getitem__` where it is always used
- added tests that fail without these changes
- fixes #994

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
