### PR TITLE
[MRG] Accept floats in strings (e.g. "1.0") for IS VR

### DIFF
--- a/doc/release_notes/v2.1.0.rst
+++ b/doc/release_notes/v2.1.0.rst
@@ -66,6 +66,8 @@ Enhancements
 * :func:`~pydicom.pixel_data_handlers.numpy_handler.pack_bits` can now be used
   with 2D or 3D input arrays and will pad the packed data to even length by
   default.
+* Elements with the :class:`~pydicom.valuerep.IS` VR accept float strings that
+  are convertible to integers without loss, e.g. "1.0" (:pr:`1240`)
 
 Changes
 .......

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -307,13 +307,16 @@ class TestIS:
     def test_valid_value(self):
         assert 42 == IS(42)
         assert 42 == IS("42")
+        assert 42 == IS("42.0")
         assert 42 == IS(42.0)
 
     def test_invalid_value(self):
         with pytest.raises(TypeError, match="Could not convert value"):
             IS(0.9)
-        with pytest.raises(ValueError, match="invalid literal for int()"):
+        with pytest.raises(TypeError, match="Could not convert value"):
             IS("0.9")
+        with pytest.raises(ValueError, match="could not convert string"):
+            IS("foo")
 
     def test_pickling(self):
         # Check that a pickled IS is read back properly
@@ -349,6 +352,10 @@ class TestIS:
         val = pydicom.valuerep.IS("1")
         assert "1" == str(val)
 
+        val = pydicom.valuerep.IS("1.0")
+        assert "1.0" == str(val)
+
+
     def test_repr(self):
         """Test IS.__repr__()."""
         val = pydicom.valuerep.IS(1)
@@ -356,6 +363,9 @@ class TestIS:
 
         val = pydicom.valuerep.IS("1")
         assert '"1"' == repr(val)
+
+        val = pydicom.valuerep.IS("1.0")
+        assert "1.0" == str(val)
 
 
 class TestBadValueRead:

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -478,11 +478,16 @@ class IS(int):
         if isinstance(val, str) and val.strip() == '':
             return None
 
-        newval: _IS = super().__new__(cls, val)
+        try:
+            newval: _IS = super().__new__(cls, val)
+        except ValueError:
+            # accept float strings when no integer loss, e.g. "1.0"
+            newval: _IS = super().__new__(cls, float(val))
+
         # check if a float or Decimal passed in, then could have lost info,
         # and will raise error. E.g. IS(Decimal('1')) is ok, but not IS(1.23)
         #   IS('1.23') will raise ValueError
-        if isinstance(val, (float, Decimal)) and newval != val:
+        if isinstance(val, (float, Decimal, str)) and newval != float(val):
             raise TypeError("Could not convert value to integer without loss")
 
         # Checks in case underlying int is >32 bits, DICOM does not allow this


### PR DESCRIPTION
#### Describe the changes
pydicom currently accepts floats for `IS` when `int(float_val) == float_val`. This PR allows conversion of floats that are represented as strings to `IS` when `int(float(str_val)) == float(str_val)`. 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [x] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
