### PR TITLE
[MRG] Change default handling for reading unknown tags

### DIFF
--- a/doc/release_notes/v2.1.0.rst
+++ b/doc/release_notes/v2.1.0.rst
@@ -25,6 +25,11 @@ Enhancements
   object that yields an :class:`~numpy.ndarray` for each multiplex group in
   a *Waveform Sequence*.
 
+Changes
+.......
+* Reading and adding unknown non-private tags now does not raise an exception
+  per default, only when `config.enforce_valid_values` is set (:issue:`1161`)
+
 Fixes
 .....
 * ``Dataset.copy`` now works as expected (see :issue:`1146`)

--- a/pydicom/tests/conftest.py
+++ b/pydicom/tests/conftest.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2008-2020 pydicom authors. See LICENSE file for details.
+"""Fixtures used in different tests."""
+
+import pytest
+
+from pydicom import config
+
+
+@pytest.fixture
+def enforce_valid_values():
+    value = config.enforce_valid_values
+    config.enforce_valid_values = True
+    yield
+    config.enforce_valid_values = value
+
+
+@pytest.fixture
+def allow_invalid_values():
+    value = config.enforce_valid_values
+    config.enforce_valid_values = False
+    yield
+    config.enforce_valid_values = value

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -140,7 +140,7 @@ class TestCharset:
         pydicom.charset.decode_element(elem, [])
         assert 'iso8859' in elem.value.encodings
 
-    def test_bad_encoded_single_encoding(self):
+    def test_bad_encoded_single_encoding(self, allow_invalid_values):
         """Test handling bad encoding for single encoding"""
         elem = DataElement(0x00100010, 'PN',
                            b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')
@@ -230,7 +230,7 @@ class TestCharset:
                                              'in encoded string value'):
             pydicom.charset.decode_element(elem, ['ISO_IR 100'])
 
-    def test_patched_charset(self):
+    def test_patched_charset(self, allow_invalid_values):
         """Test some commonly misspelled charset values"""
         elem = DataElement(0x00100010, 'PN', b'Buc^J\xc3\xa9r\xc3\xb4me')
         pydicom.charset.decode_element(elem, ['ISO_IR 192'])
@@ -409,7 +409,7 @@ class TestCharset:
         # we expect UTF-8 encoding here
         assert b'Buc^J\xc3\xa9r\xc3\xb4me' == ds_out.get_item(0x00100010).value
 
