### PR TITLE
[MRG] Remove Python 3.5 codes; warn on compat module

### DIFF
--- a/doc/release_notes/v2.1.0.rst
+++ b/doc/release_notes/v2.1.0.rst
@@ -3,6 +3,7 @@ Version 2.1.0
 
 Changes
 -------
+* Dropped support for Python 3.5 (only Python 3.6+ supported)
 
 Enhancements
 ------------

--- a/pydicom/compat.py
+++ b/pydicom/compat.py
@@ -1,6 +1,14 @@
-# Copyright 2008-2018 pydicom authors. See LICENSE file for details.
+# Copyright 2008-2020 pydicom authors. See LICENSE file for details.
 """Compatibility functions for previous Python 2 support"""
 
+# Python 2 only - warn and mark this as deprecated.
+import warnings
+
+warnings.warn(
+    "Starting in pydicom 3.0, the compat module (used for Python 2)"
+    " will be removed",
+    DeprecationWarning
+)
 
 # Text types
 text_type = str

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -605,8 +605,7 @@ class Dataset(dict):
         List of attributes is used, for example, in auto-completion in editors
         or command-line environments.
         """
-        # Force zip object into a list in case of python3. Also backwards
-        # compatible
+        # Force zip object into a list
         meths = set(list(zip(
             *inspect.getmembers(self.__class__, inspect.isroutine)))[0])
         props = set(list(zip(

--- a/pydicom/fileutil.py
+++ b/pydicom/fileutil.py
@@ -277,11 +277,6 @@ def path_from_pathlike(file_object):
     str or file-like
         the string representation of the given path object, or the object
         itself in case of an object not representing a path.
-
-    ..note:
-
-        ``PathLike`` objects have been introduced in Python 3.6. In Python 3.5,
-        only objects of type :class:`pathlib.Path` are considered.
     """
     try:
         return os.fspath(file_object)

--- a/pydicom/sr/codedict.py
+++ b/pydicom/sr/codedict.py
@@ -42,8 +42,7 @@ class _CID_Dict:
         List of attributes is used, for example, in auto-completion in editors
         or command-line environments.
         """
-        # Force zip object into a list in case of python3. Also backwards
-        # compatible
+        # Force zip object into a list
         meths = set(
             list(zip(*inspect.getmembers(self.__class__, inspect.isroutine)))[
                 0
@@ -183,8 +182,7 @@ class _CodesDict:
         List of attributes is used, for example, in auto-completion in editors
         or command-line environments.
         """
-        # Force zip object into a list in case of python3. Also backwards
-        # compatible
+        # Force zip object into a list
         meths = set(
             list(zip(*inspect.getmembers(self.__class__, inspect.isroutine)))[
                 0

--- a/pydicom/tests/test_fileutil.py
+++ b/pydicom/tests/test_fileutil.py
@@ -31,7 +31,5 @@ class TestPathFromPathLike:
     def test_pathlib_path(self):
         assert 'test.dcm' == path_from_pathlike(Path('test.dcm'))
 
-    @pytest.mark.skipif(sys.version_info < (3, 6),
-                        reason="Path-like objects introduced in Python 3.6")
     def test_path_like(self):
         assert 'test.dcm' == path_from_pathlike(PathLike('test.dcm'))


### PR DESCRIPTION
* clean up some other Python 2 related code

#### Tasks
- ~~[ ] Unit tests added that reproduce the issue or prove feature is working~~
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [x] Preview link: [Release Notes 2.1](https://2064-14006067-gh.circle-artifacts.com/0/doc/_build/html/release_notes/v2.1.0.html)
- [x] Unit tests passing and overall coverage the same or better
