### PR TITLE
[MRG] Add type hints for Sequence and MultiValue

### DIFF
--- a/pydicom/tests/test_multival.py
+++ b/pydicom/tests/test_multival.py
@@ -134,3 +134,17 @@ class TestMultiValue:
         assert '[1, 2, 3]' == str(multival)
         multival = MultiValue(float, [1.1, 2.2, 3.3])
         assert '[1.1, 2.2, 3.3]' == str(multival)
+
+    def test_setitem(self):
+        """Test MultiValue.__setitem__()."""
+        mv = MultiValue(int, [1, 2, 3])
+        with pytest.raises(TypeError, match="'int' object is not iterable"):
+            mv[1:1] = 4
+
+        assert [1, 2, 3] == mv
+        mv[1:1] = [4]
+        assert [1, 4, 2, 3] == mv
+        mv[1:2] = [5, 6]
+        assert [1, 5, 6, 2, 3] == mv
+        mv[1:3] = [7, 8]
+        assert [1, 7, 8, 2, 3] == mv

--- a/pydicom/tests/test_sequence.py
+++ b/pydicom/tests/test_sequence.py
@@ -1,5 +1,7 @@
-# Copyright 2008-2018 pydicom authors. See LICENSE file for details.
+# Copyright 2008-2020 pydicom authors. See LICENSE file for details.
 """Unit tests for the pydicom.sequence module."""
+
+import weakref
 
 import pytest
 
@@ -67,3 +69,39 @@ class TestSequence:
         assert "PN: 'TEST'" in out
         assert "(0010, 0020) Patient ID" in out
         assert "LO: '12345']" in out
+
+    def test_adding_datasets(self):
+        """Tests for adding datasets to the Sequence"""
+        ds_a = Dataset()
+        ds_a.Rows = 1
+        ds_b = Dataset()
+        ds_b.Rows = 2
+        ds_c = Dataset()
+        ds_c.Rows = 3
+        ds_d = Dataset()
+        ds_d.Rows = 4
+        ds_e = Dataset()
+        ds_e.Rows = 5
+
+        parent = Dataset()
+        parent.PatientName = "Parent"
+
+        seq = Sequence()
+        seq.parent = parent
+        assert isinstance(seq.parent, weakref.ReferenceType)
+        seq.append(ds_a)
+        seq.append(ds_c)
+        seq.insert(1, ds_b)
+        assert 3 == len(seq)
+        for ds in seq:
+            assert isinstance(ds.parent, weakref.ReferenceType)
+
+        seq[1] = ds_e
+        assert ds_e == seq[1]
+        assert [ds_a, ds_e, ds_c] == seq
+        seq[1:1] = [ds_d]
+        assert [ds_a, ds_d, ds_e, ds_c] == seq
+        seq[1:2] = [ds_c, ds_e]
+        assert [ds_a, ds_c, ds_e, ds_e, ds_c] == seq
+        for ds in seq:
+            assert isinstance(ds.parent, weakref.ReferenceType)


### PR DESCRIPTION
#### Describe the changes
* Add type hints for Sequence and MultiValue
* Add `append` and `insert` methods to Sequence so the `parent` attr is set correctly, fix `__setitem__` not working with slices.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
