### PR TITLE
Update version for v2.0.0-rc.1

### DIFF
--- a/pydicom/_version.py
+++ b/pydicom/_version.py
@@ -2,6 +2,6 @@
 import re
 
 
-__version__ = '2.0.0.dev0'
+__version__ = '2.0.0-rc.1'
 __version_info__ = tuple(
     re.match(r'(\d+\.\d+\.\d+).*', __version__).group(1).split('.'))


### PR DESCRIPTION
Slightly different naming than previously used for release candidate - trying to follow semver.org.  However, can go back to the previous style "2.0.0rc1" if there is some reason to - I just thought semver.org provides a clear grammar that's easy to point to.