### PR TITLE
Update zenodo DOI for v2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![codecov](https://codecov.io/gh/pydicom/pydicom/branch/master/graph/badge.svg)](https://codecov.io/gh/pydicom/pydicom)
 [![Python version](https://img.shields.io/pypi/pyversions/pydicom.svg)](https://img.shields.io/pypi/pyversions/pydicom.svg)
 [![PyPI version](https://badge.fury.io/py/pydicom.svg)](https://badge.fury.io/py/pydicom)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3614067.svg)](https://doi.org/10.5281/zenodo.3614067)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3891702.svg)](https://doi.org/10.5281/zenodo.3891702)
 [![Gitter](https://badges.gitter.im/pydicom/Lobby.svg)](https://gitter.im/pydicom/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 *pydicom* is a pure python package for working with [DICOM](http://medical.nema.org/) files.


### PR DESCRIPTION
Zenodo did not trigger on creation of github release of pydicom 2.0 as expected.  With help from zenodo support, got it built and a DOI assigned.