### PR TITLE
[MRG] Automatically fragment large frames when using encapsulate

### DIFF
--- a/doc/release_notes/v2.1.0.rst
+++ b/doc/release_notes/v2.1.0.rst
@@ -66,6 +66,8 @@ Enhancements
 * :func:`~pydicom.pixel_data_handlers.numpy_handler.pack_bits` can now be used
   with 2D or 3D input arrays and will pad the packed data to even length by
   default.
+* Automatically fragment large frames when using
+  :func:`~pydicom.encaps.encapsulate`
 
 Changes
 .......

--- a/pydicom/tests/test_encaps.py
+++ b/pydicom/tests/test_encaps.py
@@ -1199,3 +1199,10 @@ class TestEncapsulate:
             b'\xfe\xff\x00\xe0'  # Next item tag
             b'\xe6\x0e\x00\x00'  # Next item length
         )
+
+    def test_encapsulate_large(self):
+        """Test encapsulating a large frame."""
+        data = bytearray(2**32 - 1)  # Odd length frame gets padded
+        data = encapsulate([data], fragments_per_frame=1)
+        fragments = decode_data_sequence(data)
+        assert 2 == len(fragments)

--- a/pydicom/tests/test_encaps.py
+++ b/pydicom/tests/test_encaps.py
@@ -1204,6 +1204,7 @@ class TestEncapsulate:
         """Test encapsulating a large frame."""
         class FakeBytes(bytes):
             length = -1
+
             def __len__(self):
                 return self.length
 
@@ -1230,3 +1231,8 @@ class TestEncapsulate:
         encapsulated = encapsulate([data], fragments_per_frame=1)
         fragments = decode_data_sequence(encapsulated)
         assert 4 == len(fragments)
+
+        data.length = 3 * (2**32 - 1)
+        encapsulated = encapsulate([data], fragments_per_frame=10)
+        fragments = decode_data_sequence(encapsulated)
+        assert 10 == len(fragments)


### PR DESCRIPTION
#### Describe the changes
Related to #1220, automatically fragment frames when the specified number of fragments would lead to a fragment length larger than the maximum allowed.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
