### PR TITLE
[MRG] fix numerical json export bug

### DIFF
--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -29,3 +29,5 @@ Fixes
 .....
 * Fixed pickling a :class:`~pydicom.dataset.Dataset` instance with sequences
   after the sequence had been read (:issue:`1278`)
+* Fixed JSON export of numeric values
+  

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -365,7 +365,7 @@ class DataElement:
                 else:
                     value = [self.value]
                 json_element['Value'] = [v for v in value]
-        if hasattr(json_element, 'Value'):
+        if 'Value' in json_element:
             json_element['Value'] = jsonrep.convert_to_python_number(
                 json_element['Value'], self.VR
             )

--- a/pydicom/tests/test_json.py
+++ b/pydicom/tests/test_json.py
@@ -379,7 +379,7 @@ class TestBinary:
 
 
 class TestNumeric:
-    def test_numeric(self):
+    def test_numeric_values(self):
         ds = Dataset()
 
         ds.add_new(0x0009100b, 'UL', 3000000000)
@@ -404,3 +404,27 @@ class TestNumeric:
         assert ds_json['00091015']['Value'] == [3.14159265]
         assert ds_json['00091102']['Value'] == [2]
 
+    def test_numeric_types(self):
+        ds = Dataset()
+
+        ds.add_new(0x0009100b, 'UL', 3000000000)
+        ds.add_new(0x0009100c, 'SL', -2000000000)
+        ds.add_new(0x0009100d, 'US', 40000)
+        ds.add_new(0x0009100e, 'SS', -22222)
+        ds.add_new(0x0009100f, 'FL', 3.14)
+        ds.add_new(0x00091010, 'FD', 3.14159265)
+        ds.add_new(0x00091014, 'IS', '42')
+        ds.add_new(0x00091015, 'DS', '3.14159265')
+        ds.add_new(0x00091102, 'US', 2)
+
+        ds_json = ds.to_json_dict()
+
+        assert type(ds_json['0009100B']['Value'][0]) == int
+        assert type(ds_json['0009100C']['Value'][0]) == int
+        assert type(ds_json['0009100D']['Value'][0]) == int
+        assert type(ds_json['0009100E']['Value'][0]) == int
+        assert type(ds_json['0009100F']['Value'][0]) == float
+        assert type(ds_json['00091010']['Value'][0]) == float
+        assert type(ds_json['00091014']['Value'][0]) == int
+        assert type(ds_json['00091015']['Value'][0]) == float
+        assert type(ds_json['00091102']['Value'][0]) == int

--- a/pydicom/tests/test_json.py
+++ b/pydicom/tests/test_json.py
@@ -376,3 +376,31 @@ class TestBinary:
         ds = Dataset().from_json(json.dumps(json_data), bulk_data_reader)
 
         assert b'xyzzy' == ds[0x003a0200].value[0][0x54001010].value
+
+
+class TestNumeric:
+    def test_numeric(self):
+        ds = Dataset()
+
+        ds.add_new(0x0009100b, 'UL', 3000000000)
+        ds.add_new(0x0009100c, 'SL', -2000000000)
+        ds.add_new(0x0009100d, 'US', 40000)
+        ds.add_new(0x0009100e, 'SS', -22222)
+        ds.add_new(0x0009100f, 'FL', 3.14)
+        ds.add_new(0x00091010, 'FD', 3.14159265)
+        ds.add_new(0x00091014, 'IS', '42')
+        ds.add_new(0x00091015, 'DS', '3.14159265')
+        ds.add_new(0x00091102, 'US', 2)
+
+        ds_json = ds.to_json_dict()
+
+        assert ds_json['0009100B']['Value'] == [3000000000]
+        assert ds_json['0009100C']['Value'] == [-2000000000]
+        assert ds_json['0009100D']['Value'] == [40000]
+        assert ds_json['0009100E']['Value'] == [-22222]
+        assert ds_json['0009100F']['Value'] == [3.14]
+        assert ds_json['00091010']['Value'] == [3.14159265]
+        assert ds_json['00091014']['Value'] == [42]
+        assert ds_json['00091015']['Value'] == [3.14159265]
+        assert ds_json['00091102']['Value'] == [2]
+


### PR DESCRIPTION
#### Describe the changes
It is incorrect to check for presence of keys in a dictionary object using `hasattr`. This will always return `False` and thus will never run the numerical conversion. 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
