### PR TITLE
[MRG] Fix reading and writing elements with a VR of OF

### DIFF
--- a/doc/release_notes/v2.0.0.rst
+++ b/doc/release_notes/v2.0.0.rst
@@ -24,3 +24,4 @@ Fixes
 * Removed ``1.2.840.10008.1.2.4.70`` - JPEG Lossless (Process 14, SV1) from
   the Pillow pixel data handler as Pillow doesn't support JPEG Lossless.
   (:issue:`1053`)
+* Fixed error writing elements with a VR of **OF** (:issue:`1075`)

--- a/doc/release_notes/v2.0.0.rst
+++ b/doc/release_notes/v2.0.0.rst
@@ -24,4 +24,6 @@ Fixes
 * Removed ``1.2.840.10008.1.2.4.70`` - JPEG Lossless (Process 14, SV1) from
   the Pillow pixel data handler as Pillow doesn't support JPEG Lossless.
   (:issue:`1053`)
-* Fixed error writing elements with a VR of **OF** (:issue:`1075`)
+* Fixed error when writing elements with a VR of **OF** (:issue:`1075`)
+* Fixed improper conversion when reading elements with a VR of **OF**
+  (:issue:`1075`)

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -1004,7 +1004,7 @@ writers = {
     'LT': (write_text, None),
     'OB': (write_OBvalue, None),
     'OD': (write_OWvalue, None),
-    'OF': (write_numbers, 'f'),
+    'OF': (write_OWvalue, None),
     'OL': (write_OWvalue, None),
     'OW': (write_OWvalue, None),
     'OV': (write_OWvalue, None),

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -700,6 +700,20 @@ class TestReader(object):
         assert elem.value == -2816
         assert elem.VR == 'SS'
 
+    def test_reading_of(self):
+        """Test reading a dataset with OF element."""
+        bs = DicomBytesIO(
+            b'\x28\x00\x01\x11\x53\x53\x06\x00\x00\xf5\x00\xf8\x10\x00'
+            b'\xe0\x7f\x08\x00\x4F\x46\x00\x00\x04\x00\x00\x00\x00\x01\x02\x03'
+        )
+        bs.is_little_endian = True
+        bs.is_implicit_VR = False
+
+        ds = dcmread(bs, force=True)
+        elem = ds['FloatPixelData']
+        assert 'OF' == elem.VR
+        assert b'\x00\x01\x02\x03' == elem.value
+
 
 class TestIncorrectVR(object):
     def setup(self):

--- a/pydicom/tests/test_values.py
+++ b/pydicom/tests/test_values.py
@@ -5,9 +5,10 @@
 import pytest
 
 from pydicom.tag import Tag
-from pydicom.values import (convert_value, converters, convert_tag,
-                            convert_ATvalue, convert_DA_string, convert_text,
-                            convert_single_string, convert_AE_string)
+from pydicom.values import (
+    convert_value, converters, convert_tag, convert_ATvalue, convert_DA_string,
+    convert_text, convert_single_string, convert_AE_string, convert_OWvalue
+)
 
 
 class TestConvertTag(object):
@@ -188,3 +189,11 @@ class TestConvertValue(object):
         # Fix converters
         converters['PN'] = converter_func
         assert 'PN' in converters
+
+
+class TestConvertOValues(object):
+    """Test converting values with the 'O' VRs like OB, OW, OF, etc."""
+    def test_convert_of(self):
+        """Test converting OF."""
+        fp = b'\x00\x01\x02\x03'
+        assert b'\x00\x01\x02\x03' == convert_OWvalue(fp, True)

--- a/pydicom/tests/test_values.py
+++ b/pydicom/tests/test_values.py
@@ -7,7 +7,7 @@ import pytest
 from pydicom.tag import Tag
 from pydicom.values import (
     convert_value, converters, convert_tag, convert_ATvalue, convert_DA_string,
-    convert_text, convert_single_string, convert_AE_string, convert_OWvalue
+    convert_text, convert_single_string, convert_AE_string
 )
 
 
@@ -196,4 +196,4 @@ class TestConvertOValues(object):
     def test_convert_of(self):
         """Test converting OF."""
         fp = b'\x00\x01\x02\x03'
-        assert b'\x00\x01\x02\x03' == convert_OWvalue(fp, True)
+        assert b'\x00\x01\x02\x03' == converters['OF'](fp, True)

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -634,7 +634,7 @@ converters = {
     'LT': convert_single_string,
     'OB': convert_OBvalue,
     'OD': convert_OBvalue,
-    'OF': (convert_numbers, 'f'),
+    'OF': convert_OWvalue,
     'OL': convert_OBvalue,
     'OW': convert_OWvalue,
     'OV': convert_OVvalue,


### PR DESCRIPTION
#### Describe the changes
* Closes #1075
* Reading OF values now results in ``bytes``  consistent with the other O* elements.
* Writing OF values now works correctly

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
