### PR TITLE
[MRG] Improvements for Dataset's dict methods

### DIFF
--- a/doc/reference/config.rst
+++ b/doc/reference/config.rst
@@ -26,4 +26,5 @@ Configuration Options (:mod:`pydicom.config`)
    use_IS_numpy
    use_DS_numpy
    APPLY_J2K_CORRECTIONS
+   INVALID_KEY_BEHAVIOR
    INVALID_KEYWORD_BEHAVIOR

--- a/doc/release_notes/v2.1.0.rst
+++ b/doc/release_notes/v2.1.0.rst
@@ -48,7 +48,7 @@ Enhancements
   a known element keyword (:issue:`1014`)
 * Added :attr:`~pydicom.config.INVALID_KEY_BEHAVIOR` config option to allow
   customizing the behavior when an invalid key is used with the
-  :class:`~pydicom.dataset.Dataset` :func:`in<operator.__contains__>`
+  :class:`~pydicom.dataset.Dataset` :func:`in<operator.__contains__>` operator
   (:issue:`1200`)
 * Implemented full support (loading, accessing, modifying, writing) of
   DICOM File-sets and their DICOMDIR files via the
@@ -114,7 +114,6 @@ Fixes
 * Allow :func:`~pydicom.pixel_data_handlers.util.apply_voi_lut` to apply VOI
   lookup to an input float array
 * Fixed :meth:`Dataset.setdefault()<pydicom.dataset.Dataset.setdefault>` not
-  adding working correctly when the `default` value is ``None`` (:issue:`1215`)
-* Fixed :meth:`Dataset.setdefault()<pydicom.dataset.Dataset.setdefault>` not
-  adding private elements when :attr:`config.enforce_valid_values` is ``True``
-  (:issue:`1215`)
+  adding working correctly when the `default` value is ``None`` and not
+  adding private elements when :attr:`~pydicom.config.enforce_valid_values` is
+  ``True`` (:issue:`1215`)

--- a/doc/release_notes/v2.1.0.rst
+++ b/doc/release_notes/v2.1.0.rst
@@ -46,6 +46,10 @@ Enhancements
   :attr:`~pydicom.config.INVALID_KEYWORD_BEHAVIOR` config option to allow
   customizing the behavior when a camel case variable name is used that isn't
   a known element keyword (:issue:`1014`)
