### PR TITLE
[MRG] Raise TypeError if dcmread or dcmwrite is called with wrong argument

### DIFF
--- a/doc/release_notes/v2.1.0.rst
+++ b/doc/release_notes/v2.1.0.rst
@@ -58,5 +58,5 @@ Fixes
   connection is available (:pr:`1156`)
 * Fixed GDCM < v2.8.8 not returning the pixel array for datasets not read from
   a file-like (:issue:`1153`)
-* Raise ``TypeError`` if `~pydicom.dcmread` or `~pydicom.dcmwrite` is called
-  with wrong argument
+* Raise ``TypeError`` if :func:`~pydicom.dcmread` or :func:`~pydicom.dcmwrite`
+  is called with wrong argument

--- a/doc/release_notes/v2.1.0.rst
+++ b/doc/release_notes/v2.1.0.rst
@@ -58,3 +58,5 @@ Fixes
   connection is available (:pr:`1156`)
 * Fixed GDCM < v2.8.8 not returning the pixel array for datasets not read from
   a file-like (:issue:`1153`)
+* Raise ``TypeError`` if `~pydicom.dcmread` or `~pydicom.dcmwrite` is called
+  with wrong argument

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -809,6 +809,8 @@ def dcmread(fp, defer_size=None, stop_before_pixels=False,
     ------
     InvalidDicomError
         If `force` is ``True`` and the file is not a valid DICOM file.
+    TypeError
+        If `fp` is ``None`` or of an unsupported type.
 
     See Also
     --------
@@ -842,6 +844,9 @@ def dcmread(fp, defer_size=None, stop_before_pixels=False,
         caller_owns_file = False
         logger.debug("Reading file '{0}'".format(fp))
         fp = open(fp, 'rb')
+    elif fp is None or not hasattr(fp, "read") or not hasattr(fp, "seek"):
+        raise TypeError("dcmread: Expected a file path or a file-like, "
+                        "but got " + type(fp).__name__)
 
     if config.debugging:
         logger.debug("\n" + "-" * 80)

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -1004,8 +1004,11 @@ def dcmwrite(filename, dataset, write_like_original=True):
         # caller provided a file name; we own the file handle
         caller_owns_file = False
     else:
-        fp = DicomFileLike(filename)
-
+        try:
+            fp = DicomFileLike(filename)
+        except AttributeError:
+            raise TypeError("dcmwrite: Expected a file path or a file-like, "
+                            "but got " + type(filename).__name__)
     try:
         # WRITE FILE META INFORMATION
         if preamble:

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -751,6 +751,17 @@ class TestReader:
             assert Dataset() == ds.file_meta
             assert Dataset() == ds[:]
 
+    def test_bad_filename(self):
+        """Test reading from non-existing file raises."""
+        with pytest.raises(FileNotFoundError):
+            dcmread("InvalidFilePath")
+        with pytest.raises(TypeError, match="dcmread: Expected a file path or "
+                                            "a file-like, but got None"):
+            dcmread(None)
+        with pytest.raises(TypeError, match="dcmread: Expected a file path or "
+                                            "a file-like, but got int"):
+            dcmread(42)
+
     def test_empty_specific_character_set(self):
         """Test that an empty Specific Character Set is handled correctly.
         Regression test for #1038"""

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -1252,6 +1252,16 @@ class TestWriteToStandard:
         with pytest.raises(ValueError):
             ds.save_as(DicomBytesIO(), write_like_original=False)
 
+    def test_bad_filename(self):
+        """Test that TypeError is raised for a bad filename."""
+        ds = dcmread(ct_name)
+        with pytest.raises(TypeError, match="dcmwrite: Expected a file path "
+                                            "or a file-like, but got None"):
+            ds.save_as(None)
+        with pytest.raises(TypeError, match="dcmwrite: Expected a file path "
+                                            "or a file-like, but got int"):
+            ds.save_as(42)
+
     def test_prefix(self):
         """Test that the 'DICM' prefix
            is written with preamble."""


### PR DESCRIPTION
- raise if the filename / fp argument is None or not a str or file-like

This came up twice in Stackoveflow: someone tried to use `get_testdata_file` with  a local file, passed the result (which was `None`) into `dcmread` and got something like:
```
Traceback (most recent call last):
  File "addfields.py", line 14, in <module>
    ds = pydicom.dcmread(fn)
  File "/Users/user/opt/anaconda3/lib/python3.7/site-packages/pydicom/filereader.py", line 871, in dcmread
    force=force, specific_tags=specific_tags)
  File "/Users/user/opt/anaconda3/lib/python3.7/site-packages/pydicom/filereader.py", line 668, in read_partial
    preamble = read_preamble(fileobj, force)
  File "/Users/user/opt/anaconda3/lib/python3.7/site-packages/pydicom/filereader.py", line 605, in read_preamble
    preamble = fp.read(128)
AttributeError: 'NoneType' object has no attribute 'read'
``` 
leading to incorrect reasoning about the cause (problem with preamble?).

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
