### PR TITLE
[MRG] Check is_little_endian and is_implicit_VR in write_dataset()

### DIFF
--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -38,7 +38,7 @@ def _correct_ambiguous_vr_element(elem, ds, is_little_endian):
         #   If encapsulated, VR is OB and length is undefined
         if elem.is_undefined_length:
             elem.VR = 'OB'
-        elif ds.is_implicit_VR :
+        elif ds.is_implicit_VR:
             # Non-compressed Pixel Data - Implicit Little Endian
             # PS3.5 Annex A1: VR is always OW
             elem.VR = 'OW'
@@ -986,7 +986,7 @@ def dcmwrite(filename, dataset, write_like_original=True):
     # Check for decompression, give warnings if inconsistencies
     # If decompressed, then pixel_array is now used instead of PixelData
     if dataset.is_decompressed:
-        if dataset.file_meta.TransferSyntaxUID.is_compressed is True:
+        if dataset.file_meta.TransferSyntaxUID.is_compressed:
             raise ValueError(
                 f"The Transfer Syntax UID element in "
                 f"'{dataset.__class__.__name__}.file_meta' is compressed "

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1246,7 +1246,7 @@ class TestDataset:
         # Raise if is_implicit_VR or is_little_endian missing with no tsyntax
         msg = (
             r"'Dataset.is_little_endian' and 'Dataset.is_implicit_VR' must be "
-            r"set appropriately before saving."
+            r"set appropriately before saving"
         )
         with pytest.raises(AttributeError, match=msg):
             ds.save_as(fp)

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -271,6 +271,17 @@ class TestWriteFile:
 
         assert unzipped_rewritten == unzipped_original
 
+    def test_write_dataset_without_encoding(self):
+        """Test that write_dataset() raises if encoding not set."""
+        ds = Dataset()
+        bs = BytesIO()
+        msg = (
+            r"'Dataset.is_little_endian' and 'Dataset.is_implicit_VR' must "
+            r"be set appropriately before saving"
+        )
+        with pytest.raises(AttributeError, match=msg):
+            write_dataset(bs, ds)
+
 
 class TestScratchWriteDateTime(TestWriteFile):
     """Write and reread simple or multi-value DA/DT/TM data elements"""

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -2663,10 +2663,10 @@ class TestWriteUndefinedLengthPixelData:
         self.fp.is_little_endian = True
         self.fp.is_implicit_VR = False
 
-        msg = (r'The value for the data element \(3004, 0058\) exceeds the '
-               r'size of 64 kByte and cannot be written in an explicit '
-               r'transfer syntax. The data element VR is changed from '
-               r'"DS" to "UN" to allow saving the data.')
+        msg = (r"The value for the data element \(3004, 0058\) exceeds the "
+               r"size of 64 kByte and cannot be written in an explicit "
+               r"transfer syntax. The data element VR is changed from "
+               r"'DS' to 'UN' to allow saving the data.")
 
         with pytest.warns(UserWarning, match=msg):
             write_data_element(self.fp, pixel_data)

--- a/pydicom/tests/test_handler_util.py
+++ b/pydicom/tests/test_handler_util.py
@@ -944,9 +944,7 @@ class TestNumpy_PaletteColor:
         """Test that an invalid bit depth raises an exception."""
         ds = dcmread(PAL_08_256_0_16_1F)
         ds.RedPaletteColorLookupTableDescriptor[2] = 15
-        msg = (
-            r'data type "uint15" not understood'
-        )
+        msg = r"data type ['\"]uint15['\"] not understood"
         with pytest.raises(TypeError, match=msg):
             apply_color_lut(ds.pixel_array, ds)
 


### PR DESCRIPTION
#### Describe the changes
* Add test of encoding attributes when `write_dataset()` is called (related to #1062)
* Switch to f-strings
* Bit of a style cleanup

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
