### PR TITLE
[MRG] Change minimum supported Python version

### DIFF
--- a/doc/release_notes/index.rst
+++ b/doc/release_notes/index.rst
@@ -2,6 +2,7 @@
 Release notes
 =============
 
+.. include:: v2.1.2.rst
 .. include:: v2.1.1.rst
 .. include:: v2.1.0.rst
 .. include:: v2.0.0.rst

--- a/doc/release_notes/v2.1.2.rst
+++ b/doc/release_notes/v2.1.2.rst
@@ -1,0 +1,7 @@
+Version 2.1.2
+=============
+
+Changes
+-------
+
+* Changed minimum supported Python version to 3.6.1 (:issue:`1270`)

--- a/pydicom/_version.py
+++ b/pydicom/_version.py
@@ -3,7 +3,7 @@ import re
 from typing import Tuple
 
 
-__version__: str = '2.1.1'
+__version__: str = '2.1.2'
 __version_info__: Tuple[str, str, str] = tuple(
     re.match(r'(\d+\.\d+\.\d+).*', __version__).group(1).split('.')
 )

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ PACKAGE_DATA = {
 
 opts = dict(
     name=NAME,
-    python_requires='>=3.6',
+    python_requires='>=3.6.1',
     version=VERSION,
     maintainer=MAINTAINER,
     maintainer_email=MAINTAINER_EMAIL,


### PR DESCRIPTION
* Change minimum Python version to 3.6.1
* Bump pydicom version to 2.1.2
* Add release notes for 2.1.2
