### PR TITLE
[MRG] New file meta

### DIFF
--- a/doc/old/base_element.rst
+++ b/doc/old/base_element.rst
@@ -27,15 +27,23 @@ A :class:`~dataset.Dataset` could be created directly, but you will
 usually get one by reading an existing DICOM file::
 
   >>> import pydicom
-  >>> from pydicom.data import get_testdata_files
+  >>> from pydicom.data import get_testdata_file
   >>> # get some test data
-  >>> filename = get_testdata_files("rtplan.dcm")[0]
+  >>> filename = get_testdata_file("rtplan.dcm")
   >>> ds = pydicom.dcmread(filename)
 
 You can display the entire dataset by simply printing its string
 (:class:`str()<str>` or :func:`repr`) value::
 
   >>> ds # doctest: +ELLIPSIS
+  Dataset.file_meta -------------------------------
+  (0002, 0000) File Meta Information Group Length  UL: 156
+  (0002, 0001) File Meta Information Version       OB: b'\x00\x01'
+  (0002, 0002) Media Storage SOP Class UID         UI: RT Plan Storage
+  (0002, 0003) Media Storage SOP Instance UID      UI: 1.2.999.999.99.9.9999.9999.20030903150023
+  (0002, 0010) Transfer Syntax UID                 UI: Implicit VR Little Endian
+  (0002, 0012) Implementation Class UID            UI: 1.2.888.888.88.8.8.8
+  -------------------------------------------------
   (0008, 0012) Instance Creation Date              DA: '20030903'
   (0008, 0013) Instance Creation Time              TM: '150031'
   (0008, 0016) SOP Class UID                       UI: RT Plan Storage
@@ -185,7 +193,7 @@ To work with (7FE0,0010) *Pixel Data*, the raw :class:`bytes` are available
 through the `PixelData` keyword::
 
   >>> # read data with actual pixel data
-  >>> filename = get_testdata_files("CT_small.dcm")[0]
+  >>> filename = get_testdata_file("CT_small.dcm")
   >>> ds = pydicom.dcmread(filename)
   >>> pixel_bytes = ds.PixelData
 

--- a/doc/old/private_data_elements.rst
+++ b/doc/old/private_data_elements.rst
@@ -34,7 +34,7 @@ Here is an example of some private tags displayed for pydicom's test file
 
     >>> from pydicom import dcmread
     >>> from pydicom.data import get_testdata_file
-    >>> ct_filename = get_testdata_file("CT_small")
+    >>> ct_filename = get_testdata_file("CT_small.dcm")
     >>> ds = dcmread(ct_filename)
     >>> ds
     Dataset.file_meta -------------------------------

--- a/doc/old/private_data_elements.rst
+++ b/doc/old/private_data_elements.rst
@@ -33,10 +33,20 @@ Here is an example of some private tags displayed for pydicom's test file
 'CT_small.dcm'::
 
     >>> from pydicom import dcmread
-    >>> from pydicom.data import get_testdata_files
-    >>> ct_filename = get_testdata_files("CT_small")[0]
+    >>> from pydicom.data import get_testdata_file
+    >>> ct_filename = get_testdata_file("CT_small")
     >>> ds = dcmread(ct_filename)
     >>> ds
