### PR TITLE
[MRG] Write deflated content when called Transfer Syntax is Deflated Explicit VR Little Endian

### DIFF
--- a/doc/release_notes/v2.0.0.rst
+++ b/doc/release_notes/v2.0.0.rst
@@ -12,7 +12,7 @@ Enhancements
 ............
 * Allow PathLike objects for filename argument in `dcmread`, `dcmwrite` and
   `Dataset.save_as` (:issue:`1047`)
-* Deflate post-file mata information data when writing a dataset with the
+* Deflate post-file meta information data when writing a dataset with the
   Deflated Explicit VR Little Endian transfer syntax UID (:issue:`1086`)
 
 Fixes

--- a/doc/release_notes/v2.0.0.rst
+++ b/doc/release_notes/v2.0.0.rst
@@ -12,6 +12,8 @@ Enhancements
 ............
 * Allow PathLike objects for filename argument in `dcmread`, `dcmwrite` and
   `Dataset.save_as` (:issue:`1047`)
+* Deflate post-file mata information data when writing a dataset with the
+  Deflated Explicit VR Little Endian transfer syntax UID (:issue:`1086`)
 
 Fixes
 .....

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -710,7 +710,7 @@ def read_partial(fileobj, stop_when=None, defer_size=None,
         is_implicit_VR = False
         is_little_endian = False
     elif transfer_syntax == pydicom.uid.DeflatedExplicitVRLittleEndian:
-        # See PS3.6-2008 A.5 (p 71)
+        # See PS3.5 section A.5
         # when written, the entire dataset following
         #     the file metadata was prepared the normal way,
         #     then "deflate" compression applied.

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -991,9 +991,9 @@ def dcmwrite(filename, dataset, write_like_original=True):
             tsyntax = getattr(dataset.file_meta, "TransferSyntaxUID", None)
 
         if (tsyntax == DeflatedExplicitVRLittleEndian):
-            # See PS3.6-2008 A.5 (p 71)
-            # when written, the entire dataset following
-            #     the file metadata was prepared the normal way,
+            # See PS3.5 section A.5
+            # when writing, the entire dataset following
+            #     the file metadata is prepared the normal way,
             #     then "deflate" compression applied.
             buffer = DicomBytesIO()
             _write_dataset(buffer, dataset, write_like_original)

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -49,6 +49,7 @@ datetime_name = mr_name
 
 unicode_name = get_charset_files("chrH31.dcm")[0]
 multiPN_name = get_charset_files("chrFrenMulti.dcm")[0]
+deflate_name = get_testdata_file("image_dfl.dcm")
 
 base_version = '.'.join(str(i) for i in __version_info__)
 
@@ -221,6 +222,23 @@ class TestWriteFile(object):
         self.file_out.seek(0)
         ds = read_file(self.file_out)
         assert ds.PerformedProcedureCodeSequence == []
+
+    def test_write_deflated(self):
+        """Read a Deflated Explicit VR Little Endian file, write it,
+           and then read the output, to verify that the written file
+           is correct.
+           """
+        original = read_file(deflate_name)
+        original.save_as(self.file_out)
+
+        self.file_out.seek(0)
+        rewritten = read_file(self.file_out)
+
+        assert (original.file_meta.TransferSyntaxUID ==
+                rewritten.file_meta.TransferSyntaxUID)
+        assert len(original) == len(rewritten)
+        assert original.ImageComments == rewritten.ImageComments
+        assert original.PixelData == rewritten.PixelData
 
 
 class TestScratchWriteDateTime(TestWriteFile):


### PR DESCRIPTION
#### Describe the changes
Fixes #1086

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Documentation updated (if relevant) **I didn't change the docs**. Can if you like, but it felt like a feature that should just work, without anyone thinking about it.
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
    * I do  not understand what's being asked of me. The CircleCI build passed. I can see that artifacts were uploaded, but cannot figure out how to view the index.html
- [x] Unit tests passing and overall coverage the same or better
   I was unable to run the pillow tests, despite installing NUMPY. We'll see if the automatic checks pass. Code coverage for filewriter:
   ```
   Name                                             Stmts   Miss Branch BrPart  Cover
   ----------------------------------------------------------------------------------
   pydicom\filewriter.py                              371     28    210     16    91%
   ```
   compared to master at
   ```
   pydicom\filewriter.py                              357     28    206     15    91%
   ```
- [x] code standards maintained 
     * No new pyflake warnings. Unused `tzinfo` in `test_filewriter.py` remains
     * No new pep8 warnings. These exist in the files I touched, but predate my changes:
       ```
       pydicom/filewriter.py:121:11: W503 line break before binary operator
       pydicom/tests/test_filewriter.py:1669:32: W503 line break before binary operator
       pydicom/tests/test_filewriter.py:1670:32: W503 line break before binary operator
       ```
