### PR TITLE
[MRG] Add support for the Extended Offset Table

### DIFF
--- a/doc/reference/encaps.rst
+++ b/doc/reference/encaps.rst
@@ -29,6 +29,7 @@ Creating Encapsulated Data
    :toctree: generated/
 
    encapsulate
+   encapsulate_extended
    fragment_frame
    itemize_fragment
    itemize_frame

--- a/doc/release_notes/v2.1.0.rst
+++ b/doc/release_notes/v2.1.0.rst
@@ -66,6 +66,8 @@ Enhancements
 * :func:`~pydicom.pixel_data_handlers.numpy_handler.pack_bits` can now be used
   with 2D or 3D input arrays and will pad the packed data to even length by
   default.
+* Added :func:`~pydicom.encaps.encapsulate_extended` function for use when
+  an Extended Offset Table is required (:issue:`1178`)
 
 Changes
 .......

--- a/pydicom/encaps.py
+++ b/pydicom/encaps.py
@@ -675,8 +675,8 @@ def encapsulate(
 
     When many large frames are to be encapsulated, the total length of
     encapsulated data may exceed the maximum length available with the
-    :dcm:`Basic Offset Table<part05/sect_A.4.html>`. Under these
-    circumstances you can:
+    :dcm:`Basic Offset Table<part05/sect_A.4.html>` (2**31 - 1 bytes). Under
+    these circumstances you can:
 
     * Pass ``has_bot=False`` to :func:`~pydicom.encaps.encapsulate`
     * Use :func:`~pydicom.encaps.encapsulate_extended` and add the
@@ -765,8 +765,8 @@ def encapsulate_extended(frames: List[bytes]) -> Tuple[bytes, bytes, bytes]:
     JPEG formats) then any *Pixel Data* must be :dcm:`encapsulated
     <part05/sect_A.4.html>`. When many large frames are to be encapsulated, the
     total length of encapsulated data may exceed the maximum length available
-    with the :dcm:`Basic Offset Table<part05/sect_A.4.html>`. Under these
-    circumstances you can:
+    with the :dcm:`Basic Offset Table<part05/sect_A.4.html>` (2**32 - 1 bytes).
+    Under these circumstances you can:
 
     * Pass ``has_bot=False`` to :func:`~pydicom.encaps.encapsulate`
     * Use :func:`~pydicom.encaps.encapsulate_extended` and add the

