### PR TITLE
[MRG] Do not build universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 test=pytest
 
 [bdist_wheel]
-universal=1
+universal=0


### PR DESCRIPTION
- we do not support Python 2, so the wheels should not be found under Python 2

I ran into this issue with another Python 3-only-package, that could be installed under Python 2 due to this flag. To be sure not to forget this... 