### PR TITLE
[RFR] Make pymedphys testing only install production versions

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -128,7 +128,7 @@ jobs:
 
     - name: Install pymedphys
       if: ${{ matrix.pymedphys-dep == 'pymedphys' }}
-      run: python -m pip install --pre pymedphys[tests]>=0.31.0dev0
+      run: python -m pip install pymedphys[tests]>=0.31.0
     - name: Get PyMedPhys cache directory
       if: ${{ matrix.pymedphys-dep == 'pymedphys' }}
       id: pymedphys-cache-location


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
Now that the tests that utilise pydicom are within the released package, make it so that only production versions of pymedphys are tested by the master merge for pydicom