### PR TITLE
Better error handling for "apply_voi_lut"

### DIFF
--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -308,7 +308,10 @@ def apply_voi_lut(arr, ds, index=0):
     """
     if 'VOILUTSequence' in ds:
         if not np.issubdtype(arr.dtype, np.integer):
-            raise TypeError("Expected input 'arr' to be of integer dtype, received: {} dtype".format(arr.dtype))
+            raise TypeError(
+                "Expected input 'arr' to be of integer dtype, "
+                "received: {} dtype".format(arr.dtype)
+            )
 
         # VOI LUT Sequence contains one or more items
         item = ds.VOILUTSequence[index]

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -307,6 +307,9 @@ def apply_voi_lut(arr, ds, index=0):
       <part04/sect_N.2.html#sect_N.2.1.1>`
     """
     if 'VOILUTSequence' in ds:
+        if not np.issubdtype(arr.dtype, np.integer):
+            raise TypeError("Expected input 'arr' to be of integer dtype, received: {} dtype".format(arr.dtype))
+
         # VOI LUT Sequence contains one or more items
         item = ds.VOILUTSequence[index]
         nr_entries = item.LUTDescriptor[0] or 2**16


### PR DESCRIPTION
`apply_voi_lut` will crash if `VOILUTSequence` is in dicom AND if array that is passed in any type, other than bool or integer.

I have accidentaly encountered the problem and error I was receiving was not really informative:

```
IndexError                                Traceback (most recent call last)
 in 
      3 
      4 # extracting image (pixels data)
----> 5 img = apply_voi_lut(apply_modality_lut(dcm.pixel_array,dcm),dcm)
      6 
      7 plt.imshow(img)

~/anaconda3/envs/pt/lib/python3.7/site-packages/pydicom/pixel_data_handlers/util.py in apply_voi_lut(arr, ds, index)
    343         np.clip(clipped_iv, 0, nr_entries - 1, out=clipped_iv)
    344 
--> 345         return lut_data[clipped_iv]
    346     elif 'WindowCenter' in ds and 'WindowWidth' in ds:
    347         if ds.PhotometricInterpretation not in ['MONOCHROME1', 'MONOCHROME2']:

IndexError: arrays used as indices must be of integer (or boolean) type
```

This fix allows you to know exactly what you did wrong if you passed a float array (just checks arr.dtype and raises a error, if it is not any integer subdtype).

This fix should not be applied with https://github.com/pydicom/pydicom/pull/1183 (one or another)

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