-    def test_invalid_second_encoding(self):
+    def test_invalid_second_encoding(self, allow_invalid_values):
         # regression test for #850
         elem = DataElement(0x00100010, 'PN', 'CITIZEN')
         with pytest.warns(UserWarning,

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -512,13 +512,23 @@ class TestDataElement:
 
 
 class TestRawDataElement:
+
     """Tests for dataelem.RawDataElement."""
-    def test_key_error(self):
+    def test_invalid_tag_warning(self, allow_invalid_values):
+        """RawDataElement: conversion of unknown tag warns..."""
+        raw = RawDataElement(Tag(0x88880088), None, 4, b'unknown',
+                             0, True, True)
+
+        with pytest.warns(UserWarning, match=r"\(8888, 0088\)"):
+            element = DataElement_from_raw(raw)
+            assert element.VR == 'UN'
+
+    def test_key_error(self, enforce_valid_values):
         """RawDataElement: conversion of unknown tag throws KeyError..."""
         # raw data element -> tag VR length value
         #                       value_tell is_implicit_VR is_little_endian'
         # Unknown (not in DICOM dict), non-private, non-group 0 for this test
-        raw = RawDataElement(Tag(0x88880002), None, 4, 0x1111,
+        raw = RawDataElement(Tag(0x88880002), None, 4, b'unknown',
                              0, True, True)
 
         with pytest.raises(KeyError, match=r"\(8888, 0002\)"):

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -261,7 +261,7 @@ class TestDataset:
         with pytest.raises(KeyError, match=r"\(8888, 0004\)"):
             elem = self.ds.setdefault((0x8888, 0x0004), 'foo')
 
-    def test_setdefault_use_value(self):
+    def test_setdefault_use_value(self, allow_invalid_values):
         elem = self.ds.setdefault((0x0010, 0x0010), "Test")
         assert 'Test' == elem.value
         assert 2 == len(self.ds)

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -32,6 +32,7 @@ class BadRepr:
 
 class TestDataset:
     """Tests for dataset.Dataset."""
+
     def setup(self):
         self.ds = Dataset()
         self.ds.TreatmentMachineName = "unit001"
@@ -104,6 +105,7 @@ class TestDataset:
 
     def test_attribute_error_in_property_correct_debug(self):
         """Test AttributeError in property raises correctly."""
+
         class Foo(Dataset):
             @property
             def bar(self):
@@ -228,6 +230,17 @@ class TestDataset:
         assert 'Test' == elem.value
         assert 2 == len(self.ds)
 
+    def test_setdefault_unknown_tag(self, allow_invalid_values):
+        with pytest.warns(UserWarning, match=r"\(8888, 0002\)"):
+            elem = self.ds.setdefault(0x88880002, 'foo')
+        assert 'foo' == elem.value
+        assert 'UN' == elem.VR
+        assert 2 == len(self.ds)
+
+    def test_setdefault_unknown_tag_strict(self, enforce_valid_values):
+        with pytest.raises(KeyError, match=r"\(8888, 0004\)"):
+            elem = self.ds.setdefault(0x88880004, 'foo')
+
     def test_setdefault_tuple(self):
         elem = self.ds.setdefault((0x300a, 0x00b2), 'foo')
         assert 'unit001' == elem.value
@@ -237,12 +250,22 @@ class TestDataset:
         assert 'Test' == elem.value
         assert 2 == len(self.ds)
 
+    def test_setdefault_unknown_tuple(self, allow_invalid_values):
+        with pytest.warns(UserWarning, match=r"\(8888, 0002\)"):
+            elem = self.ds.setdefault((0x8888, 0x0002), 'foo')
+        assert 'foo' == elem.value
+        assert 'UN' == elem.VR
+        assert 2 == len(self.ds)
+
+    def test_setdefault_unknown_tuple_strict(self, enforce_valid_values):
+        with pytest.raises(KeyError, match=r"\(8888, 0004\)"):
+            elem = self.ds.setdefault((0x8888, 0x0004), 'foo')
+
     def test_setdefault_use_value(self):
         elem = self.ds.setdefault((0x0010, 0x0010), "Test")
         assert 'Test' == elem.value
         assert 2 == len(self.ds)
-        with pytest.raises(KeyError, match=r'Tag \(0011, 0010\) not found '
-                                           r'in DICOM dictionary'):
+        with pytest.warns(UserWarning, match=r'\(0011, 0010\)'):
             self.ds.setdefault((0x0011, 0x0010), "Test")
 
     def test_setdefault_keyword(self):
@@ -253,6 +276,11 @@ class TestDataset:
         )
         assert 'Test' == elem.value
         assert 2 == len(self.ds)
+
+    def test_setdefault_invalid_keyword(self):
+        with pytest.raises(ValueError, match="'FooBar' is not a valid int or"
+                                             " DICOM keyword"):
+            self.ds.setdefault('FooBar', 'foo')
 
     def test_get_exists1(self):
         """Dataset: dataset.get() returns an existing item by name."""
@@ -329,6 +357,7 @@ class TestDataset:
 
     def test_dir_subclass(self):
         """Dataset.__dir__ returns class specific dir"""
+
         class DSP(Dataset):
             def test_func(self):
                 pass
@@ -574,6 +603,7 @@ class TestDataset:
 
     def test_property(self):
         """Test properties work OK."""
+
         class DSPlus(Dataset):
             @property
             def test(self):
@@ -1337,6 +1367,7 @@ class TestDataset:
 
     def test_exit_exception(self):
         """Test Dataset.__exit__ when an exception is raised."""
+
         class DSException(Dataset):
             @property
             def test(self):
@@ -1443,6 +1474,7 @@ class TestDataset:
 
     def test_walk(self):
         """Test Dataset.walk iterates through sequences"""
+
         def test_callback(dataset, elem):
             if elem.keyword == 'PatientID':
                 dataset.PatientID = 'FIXED'
@@ -1488,6 +1520,7 @@ class TestDataset:
 
 class TestDatasetElements:
     """Test valid assignments of data elements"""
+
     def setup(self):
         self.ds = Dataset()
         self.sub_ds1 = Dataset()
@@ -1635,6 +1668,7 @@ class TestFileDataset:
 
     def test_creation_with_container(self):
         """FileDataset.__init__ works OK with a container such as gzip"""
+
         class Dummy:
             filename = '/some/path/to/test'
 
@@ -1670,6 +1704,7 @@ class TestFileDataset:
 
 class TestDatasetOverlayArray:
     """Tests for Dataset.overlay_array()."""
+
     def setup(self):
         """Setup the test datasets and the environment."""
         self.original_handlers = pydicom.config.overlay_data_handlers

--- a/pydicom/tests/test_dicomdir.py
+++ b/pydicom/tests/test_dicomdir.py
@@ -22,9 +22,6 @@ TEST_FILES = (
 class TestDicomDir:
     """Test dicomdir.DicomDir class"""
 
-    def teardown(self):
-        config.enforce_valid_values = False
-
     @pytest.mark.parametrize("testfile", TEST_FILES)
     def test_read_file(self, testfile):
         """Test creation of DicomDir instance using filereader.read_file"""
@@ -68,8 +65,7 @@ class TestDicomDir:
         ds = dcmread(get_testdata_file('DICOMDIR-empty.dcm'))
         assert [] == ds.DirectoryRecordSequence
 
-    def test_invalid_transfer_syntax_strict_mode(self):
-        config.enforce_valid_values = True
+    def test_invalid_transfer_syntax_strict_mode(self, enforce_valid_values):
         with pytest.raises(InvalidDicomError,
                            match='Invalid transfer syntax*'):
             dcmread(IMPLICIT_TEST_FILE)

--- a/pydicom/tests/test_dicomdir.py
+++ b/pydicom/tests/test_dicomdir.py
@@ -35,7 +35,7 @@ class TestDicomDir:
         with pytest.raises(InvalidDicomError, match=msg):
             DicomDir("some_name", ds, b'\x00' * 128, ds.file_meta, True, True)
 
-    def test_invalid_sop_no_file_meta(self):
+    def test_invalid_sop_no_file_meta(self, allow_invalid_values):
         """Test exception raised if invalid sop class but no file_meta"""
         ds = dcmread(get_testdata_file('CT_small.dcm'))
         with pytest.raises(AttributeError,
@@ -54,7 +54,7 @@ class TestDicomDir:
         assert ds.patient_records[0].PatientName == 'Doe^Archibald'
         assert ds.patient_records[1].PatientName == 'Doe^Peter'
 
-    def test_invalid_transfer_syntax(self):
+    def test_invalid_transfer_syntax(self, allow_invalid_values):
         with pytest.warns(UserWarning, match='Invalid transfer syntax*'):
             dcmread(IMPLICIT_TEST_FILE)
         with pytest.warns(UserWarning, match='Invalid transfer syntax*'):

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -505,7 +505,7 @@ class TestReader:
         assert "OB" == ds[0x7FE00010].VR
         assert 266 == len(ds[0x7FE00010].value)
 
-    def test_long_specific_char_set(self):
+    def test_long_specific_char_set(self, allow_invalid_values):
         """Test that specific character set is read even if it is longer
          than defer_size"""
         ds = Dataset()
@@ -691,7 +691,7 @@ class TestReader:
         assert ds.preamble is None
         assert Dataset() == ds.file_meta
 
-    def test_file_meta_dataset_implicit_vr(self):
+    def test_file_meta_dataset_implicit_vr(self, allow_invalid_values):
         """Test reading a file meta dataset that is implicit VR"""
 
         bytestream = (

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -99,7 +99,6 @@ save_dir = os.getcwd()
 
 class TestReader:
     def teardown(self):
-        config.enforce_valid_values = False
         config.replace_un_with_known_vr = True
 
     def test_empty_numbers_tag(self):
@@ -345,7 +344,7 @@ class TestReader:
         tags = sorted(tags.keys())
         assert [Tag(0x08, 0x05)] == tags
 
-    def test_tag_with_unknown_length_tag_too_short(self):
+    def test_tag_with_unknown_length_tag_too_short(self, allow_invalid_values):
         """Tests handling of incomplete sequence value."""
         # the data set is the same as emri_jpeg_2k_lossless,
         # with the last 8 bytes removed to provoke the EOF error
@@ -356,7 +355,10 @@ class TestReader:
                 specific_tags=[unknown_len_tag],
             )
 
-        config.enforce_valid_values = True
+    def test_tag_with_unknown_length_tag_too_short_strict(
+            self, enforce_valid_values):
+        """Tests handling of incomplete sequence value in strict mode."""
+        unknown_len_tag = Tag(0x7FE0, 0x0010)  # Pixel Data
         with pytest.raises(EOFError, match="End of file reached*"):
             dcmread(
                 emri_jpeg_2k_lossless_too_short,
@@ -801,7 +803,6 @@ class TestReader:
 
 class TestIncorrectVR:
     def setup(self):
-        config.enforce_valid_values = False
         self.ds_explicit = BytesIO(
             b"\x08\x00\x05\x00CS\x0a\x00ISO_IR 100"  # SpecificCharacterSet
             b"\x08\x00\x20\x00DA\x08\x0020000101"  # StudyDate
@@ -811,10 +812,7 @@ class TestIncorrectVR:
             b"\x08\x00\x20\x00\x08\x00\x00\x0020000101"
         )
 
-    def teardown(self):
-        config.enforce_valid_values = False
-
-    def test_implicit_vr_expected_explicit_used(self):
+    def test_implicit_vr_expected_explicit_used(self, allow_invalid_values):
         msg = (
             "Expected implicit VR, but found explicit VR - "
             "using explicit VR for reading"
@@ -827,8 +825,8 @@ class TestIncorrectVR:
         assert "ISO_IR 100" == ds.SpecificCharacterSet
         assert "20000101" == ds.StudyDate
 
-    def test_implicit_vr_expected_explicit_used_strict(self):
-        config.enforce_valid_values = True
+    def test_implicit_vr_expected_explicit_used_strict(
+            self, enforce_valid_values):
         msg = (
             "Expected implicit VR, but found explicit VR - "
             "using explicit VR for reading"
@@ -839,7 +837,7 @@ class TestIncorrectVR:
                 self.ds_explicit, is_implicit_VR=True, is_little_endian=True
             )
 
-    def test_explicit_vr_expected_implicit_used(self):
+    def test_explicit_vr_expected_implicit_used(self, allow_invalid_values):
         msg = (
             "Expected explicit VR, but found implicit VR - "
             "using implicit VR for reading"
@@ -852,8 +850,8 @@ class TestIncorrectVR:
         assert "ISO_IR 100" == ds.SpecificCharacterSet
         assert "20000101" == ds.StudyDate
 
-    def test_explicit_vr_expected_implicit_used_strict(self):
-        config.enforce_valid_values = True
+    def test_explicit_vr_expected_implicit_used_strict(
+            self, enforce_valid_values):
         msg = (
             "Expected explicit VR, but found implicit VR - "
             "using implicit VR for reading"

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -2411,9 +2411,6 @@ class TestWritePN:
 class TestWriteText:
     """Test filewriter.write_PN"""
 
-    def teardown(self):
-        config.enforce_valid_values = False
-
     def test_no_encoding(self):
         """If text element has no encoding info, default is used"""
         fp = DicomBytesIO()
@@ -2489,7 +2486,7 @@ class TestWriteText:
         encoded = fp.getvalue()
         assert decoded == convert_text(encoded, encodings)
 
-    def test_invalid_encoding(self):
+    def test_invalid_encoding(self, allow_invalid_values):
         """Test encoding text with invalid encodings"""
         fp = DicomBytesIO()
         fp.is_little_endian = True
@@ -2517,10 +2514,9 @@ class TestWriteText:
             write_text(fp, elem, encodings=['iso-2022-jp', 'iso_ir_58'])
             assert expected == fp.getvalue()
 
-    def test_invalid_encoding_enforce_standard(self):
+    def test_invalid_encoding_enforce_standard(self, enforce_valid_values):
         """Test encoding text with invalid encodings with
         `config.enforce_valid_values` enabled"""
-        config.enforce_valid_values = True
         fp = DicomBytesIO()
         fp.is_little_endian = True
         # data element with decoded value

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -144,7 +144,7 @@ class TestGDCM_JPEG2000_no_gdcm:
     def teardown(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
-    def test_JPEG2000(self):
+    def test_JPEG2000(self, allow_invalid_values):
         """JPEG2000: Returns correct values for sample data elements"""
         # XX also tests multiple-valued AT data element
         expected = [Tag(0x0054, 0x0010), Tag(0x0054, 0x0020)]
@@ -155,15 +155,15 @@ class TestGDCM_JPEG2000_no_gdcm:
         expected = 'Lossy Compression'
         assert expected == got
 
-    def test_JPEG2000_pixel_array(self):
+    def test_JPEG2000_pixel_array(self, allow_invalid_values):
         with pytest.raises(NotImplementedError):
             self.jpeg_2k_lossless.pixel_array
 
-    def test_emri_JPEG2000_pixel_array(self):
+    def test_emri_JPEG2000_pixel_array(self, allow_invalid_values):
         with pytest.raises(NotImplementedError):
             self.emri_jpeg_2k_lossless.pixel_array
 
-    def test_jpeg2000_lossy(self):
+    def test_jpeg2000_lossy(self, allow_invalid_values):
         with pytest.raises(NotImplementedError):
             self.sc_rgb_jpeg2k_gdcm_KY.pixel_array
 

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -97,12 +97,12 @@ class TestJPEGLS_JPEG2000_no_jpeg_ls:
     def teardown(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
-    def test_JPEG2000PixelArray(self):
+    def test_JPEG2000PixelArray(self, allow_invalid_values):
         """JPEG2000: Now works"""
         with pytest.raises(NotImplementedError):
             self.jpeg_2k.pixel_array
 
-    def test_emri_JPEG2000PixelArray(self):
+    def test_emri_JPEG2000PixelArray(self, allow_invalid_values):
         """JPEG2000: Now works"""
         with pytest.raises(NotImplementedError):
             self.emri_jpeg_2k_lossless.pixel_array

--- a/pydicom/tests/test_multival.py
+++ b/pydicom/tests/test_multival.py
@@ -35,14 +35,11 @@ class TestMultiValue:
         assert not multival
         assert 0 == len(multival)
 
-    def testLimits(self):
+    def testLimits(self, enforce_valid_values):
         """MultiValue: Raise error if any item outside DICOM limits...."""
-        original_flag = config.enforce_valid_values
-        config.enforce_valid_values = True
         with pytest.raises(OverflowError):
             MultiValue(IS, [1, -2 ** 31 - 1])
         # Overflow error not raised for IS out of DICOM valid range
-        config.enforce_valid_values = original_flag
 
     def testAppend(self):
         """MultiValue: Append of item converts it to required type..."""

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -360,7 +360,8 @@ class TestNumpy_NoNumpyHandler:
         assert 8192 == len(ds.PixelData)
 
     @pytest.mark.parametrize("fpath,data", REFERENCE_DATA_UNSUPPORTED)
-    def test_can_access_unsupported_dataset(self, fpath, data):
+    def test_can_access_unsupported_dataset(
+            self, fpath, data, allow_invalid_values):
         """Test can read and access elements in unsupported datasets."""
         ds = dcmread(fpath)
         assert data[0] == ds.file_meta.TransferSyntaxUID
@@ -483,7 +484,8 @@ class TestNumpy_NumpyHandler:
             ds.pixel_array
 
     @pytest.mark.parametrize("fpath, data", REFERENCE_DATA_UNSUPPORTED)
-    def test_can_access_unsupported_dataset(self, fpath, data):
+    def test_can_access_unsupported_dataset(
+            self, fpath, data, allow_invalid_values):
         """Test can read and access elements in unsupported datasets."""
         ds = dcmread(fpath)
         assert data[0] == ds.file_meta.TransferSyntaxUID

--- a/pydicom/tests/test_overlay_np.py
+++ b/pydicom/tests/test_overlay_np.py
@@ -225,7 +225,8 @@ class TestNumpy_NumpyHandler:
                 ds.overlay_array(0x6000)
 
     @pytest.mark.parametrize("fpath, data", REFERENCE_DATA_UNSUPPORTED)
-    def test_can_access_unsupported_dataset(self, fpath, data):
+    def test_can_access_unsupported_dataset(
+            self, fpath, data, allow_invalid_values):
         """Test can read and access elements in unsupported datasets."""
         ds = dcmread(fpath)
         assert data[0] == ds.file_meta.TransferSyntaxUID

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -316,7 +316,8 @@ class TestNumpy_NoRLEHandler:
         assert 6128 == len(ds.PixelData)
 
     @pytest.mark.parametrize("fpath,data", REFERENCE_DATA_UNSUPPORTED)
-    def test_can_access_unsupported_dataset(self, fpath, data):
+    def test_can_access_unsupported_dataset(
+            self, fpath, data, allow_invalid_values):
         """Test can read and access elements in unsupported datasets."""
         ds = dcmread(fpath)
         assert data[0] == ds.file_meta.TransferSyntaxUID
@@ -368,7 +369,8 @@ class TestNumpy_RLEHandler:
                 ds.decompress(handler_name='rle')
 
     @pytest.mark.parametrize("fpath,data", REFERENCE_DATA_UNSUPPORTED)
-    def test_can_access_unsupported_dataset(self, fpath, data):
+    def test_can_access_unsupported_dataset(
+            self, fpath, data, allow_invalid_values):
         """Test can read and access elements in unsupported datasets."""
         ds = dcmread(fpath)
         assert data[0] == ds.file_meta.TransferSyntaxUID

--- a/pydicom/tests/test_util.py
+++ b/pydicom/tests/test_util.py
@@ -230,7 +230,6 @@ class TestHexUtil:
 class TestDataElementCallbackTests:
     def setup(self):
         # Set up a dataset with commas in one item instead of backslash
-        config.enforce_valid_values = True
         namespace = {}
         exec(raw_hex_code, {}, namespace)
         ds_bytes = hexutil.hex2bytes(namespace['impl_LE_deflen_std_hex'])
@@ -240,10 +239,7 @@ class TestDataElementCallbackTests:
 
         self.bytesio = BytesIO(ds_bytes)
 
-    def teardown(self):
-        config.enforce_valid_values = False
-
-    def testBadSeparator(self):
+    def testBadSeparator(self, enforce_valid_values):
         """Ensure that unchanged bad separator does raise an error..."""
         ds = filereader.read_dataset(self.bytesio, is_little_endian=True,
                                      is_implicit_VR=True)

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -219,7 +219,7 @@ class TestBadValueRead:
     def teardown(self):
         pydicom.values.convert_retry_VR_order = self.default_retry_order
 
-    def test_read_bad_value_in_VR_default(self):
+    def test_read_bad_value_in_VR_default(self, allow_invalid_values):
         # found a conversion
         assert "1A" == convert_value("SH", self.tag)
         # converted with fallback vr "SH"

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -18,7 +18,6 @@ import pytest
 
 from pydicom.valuerep import PersonName
 
-
 try:
     import cPickle as pickle
 except ImportError:
@@ -138,7 +137,7 @@ class TestDSdecimal:
     def test_float_value(self):
         config.allow_DS_float = False
         with pytest.raises(
-            TypeError, match="cannot be instantiated with a float value"
+                TypeError, match="cannot be instantiated with a float value"
         ):
             pydicom.valuerep.DSdecimal(9.0)
         config.allow_DS_float = True
@@ -172,7 +171,7 @@ class TestIS:
         assert x.real == x2.real
         assert x.original_string == x2.original_string
 
-    def test_longint(self):
+    def test_longint(self, allow_invalid_values):
         # Check that a long int is read properly
         # Will not work with enforce_valid_values
         x = pydicom.valuerep.IS(3103050000)
@@ -180,12 +179,9 @@ class TestIS:
         x2 = pickle.loads(data1_string)
         assert x.real == x2.real
 
-    def test_overflow(self):
-        original_flag = config.enforce_valid_values
-        config.enforce_valid_values = True
+    def test_overflow(self, enforce_valid_values):
         with pytest.raises(OverflowError, match="Value exceeds DICOM limits*"):
             pydicom.valuerep.IS(3103050000)
-        config.enforce_valid_values = original_flag
 
     def test_str(self):
         """Test IS.__str__()."""
@@ -233,8 +229,8 @@ class TestBadValueRead:
         # no fallback VR succeeded, returned original value untranslated
         assert b"1A" == convert_value("IS", self.tag)
 
-    def test_read_bad_value_in_VR_enforce_valid_value(self):
-        pydicom.config.enforce_valid_values = True
+    def test_read_bad_value_in_VR_enforce_valid_value(
+            self, enforce_valid_values):
         # found a conversion
         assert "1A" == convert_value("SH", self.tag)
         # invalid literal for base 10
@@ -246,13 +242,11 @@ class TestDecimalString:
     """Unit tests unique to the use of DS class
        derived from python Decimal"""
 
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def ds_decimal(self):
         config.DS_decimal(True)
-        config.enforce_valid_values = True
-
-    def teardown(self):
+        yield
         config.DS_decimal(False)
-        config.enforce_valid_values = False
 
     def test_DS_decimal_set(self):
         config.use_DS_decimal = False
@@ -272,7 +266,7 @@ class TestDecimalString:
         ds = valuerep.DS(long_str)
         assert len(str(ds)) <= 16
 
-    def test_invalid_decimal_strings(self):
+    def test_invalid_decimal_strings(self, enforce_valid_values):
         # Now the input string truly is invalid
         invalid_string = "-9.813386743e-006"
         with pytest.raises(OverflowError):
@@ -468,7 +462,7 @@ class TestPersonName:
         """Test that iterators can be corretly constructed"""
         name_str = "John^Doe^^Dr"
         pn1 = PersonName(name_str)
-        
+
         for i, c in enumerate(pn1):
             assert name_str[i] == c
 


### PR DESCRIPTION
- now issues a warning and set the VR to UN
- raises KeyError only if config.enforce_valid_values is set
- added and used conftest.py for common fixtures
- see #1161

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Unit tests passing and overall coverage the same or better
