### PR TITLE
[WIP] Add memmap capability for binary data element values

### DIFF
--- a/pydicom/misc.py
+++ b/pydicom/misc.py
@@ -2,7 +2,7 @@
 """Miscellaneous helper functions"""
 
 
-_size_factors = dict(KB=1024, MB=1024 * 1024, GB=1024 * 1024 * 1024)
+_size_factors = dict(KB=1024, MB=1024 * 1024, GB=1024**3, TB=1024**4)
 
 
 def size_in_bytes(expr):

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -56,7 +56,9 @@ except ImportError:
 
 import warnings
 
-from pydicom.pixel_data_handlers.util import pixel_dtype, get_expected_length
+from pydicom.pixel_data_handlers.util import (
+  pixel_dtype, get_expected_length, PIXEL_DATA_KEYWORDS
+)
 import pydicom.uid
 
 HANDLER_NAME = 'Numpy'
@@ -271,13 +273,19 @@ def get_pixeldata(ds, read_only=False):
         )
 
     # Check required elements
-    keywords = ['PixelData', 'FloatPixelData', 'DoubleFloatPixelData']
-    px_keyword = [kw for kw in keywords if kw in ds]
-    if len(px_keyword) != 1:
+
+    px_keyword = [kw for kw in PIXEL_DATA_KEYWORDS if kw in ds]
+    if len(px_keyword) > 1:
+        raise AttributeError(
+            "Unable to convert the pixel data: there is more than one pixel "
+            "data element in the dataset: "
+            f"found {', '.join(px_keyword)}"
+        )
+    elif len(px_keyword) == 0:
         raise AttributeError(
             "Unable to convert the pixel data: one of Pixel Data, Float "
             "Pixel Data or Double Float Pixel Data must be present in "
-            "the dataset"
+            "the dataset.  The file may not be a DICOM image file."
         )
 
     required_elements = [

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -18,6 +18,7 @@ from pydicom.uid import UID
 if TYPE_CHECKING:
     from pydicom.dataset import Dataset
 
+PIXEL_DATA_KEYWORDS = ['PixelData', 'FloatPixelData', 'DoubleFloatPixelData']
 
 def apply_color_lut(
     arr: "np.ndarray",

--- a/pydicom/tests/test_memmap.py
+++ b/pydicom/tests/test_memmap.py
@@ -1,0 +1,56 @@
+# Copyright 2020 pydicom authors. See LICENSE file for details.
+"""Tests for the reading large values through memmap."""
+
+import pytest
+
+from pydicom import config, dcmread
+from pydicom.data import get_testdata_file
+
+try:
+    import numpy as np
+    from pydicom.pixel_data_handlers import numpy_handler as NP_HANDLER
+    HAVE_NP = True
+except ImportError:
+    NP_HANDLER = None
+    HAVE_NP = False
+
+
+@pytest.fixture(scope="function")
+def memmap_setter(request):
+    orig_memmap_size = config._memmap_size
+    orig_memmap_read_only = config._memmap_read_only
+    config.memmap_size("20KB")
+    config.memmap_read_only(True)
+    yield
+    config.memmap_size(orig_memmap_size)
+    config.memmap_read_only(orig_memmap_read_only)
+
+
+@pytest.mark.skipif(not HAVE_NP, reason='numpy not available')
+class TestMemmap:
+    """Tests for handling memmap'd data element values"""
+    def test_no_memmap(self):
+        fn = get_testdata_file("CT_small.dcm")
+        ds = dcmread(fn)
+        pix_data = ds.PixelData
+        assert isinstance(pix_data, bytes)
+        assert 175 == pix_data[0]
+        assert 3 == pix_data[-1]
+
+
+    def test_read_memmapd_pixels(self, memmap_setter):
+        """Check that a memmap is returned and gives correct values"""
+        fn = get_testdata_file("CT_small.dcm")
+        ds = dcmread(fn)
+        pix_data = ds.PixelData
+        assert isinstance(pix_data, np.memmap)
+        assert 32768 == len(pix_data)
+        assert 175 == pix_data[0]
+        assert 0 == pix_data[1]
+        assert 3 == pix_data[-1]
+
+        # Check converting to pixel_array still works
+        #  last value different than because 2-byte values
+        pix_arr = ds.pixel_array
+        assert 175 == pix_arr[0][0]
+        assert 909 == pix_arr[-1][-1]

--- a/pydicom/tests/test_misc.py
+++ b/pydicom/tests/test_misc.py
@@ -46,6 +46,6 @@ class TestMisc:
         assert size_in_bytes('2gB') == 0x80000000
 
         with pytest.raises(ValueError):
-            size_in_bytes('2 TB')
+            size_in_bytes('2 PB')
         with pytest.raises(ValueError):
             size_in_bytes('KB 2')


### PR DESCRIPTION

<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
Adds memmap config capability (reading of large values deferred, then mapped directly to file, not read into memory).
Closes #139.  Related to #291.

Defers reading of any large binary data element value (above specified threshold).  When the data element value is accessed, returns a [numpy memmap](https://numpy.org/doc/stable/reference/generated/numpy.memmap.html) for the value.  This part basically replaces previous "deferred" reading.

First step does this for any binary VR above the size threshold.  

Next step is to modify pixel_array to avoid copying the PixelData into memory, but leave as memmap where possible (uncompressed pixel data).


#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
