### PR TITLE
[MRG] Set values for VRs of AT using Tag()

### DIFF
--- a/doc/guides/element_value_types.rst
+++ b/doc/guides/element_value_types.rst
@@ -31,9 +31,6 @@ ensure that the value gets written correctly?
 
 * **SQ** element values should be set using a :class:`list` of zero or more
   :class:`~dataset.Dataset` instances.
-* To ensure **AT** elements are encoded correctly, their values should be set
-  using the 8-byte integer form of the tag - such as ``0x00100020`` for the tag
-  (0010,0020) - and not as a 2-tuple or 2-list.
 
 
 +----+------------------+-----------------+-----------------------------------+
@@ -44,19 +41,20 @@ ensure that the value gets written correctly?
 +----+------------------+-----------------+-----------------------------------+
 | AS | Age String       | :class:`str`    | :class:`str`                      |
 +----+------------------+-----------------+-----------------------------------+
-| AT | Attribute Tag    | :class:`int`    | :class:`int`                      |
+| AT | Attribute Tag    | Tag             | :class:`~tag.BaseTag`             |
+|    |                  | :sup:`1`        |                                   |
 +----+------------------+-----------------+-----------------------------------+
 | CS | Code String      | :class:`str`    | :class:`str`                      |
 +----+------------------+-----------------+-----------------------------------+
 | DA | Date             | :class:`str`    | :class:`str` or                   |
-|    |                  |                 | :class:`~valuerep.DA`\ :sup:`1`   |
+|    |                  |                 | :class:`~valuerep.DA`\ :sup:`2`   |
 +----+------------------+-----------------+-----------------------------------+
 | DS | Decimal String   | :class:`str`,   | :class:`~valuerep.DSfloat` or     |
 |    |                  | :class:`float`  | :class:`~valuerep.DSdecimal`\     |
-|    |                  | or :class:`int` | :sup:`2`                          |
+|    |                  | or :class:`int` | :sup:`3`                          |
 +----+------------------+-----------------+-----------------------------------+
 | DT | Date Time        | :class:`str`    | :class:`str` or                   |
-|    |                  |                 | :class:`~valuerep.DT`\ :sup:`1`   |
+|    |                  |                 | :class:`~valuerep.DT`\ :sup:`2`   |
 +----+------------------+-----------------+-----------------------------------+
 | FL | Floating Point   | :class:`float`  | :class:`float`                    |
 |    | Single           |                 |                                   |
@@ -101,7 +99,7 @@ ensure that the value gets written correctly?
 |    | Very Long        |                 |                                   |
 +----+------------------+-----------------+-----------------------------------+
 | TM | Time             | :class:`str`    | :class:`str` or                   |
-|    |                  |                 | :class:`~valuerep.TM`\ :sup:`1`   |
+|    |                  |                 | :class:`~valuerep.TM`\ :sup:`2`   |
 +----+------------------+-----------------+-----------------------------------+
 | UC | Unlimited        | :class:`str`    | :class:`str`                      |
 |    | Characters       |                 |                                   |
@@ -123,7 +121,8 @@ ensure that the value gets written correctly?
 |    | Very Long        |                 |                                   |
 +----+------------------+-----------------+-----------------------------------+
 
-| :sup:`1` If :attr:`config.datetime_conversion<config.datetime_conversion>`
+| :sup:`1` Any type accepted by :func:`~tag.Tag` can be used
+| :sup:`2` If :attr:`config.datetime_conversion<config.datetime_conversion>`
   = ``True`` (default ``False``)
-| :sup:`2` If :attr:`config.use_DS_decimal<config.use_DS_decimal>`
+| :sup:`3` If :attr:`config.use_DS_decimal<config.use_DS_decimal>`
   = ``True`` (default ``False``)

--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -3,7 +3,10 @@ Version 2.2.0
 
 Changelog
 ---------
-* 
+* Data elements with a VR of **AT** must now be set with values
+  acceptable to :func:`~pydicom.tag.Tag`, and are always stored as a
+  :class:`~pydicom.tag.BaseTag`.  Previously, any Python type could be
+  set.
 
 Enhancements
 ............
@@ -13,14 +16,14 @@ Enhancements
       from scratch.
   Please see the :ref:`cli_guide` for examples and details
   of all the options for each command.
-* A field containing an invalid number of bytes will result in a warning 
-  instead of an exception when 
+* A field containing an invalid number of bytes will result in a warning
+  instead of an exception when
   :attr:`~pydicom.config.convert_wrong_length_to_UN` is set to True.
 
 
 Changes
 .......
-* 
+*
 
 Fixes
 .....

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -527,6 +527,8 @@ class DataElement:
             return UID(val) if val is not None else None
         elif self.VR == "PN":
             return PersonName(val)
+        elif self.VR == "AT" and val:
+            return val if isinstance(val, BaseTag) else Tag(val)
         # Later may need this for PersonName as for UI,
         #    but needs more thought
         # elif self.VR == "PN":


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

I noticed a comment on the [Element VRs and types page](https://pydicom.github.io/pydicom/stable/guides/element_value_types.html) about having to be careful setting **AT** values, which seemed it should be unnecessary with this small change.  Also, the table had the stored value as `int`, rather than `BaseTag`, which is actually what is used when read from file (and will be guaranteed now with this change).

This PR checks for **AT** on setting a data element and converts using `Tag` so it will always be a `BaseTag` stored, and invalid `Tag` values will generate an error.  All forms accepted by `Tag`, including DICOM keywords, are accepted.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [x] Preview link (CircleCI -> Artifacts -> [Element types page](https://2649-14006067-gh.circle-artifacts.com/0/doc/_build/html/guides/element_value_types.html);  [Release notes](https://2649-14006067-gh.circle-artifacts.com/0/doc/_build/html/release_notes/v2.2.0.html)
- [x] Unit tests passing and overall coverage the same or better
