### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,18 @@ jobs:
     - name: Install pytest and our package
       run: |
         pip install pytest
-        cd ..
+        cd ..  # avoid pip seeing 'pydicom' package dir below
         pip install -f pydicom/dist pydicom
 
-    - name: Test with pytest
+    - name: Test with pytest (no numpy)
+      run: |
+        python -c "import pytest; pytest.main(['--pyargs', 'pydicom.tests'])"
+
+    - name: Install numpy
+      run: |
+        pip install numpy
+
+    - name: Test with pytest (numpy installed)
       run: |
         python -c "import pytest; pytest.main(['--pyargs', 'pydicom.tests'])"
         cd pydicom  # back to root repo dir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: release
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Build package
+      run: |
+        python -m pip install --upgrade pip
+        pip install wheel
+        python setup.py sdist bdist_wheel
+
+    - name: Upload artifacts
+      if: ${{ success() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheels
+        path: dist/*.whl
+
+    - name: Set up venv
+      run: |
+        sudo apt-get install python3-venv
+        python -m venv ~/myenv
+        source ~/myenv/bin/activate
+        echo "Virtual env: $VIRTUAL_ENV"
+
+    - name: Install pytest and our package
+      run: |
+        pip install pytest
+        cd ..
+        pip install -f pydicom/dist pydicom
+
+    - name: Test with pytest
+      run: |
+        python -c "import pytest; pytest.main(['--pyargs', 'pydicom.tests'])"
+        cd pydicom  # back to root repo dir
+
+    # - name: Publish package to Test PyPi
+    #   uses: pypa/gh-action-pypi-publish@master
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.TEST_PYPI_PASSWORD }}
+    #     repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish package to PyPi
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}

--- a/pydicom/_version.py
+++ b/pydicom/_version.py
@@ -3,7 +3,7 @@ import re
 from typing import Tuple
 
 
-__version__: str = '2.1.0.dev0'
+__version__: str = '2.1.0'
 __version_info__: Tuple[str, str, str] = tuple(
     re.match(r'(\d+\.\d+\.\d+).*', __version__).group(1).split('.')
 )


### PR DESCRIPTION
* build, test in venv, upload to PyPI

<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
As discussed in #1130, adding workflow to trigger when github release created.

This was tested in a skeleton separate package and confirmed working. 

Builds `dist` (wheel and source dist), installs the package to venv, then uploads to PyPI if tests successful.

Based on @scaramallion's draft workflow [here](https://github.com/pydicom/pynetdicom/commit/bb22bb065a06e60b19499651f03c158be7d94cdb), but did not upload to TestPyPI first, since easy to install from local wheel instead, and avoids problem of needing to update `__version__` if tests failed after install from TestPyPI (same version cannot be re-uploaded even if deleted from TestPyPI).

#### Tasks
- ~~[ ] Unit tests added that reproduce the issue or prove feature is working~~ Tested in private repo
- [x] Fix or feature added
- ~~[ ] Documentation updated (if relevant)~~
  - ~~[ ] No warnings during build~~
  - ~~[ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)~~
- ~~[ ] Unit tests passing and overall coverage the same or better~~
