### PR TITLE
[MRG] Fix pickling of weakref in Dataset and Sequence

### DIFF
--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -24,4 +24,5 @@ Changes
 
 Fixes
 .....
-* 
+* Fixed pickling a :class:`~pydicom.dataset.Dataset` instance with sequences
+  after the sequence had been read (:issue:`1278`)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -26,7 +26,7 @@ import os.path
 import re
 from types import ModuleType, TracebackType
 from typing import (
-    Generator, TYPE_CHECKING, Optional, Tuple, Union, List, ItemsView,
+    TYPE_CHECKING, Optional, Tuple, Union, List, Any, ItemsView,
     KeysView, Dict, ValuesView, Iterator, BinaryIO, AnyStr,
     Callable, TypeVar, Type, overload
 )
@@ -2364,6 +2364,18 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
 
         return dump_handler(
             self.to_json_dict(bulk_data_threshold, bulk_data_element_handler))
+
+    def __getstate__(self) -> Dict[str, Any]:
+        # pickle cannot handle weakref - remove parent
+        d = self.__dict__.copy()
+        del d['parent']
+        return d
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        # re-add parent - it will be set to the parent dataset on demand
+        # if the dataset is in a sequence
+        self.__dict__['parent'] = None
 
     __repr__ = __str__
 

--- a/pydicom/sequence.py
+++ b/pydicom/sequence.py
@@ -4,8 +4,8 @@
 Sequence is a list of pydicom Dataset objects.
 """
 from typing import (
-    Iterable, Optional, List, cast, Union, overload, MutableSequence
-)
+    Iterable, Optional, List, cast, Union, overload, MutableSequence,
+    Dict, Any)
 import weakref
 
 from pydicom.dataset import Dataset
@@ -149,3 +149,14 @@ class Sequence(MultiValue[Dataset]):
     def __repr__(self) -> str:  # type: ignore[override]
         """String representation of the Sequence."""
         return f"<{self.__class__.__name__}, length {len(self)}>"
+
+    def __getstate__(self) -> Dict[str, Any]:
+        # pickle cannot handle weakref - remove _parent
+        d = self.__dict__.copy()
+        del d['_parent']
+        return d
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        # re-add _parent - it will be set to the parent dataset on demand
+        self.__dict__['_parent'] = None


### PR DESCRIPTION
- weakref is removed on pickling and re-added during unpickling
- fixes #1278

<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

Just removing and re-adding the weakref seems to do the trick, and I couldn't find a scenario where it will not be set to the correct value afterwards, but I may have overlooked something.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
