### PR TITLE
[MRG] Implicitly set PixelData.is_undefined_length when saving

### DIFF
--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -18,7 +18,7 @@ Fixes
 * Fixed error in pickling modified datasets (:issue:`951`)
 * Fixed improper conversion of the first value of the *LUT
   Descriptor* elements (0028,1101-1103) and (0028,3002) (:issue:`942`)
-* Fixed handling of ISO IR 159 encoding (:issue: `917`)
+* Fixed handling of ISO IR 159 encoding (:issue:`917`)
 * Fixed propagation of bulk data handler in Dataset.from_json (:issue:`971`)
 * Correctly handle DICOMDIR files with records in reverse-hierarchical order
   (:issue:`822`)
@@ -71,6 +71,9 @@ Enhancements
   with bit depth > 8 with the Pillow pixel data handler
 * A warning has been added when attempting to save a dataset with compressed
   transfer syntax but no encapsulation of the pixel data. (:issue:`1007`)
+* :attr:`PixelData.is_undefined_length
+  <pydicom.dataelem.DataElement.is_undefined_length>` is now set automatically
+  based on whether the Dataset's Transfer Syntax is compressed (:issue:`1006`)
 
 Changes
 .......

--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -69,8 +69,6 @@ Enhancements
   (:issue:`452`)
 * JPEG 2000 (1.2.840.10008.1.2.4.91) transfer syntax is supported for data
   with bit depth > 8 with the Pillow pixel data handler
-* A warning has been added when attempting to save a dataset with compressed
-  transfer syntax but no encapsulation of the pixel data. (:issue:`1007`)
 * :attr:`PixelData.is_undefined_length
   <pydicom.dataelem.DataElement.is_undefined_length>` is now set automatically
   based on whether the Dataset's Transfer Syntax is compressed (:issue:`1006`)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1771,20 +1771,13 @@ class Dataset(dict):
                     .format(self.__class__.__name__)
                 )
 
-        # If compressed transfer syntax check that Pixel Data is encapsulated
-        #   and `is_undefined_length` set correctly
+        # Try and ensure that `is_undefined_length` is set correctly
         try:
             tsyntax = self.file_meta.TransferSyntaxUID
             if not tsyntax.is_private:
                 self['PixelData'].is_undefined_length = tsyntax.is_compressed
         except (AttributeError, KeyError):
             pass
-        except AssertionError:
-            warnings.warn(
-                "The dataset uses a compressed Transfer Syntax UID but the "
-                "Pixel Data hasn't been encapsulated. See the "
-                "pydicom.encaps.encapsulate() function for more information"
-            )
 
         pydicom.dcmwrite(filename, self, write_like_original)
 

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1777,10 +1777,6 @@ class Dataset(dict):
             tsyntax = self.file_meta.TransferSyntaxUID
             if not tsyntax.is_private:
                 self['PixelData'].is_undefined_length = tsyntax.is_compressed
-                if tsyntax.is_compressed:
-                    # Check for Basic Offset Table item tag
-                    # Must always be little endian - PS3.5 Annex A.4
-                    assert self.PixelData[:4] == b'\xFE\xFF\x00\xE0'
         except (AttributeError, KeyError):
             pass
         except AssertionError:

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1758,8 +1758,8 @@ class Dataset(dict):
             try:
                 tsyntax = self.file_meta.TransferSyntaxUID
                 if not tsyntax.is_private:
-                    self.is_little_endian = transfer_syntax.is_little_endian
-                    self.is_implicit_VR = transfer_syntax.is_implicit_VR
+                    self.is_little_endian = tsyntax.is_little_endian
+                    self.is_implicit_VR = tsyntax.is_implicit_VR
                     has_tsyntax = True
             except AttributeError:
                 pass

--- a/pydicom/encaps.py
+++ b/pydicom/encaps.py
@@ -633,7 +633,8 @@ def encapsulate(frames, fragments_per_frame=1, has_bot=True):
       # using the corresponding compression method to Transfer Syntax UID
       ds.PixelData = encapsulate([frame1, frame2, ...])
 
