### PR TITLE
[MRG] Add 'user' extras to pymedphys install

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -128,7 +128,7 @@ jobs:
 
     - name: Install pymedphys
       if: ${{ matrix.pymedphys-dep == 'pymedphys' }}
-      run: python -m pip install pymedphys[tests]>=0.31.0
+      run: python -m pip install pymedphys[user,tests]>=0.31.0
     - name: Get PyMedPhys cache directory
       if: ${{ matrix.pymedphys-dep == 'pymedphys' }}
       id: pymedphys-cache-location


### PR DESCRIPTION
As of 0.33.0 all dependencies are classified as "optional". To install everything that might be needed to use pymedphys it now requires the `user` flag:

https://docs.pymedphys.com/release-notes.html#installation-changes

It should have twigged that this would mess up the pymedphys on-master push.

Thanks @darcymason for you patience with this one.