+    Dataset.file_meta -------------------------------
+    (0002, 0000) File Meta Information Group Length  UL: 192
+    (0002, 0001) File Meta Information Version       OB: b'\x00\x01'
+    (0002, 0002) Media Storage SOP Class UID         UI: CT Image Storage
+    (0002, 0003) Media Storage SOP Instance UID      UI: 1.3.6.1.4.1.5962.1.1.1.1.1.20040119072730.12322
+    (0002, 0010) Transfer Syntax UID                 UI: Explicit VR Little Endian
+    (0002, 0012) Implementation Class UID            UI: 1.3.6.1.4.1.5962.2
+    (0002, 0013) Implementation Version Name         SH: 'DCTOOL100'
+    (0002, 0016) Source Application Entity Title     AE: 'CLUNIE1'
+    -------------------------------------------------
     (0008, 0005) Specific Character Set              CS: 'ISO_IR 100'
     (0008, 0008) Image Type                          CS: ['ORIGINAL', 'PRIMARY', 'AX
     IAL']

--- a/doc/reference/config.rst
+++ b/doc/reference/config.rst
@@ -19,8 +19,10 @@ Configuration Options (:mod:`pydicom.config`)
    overlay_data_handlers
    pixel_data_handlers
    reset_data_element_callback
+   show_file_meta
    DS_decimal
    DS_numpy
    use_DS_decimal
    use_IS_numpy
    use_DS_numpy
+

--- a/doc/reference/dataset.rst
+++ b/doc/reference/dataset.rst
@@ -12,5 +12,6 @@ Representation of DICOM datasets and related functions.
 
    Dataset
    FileDataset
+   FileMetaDataset
    PrivateBlock
    validate_file_meta

--- a/doc/release_notes/v2.0.0.rst
+++ b/doc/release_notes/v2.0.0.rst
@@ -4,6 +4,20 @@ Version 2.0.0
 Changelog
 ---------
 * Dropped support for Python 2 (only Python 3.5+ supported)
+
+* Changes to `Dataset.file_meta`
+
+  * file_meta now shown by default in dataset `str` or `repr` output;
+    :data:`pydicom.config.show_file_meta` can be set ``False`` to restore
+    previous behavior
+
+  * new :class:`~pydicom.dataset.FileMetaDataset` class that accepts
+    only group 2 data elements
+
+  * Deprecation warning given unless `Dataset.file_meta` set with
+    a :class:`~pydicom.dataset.FileMetaDataset` object (in *pydicom* 3,
+    it will be required)
+
 * Old `PersonName` class removed; `PersonName3` renamed to `PersonName`.
   Classes `PersonNameUnicode` and `PersonName3` are aliased to `PersonName` but
   are deprecated and will be removed in version 2.1

--- a/doc/tutorials/dataset_basics.rst
+++ b/doc/tutorials/dataset_basics.rst
@@ -325,7 +325,7 @@ The answer is a file header containing:
 * Followed by a 4 byte ``DICM`` prefix
 * Followed by the required DICOM :dcm:`File Meta Information
   <part10/chapter_7.html#table_7.1-1>` elements, which in *pydicom* are
-  stored in a :class:`~pydicom.dataset.Dataset` instance in the
+  stored in a :class:`~pydicom.dataset.FileMetaDataset` instance in the
   :attr:`~pydicom.dataset.FileDataset.file_meta` attribute::
 
     >>> ds.file_meta
@@ -584,7 +584,7 @@ so get in the habit of making sure it's there and correct.
 Because we deleted the :attr:`~pydicom.dataset.FileDataset.file_meta` dataset
 we need to add it back::
 
-    >>> ds.file_meta = Dataset()
+    >>> ds.file_meta = FileMetaDataset()
 
 And now we can add our *Transfer Syntax UID* element and save to file::
 

--- a/doc/tutorials/dataset_basics.rst
+++ b/doc/tutorials/dataset_basics.rst
@@ -136,6 +136,16 @@ Let's go back to our ``CT_small.dcm`` dataset::
 You can view the contents of the entire dataset by using :func:`print`::
 
     >>> print(ds)
+    Dataset.file_meta -------------------------------
+    (0002, 0000) File Meta Information Group Length  UL: 192
+    (0002, 0001) File Meta Information Version       OB: b'\x00\x01'
+    (0002, 0002) Media Storage SOP Class UID         UI: CT Image Storage
+    (0002, 0003) Media Storage SOP Instance UID      UI: 1.3.6.1.4.1.5962.1.1.1.1.1.20040119072730.12322
+    (0002, 0010) Transfer Syntax UID                 UI: Explicit VR Little Endian
+    (0002, 0012) Implementation Class UID            UI: 1.3.6.1.4.1.5962.2
+    (0002, 0013) Implementation Version Name         SH: 'DCTOOL100'
+    (0002, 0016) Source Application Entity Title     AE: 'CLUNIE1'
+    -------------------------------------------------
     (0008, 0005) Specific Character Set              CS: 'ISO_IR 100'
     (0008, 0008) Image Type                          CS: ['ORIGINAL', 'PRIMARY', 'AXIAL']
     (0008, 0012) Instance Creation Date              DA: '20040119'

--- a/examples/input_output/plot_write_dicom.py
+++ b/examples/input_output/plot_write_dicom.py
@@ -17,7 +17,7 @@ import tempfile
 import datetime
 
 import pydicom
-from pydicom.dataset import Dataset, FileDataset
+from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
 
 # Create some temporary filenames
 suffix = '.dcm'
@@ -26,7 +26,7 @@ filename_big_endian = tempfile.NamedTemporaryFile(suffix=suffix).name
 
 print("Setting file meta information...")
 # Populate required values for file meta information
-file_meta = Dataset()
+file_meta = FileMetaDataset()
 file_meta.MediaStorageSOPClassUID = '1.2.840.10008.5.1.4.1.1.2'
 file_meta.MediaStorageSOPInstanceUID = "1.2.3"
 file_meta.ImplementationClassUID = "1.2.3.4"

--- a/pydicom/benchmarks/bench_handler_numpy.py
+++ b/pydicom/benchmarks/bench_handler_numpy.py
@@ -10,7 +10,7 @@ from tempfile import TemporaryFile
 import numpy as np
 
 from pydicom import dcmread
-from pydicom.dataset import Dataset
+from pydicom.dataset import Dataset, FileMetaDataset
 from pydicom.data import get_testdata_files
 from pydicom.encaps import decode_data_sequence
 from pydicom.pixel_data_handlers.numpy_handler import get_pixeldata
@@ -67,7 +67,7 @@ def _create_temporary_dataset(shape=(100, 1024, 1024, 3), bit_depth=16):
     ds = Dataset()
     ds.is_little_endian = True
     ds.is_implicit_VR = False
-    ds.file_meta = Dataset()
+    ds.file_meta = FileMetaDataset()
     ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
     ds.SOPClassUID = '1.2.3.4'
     ds.SOPInstanceUID = generate_uid()

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -172,11 +172,12 @@ not DICOM conformant and would lead to a failure if accessing it.
 """
 
 show_file_meta = True
-""" If ``True`` (default), the 'str' and 'repr' methods
-of :class:`~pydicom.dataset.Dataset begin with a separate section
-displaying the file meta information data elements
-
+"""
 .. versionadded:: 2.0
+
+If ``True`` (default), the 'str' and 'repr' methods
+of :class:`~pydicom.dataset.Dataset` begin with a separate section
+displaying the file meta information data elements
 """
 
 # Logging system and debug function to change logging level

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -171,6 +171,14 @@ not DICOM conformant and would lead to a failure if accessing it.
 .. versionadded:: 2.0
 """
 
+show_file_meta = True
+""" If ``True`` (default), the 'str' and 'repr' methods
+of :class:`~pydicom.dataset.Dataset begin with a separate section
+displaying the file meta information data elements
+
+.. versionadded:: 2.0
+"""
+
 # Logging system and debug function to change logging level
 logger = logging.getLogger('pydicom')
 logger.addHandler(logging.NullHandler())

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1698,8 +1698,7 @@ class Dataset(dict):
 
         # Display file meta, if configured to do so, and have a non-empty one
         if (
-            indent == 0
-            and hasattr(self, "file_meta")
+            hasattr(self, "file_meta")
             and self.file_meta is not None
             and len(self.file_meta) > 0
             and pydicom.config.show_file_meta

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1696,20 +1696,18 @@ class Dataset(dict):
         indent_str = self.indent_chars * indent
         nextindent_str = self.indent_chars * (indent + 1)
 
-        # Display file meta, if configured to do so, and are a regular Dataset
+        # Display file meta, if configured to do so, and have a non-empty one
         if (
             indent == 0
             and hasattr(self, "file_meta")
-            and not isinstance(self, FileMetaDataset)
+            and self.file_meta is not None
+            and len(self.file_meta) > 0
             and pydicom.config.show_file_meta
         ):
             strings.append("Dataset.file_meta -------------------------------")
-            if self.file_meta is None:
-                strings.append("None")
-            else:
-                for data_element in self.file_meta:
-                    with tag_in_exception(data_element.tag):
-                        strings.append(indent_str + repr(data_element))
+            for data_element in self.file_meta:
+                with tag_in_exception(data_element.tag):
+                    strings.append(indent_str + repr(data_element))
             strings.append("-------------------------------------------------")
 
         for data_element in self:

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -2372,7 +2372,7 @@ def validate_file_meta(file_meta, enforce_standard=True):
 class FileMetaDataset(Dataset):
     """Contains a collection (dictionary) of group 2 DICOM Data Elements.
 
-    ..versionadded:: 2.0
+    .. versionadded:: 2.0
 
     Derived from :class:`~pydicom.dataset.Dataset`, but only allows
     Group 2 (File Meta Information) data elements
@@ -2388,14 +2388,14 @@ class FileMetaDataset(Dataset):
         ------
         KeyError
             If a dict of data elements is supplied, and any are not group 2.
-        ValueError
+        TypeError
             If the passed argument is not a :class:`dict` or :class:`Dataset`
         """
 
         if args is not None and len(args) > 0:
             arg0 = args[0]
             if not isinstance(arg0, (Dataset, dict)):
-                raise ValueError(
+                raise TypeError(
                     "Argument must be a dict or Dataset, not {}".format(
                         type(arg0)
                     )

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1823,7 +1823,7 @@ class Dataset(dict):
         if value is not None:
             non_group2 = [
                 Tag(tag) for tag in value.keys()
-                if Tag(tag).group !=2
+                if Tag(tag).group != 2
             ]
             if non_group2:
                 raise KeyError(
@@ -1831,7 +1831,7 @@ class Dataset(dict):
                         non_group2
                     )
                 )
-        
+
         self.__dict__["file_meta"] = value
         if not isinstance(value, FileMetaDataset):
             warnings.warn(

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1833,7 +1833,7 @@ class Dataset(dict):
                 )
 
         self.__dict__["file_meta"] = value
-        if not isinstance(value, FileMetaDataset):
+        if value is not None and not isinstance(value, FileMetaDataset):
             warnings.warn(
                 "Starting in pydicom 3.0, Dataset.file_meta must be a "
                 "FileMetaDataset class instance",
@@ -2168,9 +2168,10 @@ class FileDataset(Dataset):
     preamble : str or bytes or None
         The optional DICOM preamble prepended to the :class:`FileDataset`, if
         available.
-    file_meta : Dataset or None
-        The Dataset's file meta information as a :class:`Dataset`, if available
-        (``None`` if not present). Consists of group ``0x0002`` elements.
+    file_meta : FileMetaDataset or None
+        The Dataset's file meta information as a :class:`FileMetaDataset`,
+        if available (``None`` if not present).
+        Consists of group ``0x0002`` elements.
     filename : str or None
         The filename that the :class:`FileDataset` was read from (if read from
         file) or ``None`` if the filename is not available (if read from a

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1736,7 +1736,7 @@ class Dataset(dict):
         """
         # Changed in v2.0 so does not re-assign self.file_meta with getattr()
         if not hasattr(self, "file_meta"):
-            self.file_meta = Dataset()
+            self.file_meta = FileMetaDataset()
 
     def fix_meta_info(self, enforce_standard=True):
         """Ensure the file meta info exists and has the correct values

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -15,7 +15,7 @@ from pydicom.config import logger
 from pydicom.datadict import dictionary_VR, tag_for_keyword
 from pydicom.dataelem import (DataElement, RawDataElement,
                               DataElement_from_raw, empty_value_for_VR)
-from pydicom.dataset import (Dataset, FileDataset)
+from pydicom.dataset import (Dataset, FileDataset, FileMetaDataset)
 from pydicom.dicomdir import DicomDir
 from pydicom.errors import InvalidDicomError
 from pydicom.filebase import DicomFile
@@ -516,8 +516,12 @@ def _read_file_meta_info(fp):
         return tag.group != 2
 
     start_file_meta = fp.tell()
-    file_meta = read_dataset(fp, is_implicit_VR=False, is_little_endian=True,
-                             stop_when=_not_group_0002)
+    file_meta = FileMetaDataset(
+                    read_dataset(
+                        fp, is_implicit_VR=False, is_little_endian=True,
+                        stop_when=_not_group_0002
+                    )
+    )
     if not file_meta._dict:
         return file_meta
 
@@ -528,9 +532,12 @@ def _read_file_meta_info(fp):
         file_meta[list(file_meta.elements())[0].tag]
     except NotImplementedError:
         fp.seek(start_file_meta)
-        file_meta = read_dataset(fp, is_implicit_VR=True,
-                                 is_little_endian=True,
-                                 stop_when=_not_group_0002)
+        file_meta = FileMetaDataset(
+                        read_dataset(
+                            fp, is_implicit_VR=True, is_little_endian=True,
+                            stop_when=_not_group_0002
+                        )
+        )
 
     # Log if the Group Length doesn't match actual length
     if 'FileMetaInformationGroupLength' in file_meta:

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1541,6 +1541,7 @@ class TestDatasetElements(object):
         assert '4.5.6' == self.ds.file_meta.MediaStorageSOPInstanceUID
         self.ds.fix_meta_info(enforce_standard=True)
 
+        self.ds.file_meta = Dataset()  # not FileMetaDataset
         self.ds.file_meta.PatientID = 'PatientID'
         with pytest.raises(ValueError,
                            match=r'Only File Meta Information Group '

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1782,18 +1782,29 @@ class TestFileMeta:
         with pytest.raises(TypeError):
             FileMetaDataset(["1", "2"])
 
-        # Raises KeyError if init with non-group-2
+        # Raises error if init with non-group-2
         ds_meta.PatientName = "x"
         with pytest.raises(ValueError):
             FileMetaDataset(ds_meta)
+
+        # None can be passed, to match Dataset behavior
+        FileMetaDataset(None)
 
     def test_set_file_meta(self):
         """Check adding items to existing FileMetaDataset"""
         file_meta = FileMetaDataset()
 
-        # Raising KeyError for non-group2 already covered
-        # Here check assigning via non-Tag
+        # Raise error if set non-group 2
+        with pytest.raises(ValueError):
+            file_meta.PatientID = "1"
+
+        # Check assigning via non-Tag
         file_meta[0x20010] = DataElement(0x20010, "UI", "2.3")
+
+        # Check RawDataElement
+        file_meta[0x20010] = RawDataElement(
+            0x20010, "UI", 4, "1.23", 0, True, True
+        )
 
     def test_del_file_meta(self):
         """Can delete the file_meta attribute"""

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -40,10 +40,10 @@ class TestDataset(object):
         # This comes from bug fix for issue 42
         # First, fake enough to try the pixel_array property
         ds = Dataset()
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.PixelData = 'xyzlmnop'
         msg_from_gdcm = r"'Dataset' object has no attribute 'filename'"
-        msg_from_numpy = (r"'Dataset' object has no attribute "
+        msg_from_numpy = (r"'FileMetaDataset' object has no attribute "
                           "'TransferSyntaxUID'")
         msg_from_pillow = (r"'Dataset' object has no attribute "
                            "'PixelRepresentation'")
@@ -1170,7 +1170,7 @@ class TestDataset(object):
             ds.save_as(fp, write_like_original=False)
 
         ds.is_implicit_VR = True
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.MediaStorageSOPClassUID = '1.1'
         ds.file_meta.MediaStorageSOPInstanceUID = '1.2'
         ds.file_meta.TransferSyntaxUID = '1.3'
@@ -1183,7 +1183,7 @@ class TestDataset(object):
         ds = Dataset()
         ds.is_little_endian = True
         ds.is_implicit_VR = False
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = JPEGBaseline
         ds.PixelData = b'\x00\x01\x02\x03\x04\x05\x06'
         ds['PixelData'].VR = 'OB'
@@ -1200,7 +1200,7 @@ class TestDataset(object):
         ds = Dataset()
         ds.is_little_endian = True
         ds.is_implicit_VR = False
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = JPEGBaseline
         ds.PixelData = encapsulate([b'\x00\x01\x02\x03\x04\x05\x06'])
         ds['PixelData'].VR = 'OB'
@@ -1212,7 +1212,7 @@ class TestDataset(object):
         ds = Dataset()
         ds.is_little_endian = True
         ds.is_implicit_VR = False
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = JPEGBaseline
         ds.save_as(fp)
 
@@ -1222,7 +1222,7 @@ class TestDataset(object):
         ds = Dataset()
         ds.is_little_endian = True
         ds.is_implicit_VR = False
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.save_as(fp)
 
         del ds.file_meta
@@ -1234,7 +1234,7 @@ class TestDataset(object):
         ds = Dataset()
         ds.is_little_endian = True
         ds.is_implicit_VR = False
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = '1.2.3.4.5.6'
         ds.save_as(fp)
 
@@ -1252,7 +1252,7 @@ class TestDataset(object):
             ds.save_as(fp)
 
         # Test private transfer syntax raises
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = '1.2'
         with pytest.raises(AttributeError, match=msg):
             ds.save_as(fp)
@@ -1267,7 +1267,7 @@ class TestDataset(object):
         ds = Dataset()
         ds.is_little_endian = True
         ds.is_implicit_VR = False
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = JPEGBaseline
         ds.PixelData = encapsulate([b'\x00\x01\x02\x03\x04\x05\x06'])
         elem = ds['PixelData']
@@ -1296,7 +1296,7 @@ class TestDataset(object):
         ds = Dataset()
         ds.is_little_endian = True
         ds.is_implicit_VR = False
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = '1.2.3.4.5'
         ds.PixelData = encapsulate([b'\x00\x01\x02\x03\x04\x05\x06'])
         elem = ds['PixelData']
@@ -1549,11 +1549,12 @@ class TestDatasetElements(object):
             self.ds.fix_meta_info(enforce_standard=True)
 
     def test_validate_and_correct_file_meta(self):
-        file_meta = Dataset()
+        file_meta = FileMetaDataset()
         validate_file_meta(file_meta, enforce_standard=False)
         with pytest.raises(ValueError):
             validate_file_meta(file_meta, enforce_standard=True)
 
+        file_meta = Dataset() # not FileMetaDataset for bkwds-compat checks
         file_meta.PatientID = 'PatientID'
         for enforce_standard in (True, False):
             with pytest.raises(
@@ -1563,7 +1564,7 @@ class TestDatasetElements(object):
                 validate_file_meta(
                     file_meta, enforce_standard=enforce_standard)
 
-        file_meta = Dataset()
+        file_meta = FileMetaDataset()
         file_meta.MediaStorageSOPClassUID = '1.2.3'
         file_meta.MediaStorageSOPInstanceUID = '1.2.4'
         # still missing TransferSyntaxUID
@@ -1738,7 +1739,7 @@ class TestFileMeta:
         """Assigning ds.file_meta warns if not FileMetaDataset instance"""
         ds = Dataset()
         with pytest.warns(DeprecationWarning):
-            ds.file_meta = Dataset()
+            ds.file_meta = Dataset()  # not FileMetaDataset
 
     def test_assign_file_meta(self):
         """Test can only set group 2 elements in File Meta"""
@@ -1749,7 +1750,7 @@ class TestFileMeta:
         
         # No error if assign file meta with no group 2:
         ds = Dataset()
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         
         ds_meta = Dataset()
         ds_meta.TransferSyntaxUID = "1.2"

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1541,7 +1541,8 @@ class TestDatasetElements(object):
         assert '4.5.6' == self.ds.file_meta.MediaStorageSOPInstanceUID
         self.ds.fix_meta_info(enforce_standard=True)
 
-        self.ds.file_meta = Dataset()  # not FileMetaDataset
+        with pytest.warns(DeprecationWarning):
+            self.ds.file_meta = Dataset()  # not FileMetaDataset
         self.ds.file_meta.PatientID = 'PatientID'
         with pytest.raises(ValueError,
                            match=r'Only File Meta Information Group '
@@ -1748,13 +1749,15 @@ class TestFileMeta:
         with pytest.raises(KeyError):
             file_meta.PatientID = "123"
 
-        # No error if assign file meta with no group 2:
+        # No error if assign empty file meta
         ds = Dataset()
         ds.file_meta = FileMetaDataset()
 
-        ds_meta = Dataset()
+        # Can assign non-empty file_meta
+        ds_meta = Dataset()  # not FileMetaDataset
         ds_meta.TransferSyntaxUID = "1.2"
-        ds.file_meta = ds_meta
+        with pytest.warns(DeprecationWarning):
+            ds.file_meta = ds_meta
 
         # Error on assigning file meta if any non-group 2
         ds_meta.PatientName = "x"
@@ -1791,3 +1794,10 @@ class TestFileMeta:
         # Raising KeyError for non-group2 already covered
         # Here check assigning via non-Tag
         file_meta[0x20010] = DataElement(0x20010, "UI", "2.3")
+
+    def test_del_file_meta(self):
+        """Can delete the file_meta attribute"""
+        ds = Dataset()
+        ds.file_meta = FileMetaDataset()
+        del ds.file_meta
+        assert not hasattr(ds, "file_meta")

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1779,7 +1779,7 @@ class TestFileMeta:
         assert "2.3" == file_meta.TransferSyntaxUID
 
         # Fails if not dict or Dataset
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             FileMetaDataset(["1", "2"])
 
         # Raises KeyError if init with non-group-2

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1554,7 +1554,7 @@ class TestDatasetElements(object):
         with pytest.raises(ValueError):
             validate_file_meta(file_meta, enforce_standard=True)
 
-        file_meta = Dataset() # not FileMetaDataset for bkwds-compat checks
+        file_meta = Dataset()  # not FileMetaDataset for bkwds-compat checks
         file_meta.PatientID = 'PatientID'
         for enforce_standard in (True, False):
             with pytest.raises(
@@ -1747,18 +1747,16 @@ class TestFileMeta:
         file_meta = FileMetaDataset()
         with pytest.raises(KeyError):
             file_meta.PatientID = "123"
-        
+
         # No error if assign file meta with no group 2:
         ds = Dataset()
         ds.file_meta = FileMetaDataset()
-        
+
         ds_meta = Dataset()
         ds_meta.TransferSyntaxUID = "1.2"
         ds.file_meta = ds_meta
-        
+
         # Error on assigning file meta if any non-group 2
         ds_meta.PatientName = "x"
         with pytest.raises(KeyError):
             ds.file_meta = ds_meta
-
-        

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1746,7 +1746,7 @@ class TestFileMeta:
         """Test can only set group 2 elements in File Meta"""
         # FileMetaDataset accepts only group 2
         file_meta = FileMetaDataset()
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             file_meta.PatientID = "123"
 
         # No error if assign empty file meta
@@ -1761,7 +1761,7 @@ class TestFileMeta:
 
         # Error on assigning file meta if any non-group 2
         ds_meta.PatientName = "x"
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             ds.file_meta = ds_meta
 
     def test_init_file_meta(self):
@@ -1784,7 +1784,7 @@ class TestFileMeta:
 
         # Raises KeyError if init with non-group-2
         ds_meta.PatientName = "x"
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             FileMetaDataset(ds_meta)
 
     def test_set_file_meta(self):

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1760,3 +1760,34 @@ class TestFileMeta:
         ds_meta.PatientName = "x"
         with pytest.raises(KeyError):
             ds.file_meta = ds_meta
+
+    def test_init_file_meta(self):
+        """Check instantiation of FileMetaDataset"""
+        ds_meta = Dataset()
+        ds_meta.TransferSyntaxUID = "1.2"
+
+        # Accepts with group 2
+        file_meta = FileMetaDataset(ds_meta)
+        assert "1.2" == file_meta.TransferSyntaxUID
+
+        # Accepts dict
+        dict_meta = {0x20010: DataElement(0x20010, "UI", "2.3")}
+        file_meta = FileMetaDataset(dict_meta)
+        assert "2.3" == file_meta.TransferSyntaxUID
+
+        # Fails if not dict or Dataset
+        with pytest.raises(ValueError):
+            FileMetaDataset(["1", "2"])
+
+        # Raises KeyError if init with non-group-2
+        ds_meta.PatientName = "x"
+        with pytest.raises(KeyError):
+            FileMetaDataset(ds_meta)
+
+    def test_set_file_meta(self):
+        """Check adding items to existing FileMetaDataset"""
+        file_meta = FileMetaDataset()
+
+        # Raising KeyError for non-group2 already covered
+        # Here check assigning via non-Tag
+        file_meta[0x20010] = DataElement(0x20010, "UI", "2.3")

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1801,3 +1801,25 @@ class TestFileMeta:
         ds.file_meta = FileMetaDataset()
         del ds.file_meta
         assert not hasattr(ds, "file_meta")
+
+    def test_show_file_meta(self):
+        orig_show = pydicom.config.show_file_meta
+        pydicom.config.show_file_meta = True
+
+        ds = Dataset()
+        ds.file_meta = FileMetaDataset()
+        ds.file_meta.TransferSyntaxUID = "1.2"
+        ds.PatientName = "test"
+        shown = str(ds)
+
+        assert shown.startswith("Dataset.file_meta ---")
+        assert shown.splitlines()[1].startswith(
+            "(0002, 0010) Transfer Syntax UID"
+        )
+
+        # Turn off file_meta display
+        pydicom.config.show_file_meta = False
+        shown = str(ds)
+        assert shown.startswith("(0010, 0010) Patient's Name")
+
+        pydicom.config.show_file_meta = orig_show

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -16,7 +16,7 @@ import pytest
 
 import pydicom.config
 from pydicom import config
-from pydicom.dataset import Dataset, FileDataset
+from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
 from pydicom.data import get_testdata_file
 from pydicom.datadict import add_dict_entries
 from pydicom.filereader import dcmread, read_dataset
@@ -854,7 +854,7 @@ class TestIncorrectVR(object):
         # followed by a sequence with an item (dataset) having
         # a data element length that looks like a potential valid VR
         ds = Dataset()
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.MediaStorageSOPClassUID = "1.1.1"
         ds.file_meta.MediaStorageSOPInstanceUID = "2.2.2"
         ds.is_implicit_VR = True

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -18,7 +18,7 @@ import pytest
 from pydicom._storage_sopclass_uids import CTImageStorage
 from pydicom import config, __version_info__, uid
 from pydicom.data import get_testdata_file, get_charset_files
-from pydicom.dataset import Dataset, FileDataset
+from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
 from pydicom.dataelem import DataElement, RawDataElement
 from pydicom.filebase import DicomBytesIO
 from pydicom.filereader import dcmread, read_dataset, read_file
@@ -208,7 +208,7 @@ class TestWriteFile(object):
         """Test writing element (FFFF, FFFF) to file #92"""
         fp = DicomBytesIO()
         ds = Dataset()
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.is_little_endian = True
         ds.is_implicit_VR = True
         ds.add_new(0xFFFFFFFF, 'LO', '123456')
@@ -1548,7 +1548,7 @@ class TestWriteToStandard(object):
         version = 'PYDICOM ' + base_version
         ds = dcmread(rtplan_name)
         transfer_syntax = ds.file_meta.TransferSyntaxUID
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.save_as(fp, write_like_original=False)
         fp.seek(0)
         out = dcmread(fp)
@@ -1575,7 +1575,7 @@ class TestWriteToStandard(object):
         """Test exception is raised if trying to write with no file_meta."""
         ds = dcmread(rtplan_name)
         del ds.SOPInstanceUID
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         with pytest.raises(ValueError):
             ds.save_as(DicomBytesIO(), write_like_original=False)
         del ds.file_meta
@@ -1852,7 +1852,7 @@ class TestWriteNonStandard(object):
     def test_file_meta_unchanged(self):
         """Test no file_meta elements are added if missing."""
         ds = dcmread(rtplan_name)
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.save_as(self.fp, write_like_original=True)
         assert Dataset() == ds.file_meta
 

--- a/pydicom/tests/test_handler_util.py
+++ b/pydicom/tests/test_handler_util.py
@@ -15,7 +15,7 @@ except ImportError:
 
 from pydicom import dcmread
 from pydicom.data import get_testdata_files, get_palette_files
-from pydicom.dataset import Dataset
+from pydicom.dataset import Dataset, FileMetaDataset
 from pydicom.pixel_data_handlers.util import (
     dtype_corrected_for_endianness,
     reshape_pixel_array,
@@ -93,7 +93,7 @@ class TestNumpy_PixelDtype(object):
     def setup(self):
         """Setup the test dataset."""
         self.ds = Dataset()
-        self.ds.file_meta = Dataset()
+        self.ds.file_meta = FileMetaDataset()
         self.ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
 
     def test_unknown_pixel_representation_raises(self):
@@ -280,7 +280,7 @@ class TestNumpy_ReshapePixelArray(object):
     def setup(self):
         """Setup the test dataset."""
         self.ds = Dataset()
-        self.ds.file_meta = Dataset()
+        self.ds.file_meta = FileMetaDataset()
         self.ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
         self.ds.Rows = 4
         self.ds.Columns = 5
@@ -889,7 +889,6 @@ class TestNumpy_ModalityLUT(object):
         assert 58974 == out[291, 385]
 
 
-
 @pytest.mark.skipif(not HAVE_NP, reason="Numpy is not available")
 class TestNumpy_PaletteColor(object):
     """Tests for util.apply_color_lut()."""
@@ -991,7 +990,7 @@ class TestNumpy_PaletteColor(object):
     def test_uint08_16(self):
         """Test uint8 Pixel Data with 16-bit LUT entries."""
         ds = dcmread(PAL_08_200_0_16_1F, force=True)
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         assert 8 == ds.BitsStored
         assert 16 == ds.RedPaletteColorLookupTableDescriptor[2]
@@ -1084,7 +1083,7 @@ class TestNumpy_PaletteColor(object):
     def test_16_allocated_8_entries(self):
         """Test LUT with 8-bit entries in 16 bits allocated."""
         ds = dcmread(PAL_08_200_0_16_1F, force=True)
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         ds.RedPaletteColorLookupTableDescriptor = [200, 0, 8]
         lut = pack('<200H', *list(range(0, 200)))
@@ -1148,7 +1147,7 @@ class TestNumpy_PaletteColor(object):
     def test_first_map_positive(self):
         """Test a positive first mapping value."""
         ds = dcmread(PAL_08_200_0_16_1F, force=True)
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         ds.RedPaletteColorLookupTableDescriptor[1] = 10
         arr = ds.pixel_array
@@ -1166,7 +1165,7 @@ class TestNumpy_PaletteColor(object):
     def test_first_map_negative(self):
         """Test a positive first mapping value."""
         ds = dcmread(PAL_08_200_0_16_1F, force=True)
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         ds.RedPaletteColorLookupTableDescriptor[1] = -10
         arr = ds.pixel_array

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -33,7 +33,7 @@ import pytest
 import pydicom
 from pydicom import config
 from pydicom.data import get_testdata_files
-from pydicom.dataset import Dataset
+from pydicom.dataset import Dataset, FileMetaDataset
 from pydicom.filereader import dcmread
 
 from pydicom.tests._handler_common import ALL_TRANSFER_SYNTAXES
@@ -1068,7 +1068,7 @@ class TestNumpy_NumpyHandler(object):
     def test_endianness_not_set(self):
         """Test for #704, Dataset.is_little_endian unset."""
         ds = Dataset()
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
         ds.Rows = 10
         ds.Columns = 10

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -30,6 +30,7 @@ import pytest
 from pydicom import dcmread, Dataset, config
 import pydicom.config
 from pydicom.data import get_testdata_files
+from pydicom.dataset import FileMetaDataset
 from pydicom.encaps import defragment_data
 from pydicom.uid import RLELossless, UID
 from pydicom.tests._handler_common import ALL_TRANSFER_SYNTAXES
@@ -1210,7 +1211,7 @@ class TestNumpy_RLEEncodeFrame(object):
         """Setup the tests."""
         # Create a dataset skeleton for use in the cycle tests
         ds = Dataset()
-        ds.file_meta = Dataset()
+        ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = '1.2.840.10008.1.2'
         ds.Rows = 2
         ds.Columns = 4

--- a/pydicom/tests/test_util.py
+++ b/pydicom/tests/test_util.py
@@ -60,7 +60,7 @@ class TestCodify(object):
     def test_code_imports(self):
         """Test utils.codify.code_imports"""
         out = 'import pydicom\n'
-        out += 'from pydicom.dataset import Dataset\n'
+        out += 'from pydicom.dataset import Dataset, FileMetaDataset\n'
         out += 'from pydicom.sequence import Sequence'
         assert out == code_imports()
 

--- a/pydicom/util/codify.py
+++ b/pydicom/util/codify.py
@@ -71,7 +71,7 @@ def code_imports():
 
     """
     line1 = "import pydicom"
-    line2 = "from pydicom.dataset import Dataset"
+    line2 = "from pydicom.dataset import Dataset, FileMetaDataset"
     line3 = "from pydicom.sequence import Sequence"
     return line_term.join((line1, line2, line3))
 
@@ -199,7 +199,8 @@ def code_sequence(dataelem,
 def code_dataset(ds,
                  dataset_name="ds",
                  exclude_size=None,
-                 include_private=False):
+                 include_private=False,
+                 is_file_meta=False):
     """Return python code lines for import statements needed by other code
 
     :arg exclude_size: if specified, values longer than this (in bytes)
@@ -212,7 +213,8 @@ def code_dataset(ds,
 
     """
     lines = []
-    lines.append(dataset_name + " = Dataset()")
+    ds_class = " = FileMetaDataset()" if is_file_meta else " = Dataset()"
+    lines.append(dataset_name + ds_class)
     for dataelem in ds:
         # If a private data element and flag says so, skip it and go to next
         if not include_private and dataelem.tag.is_private:
@@ -259,7 +261,7 @@ def code_file(filename, exclude_size=None, include_private=False):
     # Code the file_meta information
     lines.append("# File meta info data elements")
     code_meta = code_dataset(ds.file_meta, "file_meta", exclude_size,
-                             include_private)
+                             include_private, is_file_meta=True)
     lines.append(code_meta)
     lines.append('')
 


### PR DESCRIPTION
We'd discussed in #881 about moving toward complete integration of file_meta into `Dataset`.  Another alternative is to mimic that by having a file_meta which is internally separate, but appears to be integrated. 

I had worked on this in #885, but was hitting some walls - it gets very tricky very quickly.  In this PR, I'm proposing a step in the right direction, that should make it easier to move forward later. There are some small behavior changes, so ideally this step should be taken for v2.0 release.

One problem in all this is that there is a lot of existing code such as:
```python
file_meta = Dataset()
ds.file_meta = file_meta
file_meta.TransferSyntaxUID = "1.2.3"
```
Note that the object _reference_ is assigned, but the file_meta data elements are added after that assignment. So the file meta is an independent python object, and setting new items does not trigger any code in the parent `Dataset`.  So we could, for example, on setting `Dataset.file_meta`, check that all elements are group 2, but wouldn't be controlling elements after that. Note also that `file_meta` could be bound to a different `Dataset` at any point.

So, I am here proposing to take one step: file_meta is to be set with a new class, subset of `Dataset`, called `FileMetaDataset`.  For now, it only checks that data elements are group 2 when set.  Later, it could be connected to the parent dataset and exchange information with it.  This is a lot easier to manage in a distinct class rather than adding code to `Dataset` itself.

`Dataset` is altered so that setting `file_meta` goes through a class method. It warns with DeprecationWarning (required in pydicom 3.0) when setting `ds.file_meta` to anything but a `FileMetaDataset`.

Eventually, I believe `FileMetaDataset` can become a kind of *view* onto the Dataset, and if people have already changed code to use `FileMetaDataset`, this can be managed transparently with few breaking changes.

The other new thing I plan to do in this PR is to show file_meta in the dataset `repr`, but clearly labeled as separate.  That might help increase awareness of the separation of file_meta.

Hopefully these changes can help avoid some of the dataset/file_meta confusion noted in #881, and also allow us a smoother path to the ultimate integration.