### PR TITLE
[MRG] Fixed description of newly added known private tag

### DIFF
--- a/doc/release_notes/v2.0.0.rst
+++ b/doc/release_notes/v2.0.0.rst
@@ -31,3 +31,4 @@ Fixes
   :func:`~pydicom.pixel_data_handlers.util.apply_modality_lut` not handling
   (0028,3006) *LUT Data* with a VR of **OW** (:issue:`1073`)
 * Fixed access to private creator tag in raw datasets (:issue:`1078`)
+* Fixed description of newly added known private tag (:issue:`1082`)

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -856,7 +856,7 @@ def dcmwrite(filename, dataset, write_like_original=True):
 
     See Also
     --------
-    pydicom.dataset.FileDataset
+    pydicom.dataset.Dataset
         Dataset class with relevant attributes and information.
     pydicom.dataset.Dataset.save_as
         Write a DICOM file from a dataset that was read in with ``dcmread()``.

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -104,7 +104,7 @@ class TestDataElement(object):
         assert 'Private tag data' == elem.description()
         elem = DataElement(0x00110F00, 'LO', 12345)
         assert elem.tag.is_private
-        assert not hasattr(elem, 'private_creator')
+        assert elem.private_creator is None
         assert 'Private tag data' == elem.description()
 
     def test_description_unknown(self):


### PR DESCRIPTION
- minor docstring fixes
- fixes #1082

Note: I fixed this only for using the private block API. The problem will still happen if you add private tags without the private creator manually. Fixing that would be a bit more expansive, and I decided to regard this as deprecated.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