-    For multi-frame data each frame must be encoded separately.
+    For multi-frame data each frame must be encoded separately and then all
+    encoded frames encapsulated together.
 
     Data will be encapsulated with a Basic Offset Table Item at the beginning,
     then one or more fragment items. Each item will be of even length and the

--- a/pydicom/encaps.py
+++ b/pydicom/encaps.py
@@ -625,14 +625,24 @@ itemize_frame = itemise_frame
 def encapsulate(frames, fragments_per_frame=1, has_bot=True):
     """Return encapsulated `frames`.
 
+    When using a compressed transfer syntax (such as RLE Lossless or one of
+    JPEG formats) then any *Pixel Data* must be :dcm:`encapsulated
+    <part05/sect_A.4.html>`::
+
+      # Where `frame1`, `frame2` are single frames that have been encoded
+      # using the corresponding compression method to Transfer Syntax UID
+      ds.PixelData = encapsulate([frame1, frame2, ...])
+
+    For multi-frame data each frame must be encoded separately.
+
     Data will be encapsulated with a Basic Offset Table Item at the beginning,
-    then one or more fragment Items. Each item will be of even length and the
-    final fragment of each frame may be padded with 0x00 if required.
+    then one or more fragment items. Each item will be of even length and the
+    final fragment of each frame may be padded with ``0x00`` if required.
 
     Parameters
     ----------
     frames : list of bytes
-        The frame data to encapsulate.
+        The frame data to encapsulate, one frame per item.
     fragments_per_frame : int, optional
         The number of fragments to use for each frame (default ``1``).
     has_bot : bool, optional
@@ -643,21 +653,7 @@ def encapsulate(frames, fragments_per_frame=1, has_bot=True):
     Returns
     -------
     bytes
-        The encapsulated data.
-
-    Notes
-    -----
-
-    * The encoding shall be in Little Endian.
-    * Each fragment is encapsulated as a DICOM Item with tag (FFFE,E000), then
-      a 4 byte length.
-    * The first item shall be a Basic Offset Table item.
-    * The Basic Offset Table item, however, is not required to have a value.
-    * If no value is present, the Basic Offset Table length is 0.
-    * If the value is present, it shall contain concatenated 32-bit
-      unsigned integer values that are byte offsets to the first byte of the
-      Item tag of the first fragment in each frame as measured from the first
-      byte of the first Item tag following the Basic Offset Table Item.
+        The encapsulated pixel data.
 
     References
     ----------

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -493,8 +493,9 @@ def write_data_element(fp, data_element, encodings=None):
         if not data_element.value.startswith(encap_item):
             raise ValueError(
                 "(7FE0,0010) Pixel Data has an undefined length indicating "
-                "that it's compressed but the data isn't encapsulated. See "
-                "the pydicom.encaps.encapsulate() for more information"
+                "that it's compressed, but the data isn't encapsulated as "
+                "required. See pydicom.encaps.encapsulate() for more "
+                "information"
             )
 
     value_length = buffer.tell()

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -486,13 +486,16 @@ def write_data_element(fp, data_element, encodings=None):
     # valid pixel data with undefined length shall contain encapsulated
     # data, e.g. sequence items - raise ValueError otherwise (see #238)
     if is_undefined_length and data_element.tag == 0x7fe00010:
-        val = data_element.value
-        if (fp.is_little_endian and not
-                val.startswith(b'\xfe\xff\x00\xe0') or
-                not fp.is_little_endian and
-                not val.startswith(b'\xff\xfe\xe0\x00')):
-            raise ValueError('Pixel Data with undefined length must '
-                             'start with an item tag')
+        encap_item = b'\xfe\xff\x00\xe0'
+        if not fp.is_little_endian:
+            # Non-conformant endianness
+            encap_item = b'\xff\xfe\xe0\x00'
+        if not data_element.value.startswith(encap_item):
+            raise ValueError(
+                "(7FE0,0010) Pixel Data has an undefined length indicating "
+                "that it's compressed but the data isn't encapsulated. See "
+                "the pydicom.encaps.encapsulate() for more information"
+            )
 
     value_length = buffer.tell()
     if (not fp.is_implicit_VR and VR not in extra_length_VRs and

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -177,7 +177,7 @@ def get_pixeldata(ds):
 
     if transfer_syntax in PillowJPEG2000TransferSyntaxes:
         # Pillow converts N-bit data to 8- or 16-bit unsigned data
-        # See Pillow src/libImaging/Jpeg2KDecode.c##::j2ku_gray_i
+        # See Pillow src/libImaging/Jpeg2KDecode.c::j2ku_gray_i
         if ds.PixelRepresentation == 1:
             # Pillow converts signed data to unsigned
             #   so we need to undo this conversion
@@ -193,8 +193,9 @@ def get_pixeldata(ds):
             )
 
         shift = ds.BitsAllocated - ds.BitsStored
-        logger.debug("Shifting right by {} bits".format(shift))
-        numpy.right_shift(arr, shift, out=arr)
+        if shift:
+            logger.debug("Shifting right by {} bits".format(shift))
+            numpy.right_shift(arr, shift, out=arr)
 
     if should_change_PhotometricInterpretation_to_RGB(ds):
         ds.PhotometricInterpretation = "RGB"

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1135,10 +1135,10 @@ class TestDataset(object):
         ds.PixelData = b'\x00\x01\x02\x03\x04\x05\x06'
         ds['PixelData'].VR = 'OB'
         msg = (
-            r"The dataset uses a compressed Transfer Syntax UID but the "
-            r"Pixel Data hasn't been encapsulated"
+            r"Pixel Data has an undefined length indicating "
+            r"that it's compressed but the data isn't encapsulated"
         )
-        with pytest.warns(UserWarning, match=msg):
+        with pytest.raises(ValueError, match=msg):
             ds.save_as(fp)
 
     def test_save_as_compressed_encaps(self):

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1136,7 +1136,7 @@ class TestDataset(object):
         ds['PixelData'].VR = 'OB'
         msg = (
             r"Pixel Data has an undefined length indicating "
-            r"that it's compressed but the data isn't encapsulated"
+            r"that it's compressed, but the data isn't encapsulated"
         )
         with pytest.raises(ValueError, match=msg):
             ds.save_as(fp)
@@ -1209,7 +1209,7 @@ class TestDataset(object):
         ds.save_as(fp)
 
     def test_save_as_undefined(self):
-        """Test settting is_undefined_length correctly."""
+        """Test setting is_undefined_length correctly."""
         fp = DicomBytesIO()
         ds = Dataset()
         ds.is_little_endian = True

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1185,6 +1185,96 @@ class TestDataset(object):
         ds.file_meta.TransferSyntaxUID = '1.2.3.4.5.6'
         ds.save_as(fp)
 
+    def test_save_as_set_little_implicit_with_tsyntax(self):
+        """Test setting is_implicit_VR and is_little_endian from tsyntax"""
+        fp = DicomBytesIO()
+        ds = Dataset()
+        ds.PatientName = 'CITIZEN'
+        # Raise if is_implicit_VR or is_little_endian missing with no tsyntax
+        msg = (
+            r"'Dataset.is_little_endian' and 'Dataset.is_implicit_VR' must be "
+            r"set appropriately before saving."
+        )
+        with pytest.raises(AttributeError, match=msg):
+            ds.save_as(fp)
+
+        # Test private transfer syntax raises
+        ds.file_meta = Dataset()
+        ds.file_meta.TransferSyntaxUID = '1.2'
+        with pytest.raises(AttributeError, match=msg):
+            ds.save_as(fp)
+
+        # Test public transfer syntax OK
+        ds.file_meta.TransferSyntaxUID = '1.2.840.10008.1.2.1'
+        ds.save_as(fp)
+
+    def test_save_as_undefined(self):
+        """Test settting is_undefined_length correctly."""
+        fp = DicomBytesIO()
+        ds = Dataset()
+        ds.is_little_endian = True
+        ds.is_implicit_VR = False
+        ds.file_meta = Dataset()
+        ds.file_meta.TransferSyntaxUID = JPEGBaseline
+        ds.PixelData = encapsulate([b'\x00\x01\x02\x03\x04\x05\x06'])
+        elem = ds['PixelData']
+        elem.VR = 'OB'
+        # Compressed
+        # False to True
+        assert not elem.is_undefined_length
+        ds.save_as(fp)
+        assert elem.is_undefined_length
+        # True to True
+        ds.save_as(fp)
+        assert elem.is_undefined_length
+
+        # Uncompressed
+        ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
+        # True to False
+        ds.save_as(fp)
+        assert not elem.is_undefined_length
+        # False to False
+        ds.save_as(fp)
+        assert not elem.is_undefined_length
+
+    def test_save_as_undefined_private(self):
+        """Test is_undefined_length unchanged with private tsyntax."""
+        fp = DicomBytesIO()
+        ds = Dataset()
+        ds.is_little_endian = True
+        ds.is_implicit_VR = False
+        ds.file_meta = Dataset()
+        ds.file_meta.TransferSyntaxUID = '1.2.3.4.5'
+        ds.PixelData = encapsulate([b'\x00\x01\x02\x03\x04\x05\x06'])
+        elem = ds['PixelData']
+        elem.VR = 'OB'
+        # Unchanged - False
+        assert not elem.is_undefined_length
+        ds.save_as(fp)
+        assert not elem.is_undefined_length
+        # Unchanged - True
+        elem.is_undefined_length = True
+        ds.save_as(fp)
+        assert elem.is_undefined_length
+
+    def test_save_as_undefined_no_tsyntax(self):
+        """Test is_undefined_length unchanged with no tsyntax."""
+        fp = DicomBytesIO()
+        ds = Dataset()
+        ds.is_little_endian = True
+        ds.is_implicit_VR = False
+        ds.PixelData = encapsulate([b'\x00\x01\x02\x03\x04\x05\x06'])
+        elem = ds['PixelData']
+        elem.VR = 'OB'
+        # Unchanged - False
+        assert not elem.is_undefined_length
+        ds.save_as(fp)
+        assert not elem.is_undefined_length
+        # Unchanged - True
+        elem.is_undefined_length = True
+        ds.save_as(fp)
+        assert elem.is_undefined_length
+
     def test_with(self):
         """Test Dataset.__enter__ and __exit__."""
         test_file = get_testdata_files('CT_small.dcm')[0]

--- a/pydicom/tests/test_dicomdir.py
+++ b/pydicom/tests/test_dicomdir.py
@@ -34,9 +34,8 @@ class TestDicomDir(object):
     def test_invalid_sop_file_meta(self):
         """Test exception raised if SOP Class is not Media Storage Directory"""
         ds = dcmread(get_testdata_file('CT_small.dcm'))
-        with pytest.raises(InvalidDicomError,
-                           match=r"SOP Class is not Media Storage "
-                                 r"Directory \(DICOMDIR\)"):
+        msg = r"SOP Class is not Media Storage Directory \(DICOMDIR\)"
+        with pytest.raises(InvalidDicomError, match=msg):
             DicomDir("some_name", ds, b'\x00' * 128, ds.file_meta, True, True)
 
     def test_invalid_sop_no_file_meta(self):
@@ -45,7 +44,8 @@ class TestDicomDir(object):
         with pytest.raises(AttributeError,
                            match="'DicomDir' object has no attribute "
                                  "'DirectoryRecordSequence'"):
-            DicomDir("some_name", ds, b'\x00' * 128, None, True, True)
+            with pytest.warns(UserWarning, match=r"Invalid transfer syntax"):
+                DicomDir("some_name", ds, b'\x00' * 128, None, True, True)
 
     @pytest.mark.parametrize("testfile", TEST_FILES)
     def test_parse_records(self, testfile):

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -2517,7 +2517,7 @@ class TestWriteUndefinedLengthPixelData(object):
                                  is_undefined_length=True)
         msg = (
             r"Pixel Data has an undefined length indicating "
-            r"that it's compressed but the data isn't encapsulated"
+            r"that it's compressed, but the data isn't encapsulated"
         )
         with pytest.raises(ValueError, match=msg):
             write_data_element(self.fp, pixel_data)
@@ -2533,7 +2533,7 @@ class TestWriteUndefinedLengthPixelData(object):
                                  is_undefined_length=True)
         msg = (
             r"Pixel Data has an undefined length indicating "
-            r"that it's compressed but the data isn't encapsulated"
+            r"that it's compressed, but the data isn't encapsulated"
         )
         with pytest.raises(ValueError, match=msg):
             write_data_element(self.fp, pixel_data)

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -2515,8 +2515,11 @@ class TestWriteUndefinedLengthPixelData(object):
                                  b'\x00\x01\x02\x03'
                                  b'\xfe\xff\xdd\xe0',
                                  is_undefined_length=True)
-        with pytest.raises(ValueError, match='Pixel Data .* must '
-                                             'start with an item tag'):
+        msg = (
+            r"Pixel Data has an undefined length indicating "
+            r"that it's compressed but the data isn't encapsulated"
+        )
+        with pytest.raises(ValueError, match=msg):
             write_data_element(self.fp, pixel_data)
 
     def test_big_endian_incorrect_data(self):
@@ -2528,8 +2531,11 @@ class TestWriteUndefinedLengthPixelData(object):
                                  b'\x00\x01\x02\x03'
                                  b'\xff\xfe\xe0\xdd',
                                  is_undefined_length=True)
-        with pytest.raises(ValueError, match='Pixel Data .+ must '
-                                             'start with an item tag'):
+        msg = (
+            r"Pixel Data has an undefined length indicating "
+            r"that it's compressed but the data isn't encapsulated"
+        )
+        with pytest.raises(ValueError, match=msg):
             write_data_element(self.fp, pixel_data)
 
     def test_writing_to_gzip(self):

--- a/pydicom/tests/test_json.py
+++ b/pydicom/tests/test_json.py
@@ -316,7 +316,7 @@ class TestBinary(object):
         with pytest.warns(UserWarning, match=msg):
             ds = Dataset.from_json(ds_json)
         assert 0x00091002 in ds
-        
+
         ds_json = ('{"00091002": {"vr": "OB", "BulkDataURI": '
                    '["http://example.com/bulkdatahandler"]}}')
         with pytest.warns(UserWarning, match=msg):

--- a/pydicom/tests/test_json.py
+++ b/pydicom/tests/test_json.py
@@ -312,11 +312,15 @@ class TestBinary(object):
     def test_valid_bulkdata_uri(self):
         ds_json = ('{"00091002": {"vr": "OB", "BulkDataURI": '
                    '"http://example.com/bulkdatahandler"}}')
-        ds = Dataset.from_json(ds_json)
+        msg = r"no bulk data URI handler provided"
+        with pytest.warns(UserWarning, match=msg):
+            ds = Dataset.from_json(ds_json)
         assert 0x00091002 in ds
+        
         ds_json = ('{"00091002": {"vr": "OB", "BulkDataURI": '
                    '["http://example.com/bulkdatahandler"]}}')
-        ds = Dataset.from_json(ds_json)
+        with pytest.warns(UserWarning, match=msg):
+            ds = Dataset.from_json(ds_json)
         assert 0x00091002 in ds
 
     def test_invalid_bulkdata_uri(self):


### PR DESCRIPTION
#### Describe the changes
* Sets `PixelData.is_undefined_length` implicitly during saving based on the transfer syntax compression when possible (closes #1006)
* Reverts the warning from #1008 in favour of a better exception message
* Sets `Dataset.is_implicit_VR` and `Dataset.is_little_endian` automatically from transfer syntax when possible and they're unset
* Added test of `shift` to pillow handler to save on array operation (maybe)
* Docstring updates, test updates to capture warnings

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [x] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better

Documentation preview [here](https://1763-14006067-gh.circle-artifacts.com/0/home/circleci/project/doc/_build/html/index.html)