### PR TITLE
[WIP] feat: add convenience constants for MPEG transfer syntaxes

### DIFF
--- a/pydicom/uid.py
+++ b/pydicom/uid.py
@@ -229,6 +229,24 @@ JPEG2000MultiComponentLossless = UID('1.2.840.10008.1.2.4.92')
 """1.2.840.10008.1.2.4.92"""
 JPEG2000MultiComponent = UID('1.2.840.10008.1.2.4.93')
 """1.2.840.10008.1.2.4.93"""
+MPEG2MainProfileMainLevel = UID('1.2.840.10008.1.2.4.100')
+"""1.2.840.10008.1.2.4.100"""
+MPEG2MainProfileHighLevel = UID('1.2.840.10008.1.2.4.101')
+"""1.2.840.10008.1.2.4.101"""
+MPEG4HighProfileLevel41 = UID('1.2.840.10008.1.2.4.102')
+"""1.2.840.10008.1.2.4.102"""
+MPEG4BDCompatibleHighProfileLevel41 = UID('1.2.840.10008.1.2.4.103')
+"""1.2.840.10008.1.2.4.103"""
+MPEG4HighProfileLevel422D = UID('1.2.840.10008.1.2.4.104')
+"""1.2.840.10008.1.2.4.104"""
+MPEG4HighProfileLevel423D = UID('1.2.840.10008.1.2.4.105')
+"""1.2.840.10008.1.2.4.105"""
+MPEG4StereoHighProfileLevel42 = UID('1.2.840.10008.1.2.4.106')
+"""1.2.840.10008.1.2.4.106"""
+HEVCMainProfileLevel51 = UID('1.2.840.10008.1.2.4.107')
+"""1.2.840.10008.1.2.4.107"""
+HEVCMain10ProfileLevel51 = UID('1.2.840.10008.1.2.4.108')
+"""1.2.840.10008.1.2.4.108"""
 RLELossless = UID('1.2.840.10008.1.2.5')
 """1.2.840.10008.1.2.5"""
 
@@ -260,6 +278,18 @@ JPEG2000CompressedPixelTransferSyntaxes = [
 JPEGLossyCompressedPixelTransferSyntaxes = [
     JPEGBaseline,
     JPEGExtended,
+]
+
+MPEGTransferSyntaxes = [
+    MPEG2MainProfileMainLevel,
+    MPEG2MainProfileHighLevel,
+    MPEG4HighProfileLevel41,
+    MPEG4BDCompatibleHighProfileLevel41,
+    MPEG4HighProfileLevel422D,
+    MPEG4HighProfileLevel423D,
+    MPEG4StereoHighProfileLevel42,
+    HEVCMainProfileLevel51,
+    HEVCMain10ProfileLevel51,
 ]
 
 RLECompressedLosslessSyntaxes = [


### PR DESCRIPTION
#### Describe the changes

Add convenience constants for referencing MPEG family UIDs in code.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
