### PR TITLE
Remove duplicate text within `dcmwrite` docstring

### DIFF
--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -816,11 +816,6 @@ def dcmwrite(
     Meta Information Group* elements. The byte stream of the `dataset` will be
     placed into the file after the DICOM *File Meta Information*.
 
-    If `write_like_original` is ``True`` then the :class:`Dataset` will be
-    written as is (after minimal validation checking) and may or may not
-    contain all or parts of the *File Meta Information* (and hence may or
-    may not be conformant with the DICOM File Format).
-
     **File Meta Information**
 
     The *File Meta Information* consists of a 128-byte preamble, followed by

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -804,10 +804,10 @@ def dcmwrite(
 ) -> None:
     """Write `dataset` to the `filename` specified.
 
-    If `write_like_original` is ``True`` then `dataset` will be written as is
-    (after minimal validation checking) and may or may not contain all or parts
-    of the File Meta Information (and hence may or may not be conformant with
-    the DICOM File Format).
+    If `write_like_original` is ``True`` then the :class:`Dataset` will be
+    written as is (after minimal validation checking) and may or may not
+    contain all or parts of the *File Meta Information* (and hence may or
+    may not be conformant with the DICOM File Format).
 
     If `write_like_original` is ``False``, `dataset` will be stored in the
     :dcm:`DICOM File Format <part10/chapter_7.html>`.  To do


### PR DESCRIPTION
Adjustment after seeing duplicated text in the docs:

https://pydicom.github.io/pydicom/dev/reference/generated/pydicom.filewriter.dcmwrite.html#pydicom.filewriter.dcmwrite:~:text=If%20write_like_original%20is%20True%20then%20the,conformant%20with%20the%20DICOM%20File%20Format).