### PR TITLE
[MRG] Fix for dicom apply_voi_lut with float images

### DIFF
--- a/doc/release_notes/v2.1.0.rst
+++ b/doc/release_notes/v2.1.0.rst
@@ -61,5 +61,5 @@ Fixes
   a file-like (:issue:`1153`)
 * Raise ``TypeError`` if :func:`~pydicom.dcmread` or :func:`~pydicom.dcmwrite`
   is called with wrong argument
-* Allowed :func:`~pydicom.pixel_data_handlers.util.apply_voi_lut` to apply VOI lookup to float array
-* Added warning if :func:`~pydicom.pixel_data_handlers.util.apply_voi_lut` is applied to float array
+* Allow :func:`~pydicom.pixel_data_handlers.util.apply_voi_lut` to apply VOI
+  lookup to an input float array

--- a/doc/release_notes/v2.1.0.rst
+++ b/doc/release_notes/v2.1.0.rst
@@ -61,3 +61,5 @@ Fixes
   a file-like (:issue:`1153`)
 * Raise ``TypeError`` if :func:`~pydicom.dcmread` or :func:`~pydicom.dcmwrite`
   is called with wrong argument
+* Allowed :func:`~pydicom.pixel_data_handlers.util.apply_voi_lut` to apply VOI lookup to float array
+* Added warning if :func:`~pydicom.pixel_data_handlers.util.apply_voi_lut` is applied to float array

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -334,7 +334,7 @@ def apply_voi_lut(arr, ds, index=0):
         lut_data = np.asarray(lut_data, dtype=dtype)
 
         # IVs < `first_map` get set to first LUT entry (i.e. index 0)
-        clipped_iv = np.zeros(arr.shape, dtype=arr.dtype)
+        clipped_iv = np.zeros(arr.shape, dtype=dtype)
         # IVs >= `first_map` are mapped by the VOI LUT
         # `first_map` may be negative, positive or 0
         mapped_pixels = arr >= first_map

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -307,6 +307,11 @@ def apply_voi_lut(arr, ds, index=0):
       <part04/sect_N.2.html#sect_N.2.1.1>`
     """
     if 'VOILUTSequence' in ds:
+        if not np.issubdtype(arr.dtype, np.integer):
+            warnings.warn(
+                "Applying `apply_voi_lut` to float arrays " 
+                "may lead to incorrect result!")
+
         # VOI LUT Sequence contains one or more items
         item = ds.VOILUTSequence[index]
         nr_entries = item.LUTDescriptor[0] or 2**16

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -309,7 +309,7 @@ def apply_voi_lut(arr, ds, index=0):
     if 'VOILUTSequence' in ds:
         if not np.issubdtype(arr.dtype, np.integer):
             warnings.warn(
-                "Applying `apply_voi_lut` to float arrays " 
+                "Applying `apply_voi_lut` to float arrays "
                 "may lead to incorrect result!")
 
         # VOI LUT Sequence contains one or more items

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -309,8 +309,9 @@ def apply_voi_lut(arr, ds, index=0):
     if 'VOILUTSequence' in ds:
         if not np.issubdtype(arr.dtype, np.integer):
             warnings.warn(
-                "Applying `apply_voi_lut` to float arrays "
-                "may lead to incorrect result!")
+                "Applying a VOI LUT on a float input array may give "
+                "incorrect results"
+            )
 
         # VOI LUT Sequence contains one or more items
         item = ds.VOILUTSequence[index]

--- a/pydicom/tests/test_handler_util.py
+++ b/pydicom/tests/test_handler_util.py
@@ -1589,8 +1589,8 @@ class TestNumpy_VOILUT:
         item.LUTData = [0, 127, 32768, 65535]
         arr = np.asarray([0, 1, 2, 3, 255], dtype='float64')
         msg = (
-            r"Applying `apply_voi_lut` to float arrays "
-            r"may lead to incorrect result!"
+            r"Applying a VOI LUT on a float input array may give "
+            r"incorrect results"
         )
 
         with pytest.warns(UserWarning, match=msg):

--- a/pydicom/tests/test_handler_util.py
+++ b/pydicom/tests/test_handler_util.py
@@ -1578,6 +1578,25 @@ class TestNumpy_VOILUT:
         with pytest.raises(NotImplementedError, match=msg):
             apply_voi_lut(ds.pixel_array, ds)
 
+    def test_voi_uint16_array_float(self):
+        """Test warning when array is float and VOI LUT with an 16-bit LUT"""
+        ds = Dataset()
+        ds.PixelRepresentation = 0
+        ds.BitsStored = 16
+        ds.VOILUTSequence = [Dataset()]
+        item = ds.VOILUTSequence[0]
+        item.LUTDescriptor = [4, 0, 16]
+        item.LUTData = [0, 127, 32768, 65535]
+        arr = np.asarray([0, 1, 2, 3, 255], dtype='float64')
+        msg = (
+            r"Applying `apply_voi_lut` to float arrays "
+            r"may lead to incorrect result!"
+        )
+
+        with pytest.warns(UserWarning, match=msg):
+            out = apply_voi_lut(arr, ds)
+            assert [0, 127, 32768, 65535, 65535] == out.tolist()
+
     def test_window_single_view(self):
         """Test windowing with a single view."""
         # 12-bit unsigned


### PR DESCRIPTION
**Describe the issue**
Hello, we've been using 
```
img = apply_voi_lut(apply_modality_lut(dcm.pixel_array,dcm),dcm)
plt.imshow(img)
```
And it will crash if apply_modality_lut will return float (it returns float `if 'RescaleSlope' in ds and 'RescaleIntercept' in ds`)

**Expected behavior**
It should still work or at least handle error differently and say (you can only apply_vol_lut to integer values)

**Steps To Reproduce**
How to reproduce the issue. Please include:
1. Get dicom that satisfies condition `if 'RescaleSlope' in ds and 'RescaleIntercept' in ds`
2. 
```---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
 in 
      3 
      4 # extracting image (pixels data)
----> 5 img = apply_voi_lut(apply_modality_lut(dcm.pixel_array,dcm),dcm)
      6 
      7 plt.imshow(img)

~/anaconda3/envs/pt/lib/python3.7/site-packages/pydicom/pixel_data_handlers/util.py in apply_voi_lut(arr, ds, index)
    343         np.clip(clipped_iv, 0, nr_entries - 1, out=clipped_iv)
    344 
--> 345         return lut_data[clipped_iv]
    346     elif 'WindowCenter' in ds and 'WindowWidth' in ds:
    347         if ds.PhotometricInterpretation not in ['MONOCHROME1', 'MONOCHROME2']:

IndexError: arrays used as indices must be of integer (or boolean) type
```
3. Which of the following packages are available and their versions:
  * GDCM == 2.0.0
no need for the rest, you can clearly see `elif` in `apply_modality_lut`
4. Sorry, cant share my dicom file, but added test 

Python version 3.7.7

Potential solution:
Of course you can just swap `apply_voi_lut` and `apply_modality_lut` in my snippet, but anyway, this solution is better :)

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
