### PR TITLE
[MRG] Handle case where NumberOfFrames exists but is None

### DIFF
--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -893,6 +893,9 @@ def get_nr_frames(ds):
     nr_frames = getattr(ds, 'NumberOfFrames', 1)
     # 'NumberOfFrames' may exist in the DICOM file but have value equal to None
     if nr_frames is None:
+        warnings.warn("A value of None for (0028,0008) 'Number of Frames' is "
+                      "non-conformant. It's recommended that this value be "
+                      "changed to 1")
         nr_frames = 1
 
     return nr_frames

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -759,7 +759,7 @@ def get_expected_length(ds, unit='bytes'):
         pixels, excluding the NULL trailing padding byte for odd length data.
     """
     length = ds.Rows * ds.Columns * ds.SamplesPerPixel
-    length *= getattr(ds, 'NumberOfFrames', 1)
+    length *= get_nr_frames(ds)
 
     if unit == 'pixels':
         return length
@@ -874,6 +874,28 @@ def get_j2k_parameters(codestream):
         pass
 
     return {}
+
+
+def get_nr_frames(ds):
+    """Return NumberOfFrames or 1 if NumberOfFrames is None.
+
+    Parameters
+    ----------
+    ds : dataset.Dataset
+        The :class:`~pydicom.dataset.Dataset` containing the Image Pixel module
+        corresponding to the data in `arr`.
+
+    Returns
+    -------
+    int
+        An integer for the NumberOfFrames or 1 if NumberOfFrames is None
+    """
+    nr_frames = getattr(ds, 'NumberOfFrames', 1)
+    # 'NumberOfFrames' may exist in the DICOM file but have value equal to None
+    if nr_frames is None:
+        nr_frames = 1
+
+    return nr_frames
 
 
 def pixel_dtype(ds, as_float=False):
@@ -1060,7 +1082,7 @@ def reshape_pixel_array(ds, arr):
     if not HAVE_NP:
         raise ImportError("Numpy is required to reshape the pixel array.")
 
-    nr_frames = getattr(ds, 'NumberOfFrames', 1)
+    nr_frames = get_nr_frames(ds)
     nr_samples = ds.SamplesPerPixel
 
     if nr_frames < 1:

--- a/pydicom/tests/test_handler_util.py
+++ b/pydicom/tests/test_handler_util.py
@@ -3,7 +3,6 @@
 
 import os
 import random
-import warnings
 from struct import unpack, pack
 from sys import byteorder
 
@@ -2023,28 +2022,31 @@ class TestGetJ2KParameters:
 
 class TestGetNrFrames:
     """Tests for get_nr_frames."""
-    def test_warning(self):
+    def test_none(self):
         """Test warning when (0028,0008) 'Number of Frames' has a value of
             None"""
         ds = Dataset()
         ds.NumberOfFrames = None
-        with warnings.catch_warnings(record=True) as w:
+        msg = (
+            r"A value of None for \(0028,0008\) 'Number of Frames' is "
+            r"non-conformant. It's recommended that this value be "
+            r"changed to 1"
+        )
+        with pytest.warns(UserWarning, match=msg):
             assert 1 == get_nr_frames(ds)
-            assert len(w) == 1
-            assert "(0028,0008)" in str(w[0].message)
 
     def test_missing(self):
         """Test return value when (0028,0008) 'Number of Frames' does not
             exist"""
         ds = Dataset()
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(None) as w:
             assert 1 == get_nr_frames(ds)
-            assert len(w) == 0
+            assert not w
 
     def test_existing(self):
         """Test return value when (0028,0008) 'Number of Frames' exists."""
         ds = Dataset()
         ds.NumberOfFrames = random.randint(1, 10)
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(None) as w:
             assert ds.NumberOfFrames == get_nr_frames(ds)
-            assert len(w) == 0
+            assert not w


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
In certain DICOM images, the "Number of Frames" field exists but has a value of None. These images are not handled properly and throw an error.

Example DICOM contents:
_...
(0028, 0008) Number of Frames                    IS: None
..._

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [X] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
