### PR TITLE
[WIP] Added optional UserWarning and fallback behavior when a byte string cannot be unpacked into a number

### DIFF
--- a/doc/reference/config.rst
+++ b/doc/reference/config.rst
@@ -11,6 +11,7 @@ Configuration Options (:mod:`pydicom.config`)
    :toctree: generated/
 
    allow_DS_float
+   convert_wrong_length_to_UN
    data_element_callback
    data_element_callback_kwargs
    datetime_conversion

--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -1,0 +1,20 @@
+Version 2.2.0
+=================================
+
+Changelog
+---------
+* 
+
+Enhancements
+............
+* A field containing an invalid number of bytes will result in a warning 
+  instead of an exception when 
+  :attr:`~pydicom.config.convert_wrong_length_to_UN` is set to True.
+
+Changes
+.......
+* 
+
+Fixes
+.....
+* 

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -149,6 +149,11 @@ the allowed range.
 Default ``False``.
 """
 
+convert_wrong_length_to_UN = False
+"""Convert a field VR to "UN" and return bytes if bytes length is invalid.
+Default ``False``.
+"""
+
 datetime_conversion = False
 """Set to ``True`` to convert the value(s) of elements with a VR of DA, DT and
 TM to :class:`datetime.date`, :class:`datetime.datetime` and

--- a/pydicom/errors.py
+++ b/pydicom/errors.py
@@ -16,3 +16,8 @@ class InvalidDicomError(Exception):
         if not args:
             args = ('The specified file is not a valid DICOM file.', )
         Exception.__init__(self, *args)
+
+
+class BytesLengthException(Exception):
+    """Exception that is raised for an unexpected number of bytes."""
+    pass

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -6,7 +6,7 @@
 import re
 from io import BytesIO
 from struct import (unpack, calcsize)
-from typing import Optional, Union, List, cast, Tuple, Dict, Callable
+from typing import Optional, Union, List, Tuple, Dict, Callable
 from typing import Sequence as SequenceType
 
 # don't import datetime_conversion directly
@@ -14,6 +14,7 @@ from pydicom import config
 from pydicom.charset import default_encoding, decode_bytes
 from pydicom.config import logger, have_numpy
 from pydicom.dataelem import empty_value_for_VR, RawDataElement
+from pydicom.errors import BytesLengthException
 from pydicom.filereader import read_sequence
 from pydicom.multival import MultiValue
 from pydicom.sequence import Sequence
@@ -377,7 +378,12 @@ def convert_numbers(
     length = len(byte_string)
 
     if length % bytes_per_value != 0:
-        logger.warning("Expected length to be even multiple of number size")
+        raise BytesLengthException(
+            "Expected total bytes to be an even multiple of bytes per value. "
+            f"Instead received {byte_string} with length {length} and struct "
+            f"format '{struct_format}' which corresponds to bytes per value "
+            f"of {bytes_per_value}."
+        )
 
     format_string = f"{endianChar}{length // bytes_per_value}{struct_format}"
     value: Union[Tuple[int, ...], Tuple[float, ...]] = (


### PR DESCRIPTION
Added UserWarning and fallback behavior when a byte string cannot be unpacked into a number due to invalid byte string length.

<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
Private fields can have non-conformant behavior and result in errors while parsing. In my case, a field is supposed to be a double floating point (8 bytes) but the byte string only contains 6 bytes.

Example:
_...
(0019, 1027) Private tag data                    FD: b'15030 '
..._


#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