--- a/pydicom/encaps.py
+++ b/pydicom/encaps.py
@@ -257,7 +257,7 @@ def generate_pixel_data_frame(
 
 
 def generate_pixel_data(
-    bytestream: bytes, nr_frames: Optional[int] = None,
+    bytestream: bytes, nr_frames: Optional[int] = None
 ) -> Generator[Tuple[bytes, ...], None, None]:
     """Yield an encapsulated pixel data frame.
 

--- a/pydicom/tests/test_encaps.py
+++ b/pydicom/tests/test_encaps.py
@@ -1,5 +1,7 @@
-# Copyright 2008-2018 pydicom authors. See LICENSE file for details.
+# Copyright 2008-2020 pydicom authors. See LICENSE file for details.
 """Test for encaps.py"""
+
+from struct import unpack
 
 import pytest
 
@@ -16,7 +18,8 @@ from pydicom.encaps import (
     read_item,
     fragment_frame,
     itemise_frame,
-    encapsulate
+    encapsulate,
+    encapsulate_extended
 )
 from pydicom.filebase import DicomBytesIO
 
@@ -36,7 +39,7 @@ class TestGetFrameOffsets:
         fp.is_little_endian = True
         with pytest.raises(ValueError,
                            match=r"Unexpected tag '\(fffe, e100\)' when "
-                                 r"parsing the Basic Table Offset item."):
+                                 r"parsing the Basic Table Offset item"):
             get_frame_offsets(fp)
 
     def test_bad_length_multiple(self):
@@ -49,7 +52,7 @@ class TestGetFrameOffsets:
         fp.is_little_endian = True
         with pytest.raises(ValueError,
                            match="The length of the Basic Offset Table item"
-                                 " is not a multiple of 4."):
+                                 " is not a multiple of 4"):
             get_frame_offsets(fp)
 
     def test_zero_length(self):
@@ -138,7 +141,7 @@ class TestGetNrFragments:
         fp.is_little_endian = True
         msg = (
             r"Unexpected tag '\(0010, 0010\)' at offset 12 when parsing the "
-            r"encapsulated pixel data fragment items."
+            r"encapsulated pixel data fragment items"
         )
         with pytest.raises(ValueError, match=msg):
             get_nr_fragments(fp)
@@ -212,7 +215,7 @@ class TestGeneratePixelDataFragment:
         with pytest.raises(ValueError,
                            match="Undefined item length at offset 4 when "
                                  "parsing the encapsulated pixel data "
-                                 "fragments."):
+                                 "fragments"):
             next(fragments)
         pytest.raises(StopIteration, next, fragments)
 
@@ -249,8 +252,7 @@ class TestGeneratePixelDataFragment:
         with pytest.raises(ValueError,
                            match=r"Unexpected tag '\(0010, 0010\)' at offset "
                                  r"12 when parsing the encapsulated pixel "
-                                 r"data "
-                                 r"fragment items."):
+                                 r"data fragment items"):
             next(fragments)
         pytest.raises(StopIteration, next, fragments)
 
@@ -1199,3 +1201,64 @@ class TestEncapsulate:
             b'\xfe\xff\x00\xe0'  # Next item tag
             b'\xe6\x0e\x00\x00'  # Next item length
         )
+
+    def test_encapsulate_bot_large_raises(self):
+        """Test exception raised if too much pixel data for BOT."""
+
+        class FakeBytes(bytes):
+            length = -1
+
+            def __len__(self):
+                return self.length
+
+            def __getitem__(self, s):
+                return b'\x00' * 5
+
+        frame_a = FakeBytes()
+        frame_a.length = 2**32 - 1 - 8  # 8 for first BOT item tag/length
+        frame_b = FakeBytes()
+        frame_b.length = 10
+        data = encapsulate([frame_a, frame_b], has_bot=True)
+
+        frame_a.length = 2**32 - 1 - 7
+        msg = (
+            r"The total length of the encapsulated frame data \(4294967296 "
+            r"bytes\) will be greater than the maximum allowed by the Basic "
+        )
+        with pytest.raises(ValueError, match=msg):
+            encapsulate([frame_a, frame_b], has_bot=True)
+
+
+class TestEncapsulateExtended:
+    """Tests for encaps.encapsulate_extended."""
+    def test_encapsulate(self):
+        ds = dcmread(JP2K_10FRAME_NOBOT)
+        frames = decode_data_sequence(ds.PixelData)
+        assert len(frames) == 10
+
+        out = encapsulate_extended(frames)
+        # Pixel Data encapsulated OK
+        assert isinstance(out[0], bytes)
+        test_frames = decode_data_sequence(out[0])
+        for a, b in zip(test_frames, frames):
+            assert a == b
+
+        # Extended Offset Table is OK
+        assert isinstance(out[1], bytes)
+        offsets = list(unpack('<10Q', out[1]))
+        assert offsets == [
+            0x0000,  # 0
+            0x0eee,  # 3822
+            0x1df6,  # 7670
+            0x2cf8,  # 11512
+            0x3bfc,  # 15356
+            0x4ade,  # 19166
+            0x59a2,  # 22946
+            0x6834,  # 26676
+            0x76e2,  # 30434
+            0x8594  # 34196
+        ]
+
+        # Extended Offset Table Lengths are OK
+        assert isinstance(out[2], bytes)
+        assert [len(f) for f in frames] == list(unpack('<10Q', out[2]))


### PR DESCRIPTION
#### Describe the changes
* Closes #1178 
* Raise an exception if `encapsulate()` is used with to much frame data
* Add `encapsulate_extended()` helper function

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://2553-14006067-gh.circle-artifacts.com/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