+* Added :attr:`~pydicom.config.INVALID_KEY_BEHAVIOR` config option to allow
+  customizing the behavior when an invalid key is used with the
+  :class:`~pydicom.dataset.Dataset` :func:`in<operator.__contains__>`
+  (:issue:`1200`)
 * Implemented full support (loading, accessing, modifying, writing) of
   DICOM File-sets and their DICOMDIR files via the
   :class:`~pydicom.fileset.FileSet` class (:issue:`9`, :issue:`243`,
@@ -64,9 +68,6 @@ Changes
   become ``MultiFrame``, those with ``and`` in them become ``And``, and
   ``DICOSQuadrupoleResonanceQRStorage`` becomes
   ``DICOSQuadrupoleResonanceStorage``.
-* Invalid values used with the :class:`~pydicom.dataset.Dataset`
-  :func:`in<operator.__contains__>` now raise :class:`ValueError` rather than
-  returning ``False`` (:issue:`1200`)
 * Data dictionaries updated to version 2020c of the DICOM Standard
 * The following UID constants are deprecated and will be removed in v2.2:
 
@@ -112,3 +113,8 @@ Fixes
 * Fixed empty ambiguous VR elements raising an exception (:issue:`1193`)
 * Allow :func:`~pydicom.pixel_data_handlers.util.apply_voi_lut` to apply VOI
   lookup to an input float array
+* Fixed :meth:`Dataset.setdefault()<pydicom.dataset.Dataset.setdefault>` not
+  adding working correctly when the `default` value is ``None`` (:issue:`1215`)
+* Fixed :meth:`Dataset.setdefault()<pydicom.dataset.Dataset.setdefault>` not
+  adding private elements when :attr:`config.enforce_valid_values` is ``True``
+  (:issue:`1215`)

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -313,7 +313,37 @@ Examples
 >>> ds.PatientsName = "Citizen^Jan"
 ../pydicom/dataset.py:1895: UserWarning: Camel case attribute 'PatientsName'
 used which is not in the element keyword data dictionary
+"""
 
+INVALID_KEY_BEHAVIOR = "WARN"
+"""Control the behavior when invalid keys are used with
+:meth:`~pydicom.dataset.Dataset.__contains__` (e.g. ``'invalid' in ds``).
+
+.. versionadded:: 2.1
+
+Invalid keys are objects that cannot be converted to a
+:class:`~pydicom.tag.BaseTag`, such as unknown element keywords or invalid
+element tags like ``0x100100010``.
+
+If ``"WARN"`` (default), then warn when an invalid key is used, if ``"RAISE"``
+then raise a :class:`ValueError` exception. If ``"IGNORE"`` then neither warn
+nor raise.
+
+Examples
+--------
+
+>>> from pydicom import config
+>>> config.INVALID_KEY_BEHAVIOR = "RAISE"
+>>> ds = Dataset()
+>>> 'PatientName' in ds  # OK
+False
+>>> 'PatientsName' in ds
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File ".../pydicom/dataset.py", line 494, in __contains__
+    raise ValueError(msg) from exc
+ValueError: Invalid value used with the 'in' operator: must be an
+element tag as a 2-tuple or int, or an element keyword
 """
 
 

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -628,7 +628,10 @@ class DataElement:
 
     @property
     def is_private(self):
-        """Return ``True`` if the element's tag is private."""
+        """Return ``True`` if the element's tag is private.
+
+        .. versionadded:: 2.1
+        """
         return self.tag.is_private
 
     @property

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -627,6 +627,11 @@ class DataElement:
         return name
 
     @property
+    def is_private(self):
+        """Return ``True`` if the element's tag is private."""
+        return self.tag.is_private
+
+    @property
     def is_retired(self):
         """Return the element's retired status as :class:`bool`.
 

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1912,7 +1912,7 @@ class Dataset(dict):
                 )
                 if config.INVALID_KEYWORD_BEHAVIOR == "WARN":
                     warnings.warn(msg)
-                elif config.INVALID_KEYWORD_BEHAVIOR == "ERROR":
+                elif config.INVALID_KEYWORD_BEHAVIOR == "RAISE":
                     raise ValueError(msg)
 
             # name not in dicom dictionary - setting a non-dicom instance

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -115,7 +115,7 @@ def Tag(
             if long_value is None:
                 raise ValueError(
                     f"Unable to create an element tag from '{arg}': "
-                    "unknown DICOM element keyword"
+                    "unknown DICOM element keyword or an invalid int"
                 )
     # Single int parameter
     else:

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -85,12 +85,16 @@ def Tag(
         elif isinstance(arg[0], int):
             valid = isinstance(arg[1], int)
         if not valid:
-            raise ValueError("Both arguments for Tag must be the same type, "
-                             "either string or int.")
+            raise TypeError(
+                f"Unable to create an element tag from '{arg}': both "
+                "arguments must be the same type and str or int"
+            )
 
         if arg[0] > 0xFFFF or arg[1] > 0xFFFF:
-            raise OverflowError("Groups and elements of tags must each "
-                                "be <=2 byte integers")
+            raise OverflowError(
+                f"Unable to create an element tag from '{arg}': the group "
+                "and element values are limited to a maximum of 2-bytes each"
+            )
 
         long_value = (arg[0] << 16) | arg[1]
 
@@ -99,25 +103,35 @@ def Tag(
         try:
             long_value = int(arg, 16)
             if long_value > 0xFFFFFFFF:
-                raise OverflowError("Tags are limited to 32-bit length; "
-                                    "tag {0!r}"
-                                    .format(long_value))
+                raise OverflowError(
+                    f"Unable to create an element tag from '{long_value}': "
+                    "the combined group and element values  are limited to a "
+                    "maximum of 4-bytes"
+                )
         except ValueError:
             # Try a DICOM keyword
             from pydicom.datadict import tag_for_keyword
             long_value = tag_for_keyword(arg)
             if long_value is None:
-                raise ValueError("'{}' is not a valid int or DICOM keyword"
-                                 .format(arg))
+                raise ValueError(
+                    f"Unable to create an element tag from '{arg}': "
+                    "unknown DICOM element keyword"
+                )
     # Single int parameter
     else:
         long_value = arg
         if long_value > 0xFFFFFFFF:
-            raise OverflowError("Tags are limited to 32-bit length; tag {0!r}"
-                                .format(long_value))
+            raise OverflowError(
+                f"Unable to create an element tag from '{long_value}': the "
+                "combined group and element values are limited to a maximum "
+                "of 4-bytes"
+            )
 
     if long_value < 0:
-        raise ValueError("Tags must be positive.")
+        raise ValueError(
+            f"Unable to create an element tag from '{long_value}': tags must "
+            "be positive"
+        )
 
     return BaseTag(long_value)
 

--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -519,6 +519,13 @@ class TestDataElement:
         assert 0 == elem.VM
         assert elem.value == []
 
+    def test_is_private(self):
+        """Test the is_private property."""
+        elem = DataElement(0x00090010, 'UN', None)
+        assert elem.is_private
+        elem = DataElement(0x00080010, 'UN', None)
+        assert not elem.is_private
+
 
 class TestRawDataElement:
 

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -223,6 +223,12 @@ class TestDataset:
         with pytest.raises(ValueError, match=msg):
             'invalid' in self.ds
 
+    def test_contains_ignore(self, contains_ignore):
+        """Test ignoring invalid keys."""
+        with pytest.warns(None) as record:
+            assert 'invalid' not in self.ds
+            assert len(record) == 0
+
     def test_clear(self):
         assert 1 == len(self.ds)
         self.ds.clear()

--- a/pydicom/tests/test_tag.py
+++ b/pydicom/tests/test_tag.py
@@ -275,10 +275,12 @@ class TestTag:
         pytest.raises(ValueError, Tag, ('0x0', '-0x1'))
         pytest.raises(ValueError, Tag, ('-0x1', '0x0'))
         # Can't have second parameter
-        pytest.raises(ValueError, Tag, (0x01, 0x02), 0x01)
-        pytest.raises(ValueError, Tag, (0x01, 0x02), '0x01')
-        pytest.raises(ValueError, Tag, ('0x01', '0x02'), '0x01')
-        pytest.raises(ValueError, Tag, ('0x01', '0x02'), 0x01)
+        msg = r"Unable to create an element tag from '\(\(1, 2\), 1\)'"
+        with pytest.raises(TypeError, match=msg):
+             Tag((0x01, 0x02), 0x01)
+        pytest.raises(TypeError, Tag, (0x01, 0x02), '0x01')
+        pytest.raises(TypeError, Tag, ('0x01', '0x02'), '0x01')
+        pytest.raises(TypeError, Tag, ('0x01', '0x02'), 0x01)
 
     def test_tag_single_list(self):
         """Test creating a Tag from a single list."""
@@ -295,7 +297,12 @@ class TestTag:
         pytest.raises(ValueError, Tag, ['0x10'])
 
         # Must be int or string
-        pytest.raises(ValueError, Tag, [1., 2.])
+        msg = (
+            r"Unable to create an element tag from '\[1.0, 2.0\]': both "
+            r"arguments must be the same type and str or int"
+        )
+        with pytest.raises(TypeError, match=msg):
+             Tag([1., 2.])
 
         # Must be 32-bit
         pytest.raises(OverflowError, Tag, [65536, 0])
@@ -307,10 +314,13 @@ class TestTag:
         pytest.raises(ValueError, Tag, ('0x0', '-0x1'))
         pytest.raises(ValueError, Tag, ('-0x1', '0x0'))
         # Can't have second parameter
-        pytest.raises(ValueError, Tag, [0x01, 0x02], 0x01)
-        pytest.raises(ValueError, Tag, [0x01, 0x02], '0x01')
-        pytest.raises(ValueError, Tag, ['0x01', '0x02'], '0x01')
-        pytest.raises(ValueError, Tag, ['0x01', '0x02'], 0x01)
+        msg = r"Unable to create an element tag from '\(\[1, 2\], 1\)'"
+        with pytest.raises(TypeError, match=msg):
+             Tag([0x01, 0x02], 0x01)
+
+        pytest.raises(TypeError, Tag, [0x01, 0x02], '0x01')
+        pytest.raises(TypeError, Tag, ['0x01', '0x02'], '0x01')
+        pytest.raises(TypeError, Tag, ['0x01', '0x02'], 0x01)
 
     def test_tag_single_str(self):
         """Test creating a Tag from a single str."""
@@ -342,8 +352,8 @@ class TestTag:
         pytest.raises(ValueError, Tag, '0', '-0x01')
         pytest.raises(ValueError, Tag, '-1', '-0x01')
         # Must both be str
-        pytest.raises(ValueError, Tag, '0x01', 0)
-        pytest.raises(ValueError, Tag, 0, '0x01')
+        pytest.raises(TypeError, Tag, '0x01', 0)
+        pytest.raises(TypeError, Tag, 0, '0x01')
 
     def test_tag_double_int(self):
         """Test creating a Tag from a two ints."""

--- a/pydicom/tests/test_tag.py
+++ b/pydicom/tests/test_tag.py
@@ -277,7 +277,7 @@ class TestTag:
         # Can't have second parameter
         msg = r"Unable to create an element tag from '\(\(1, 2\), 1\)'"
         with pytest.raises(TypeError, match=msg):
-             Tag((0x01, 0x02), 0x01)
+            Tag((0x01, 0x02), 0x01)
         pytest.raises(TypeError, Tag, (0x01, 0x02), '0x01')
         pytest.raises(TypeError, Tag, ('0x01', '0x02'), '0x01')
         pytest.raises(TypeError, Tag, ('0x01', '0x02'), 0x01)
@@ -302,7 +302,7 @@ class TestTag:
             r"arguments must be the same type and str or int"
         )
         with pytest.raises(TypeError, match=msg):
-             Tag([1., 2.])
+            Tag([1., 2.])
 
         # Must be 32-bit
         pytest.raises(OverflowError, Tag, [65536, 0])
@@ -316,7 +316,7 @@ class TestTag:
         # Can't have second parameter
         msg = r"Unable to create an element tag from '\(\[1, 2\], 1\)'"
         with pytest.raises(TypeError, match=msg):
-             Tag([0x01, 0x02], 0x01)
+            Tag([0x01, 0x02], 0x01)
 
         pytest.raises(TypeError, Tag, [0x01, 0x02], '0x01')
         pytest.raises(TypeError, Tag, ['0x01', '0x02'], '0x01')


### PR DESCRIPTION
#### Describe the changes
Closes #1215, related to #1214  

* Improve exceptions messages for `Tag()` and change a `ValueError` to a `TypeError`
* Raise `KeyError` with `ds['invalid']` instead of `ValueError`
* Add configurable behaviour (and warn instead of raising) for invalid keys used with the `in` operator: `'invalid' in ds`
* Fix `setdefault()` not working correctly for a value of `None` and with private tags
* Add `DataElement.is_private` property

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
