### PR TITLE
Remove warning for attempted switch to implicit VR

### DIFF
--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -21,6 +21,9 @@ Enhancements
   :attr:`~pydicom.config.convert_wrong_length_to_UN` is set to True.
 * Private tags known via the private dictionary will now get the configured
   VR if read from a dataset instead of "UN" (:issue:`1051`).
+* while reading explicit VR, a switch to implicit VR will be silently attempted
+  if the VR bytes are not valid VR characters, and config option
+  :attr:`~pydicom.config.assume_implicit_vr_switch` is ``True`` (default)
 
 
 Changes

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -142,14 +142,8 @@ def data_element_generator(fp,
             # defend against switching to implicit VR, some writer do in SQ's
             # issue 1067, issue 1035
 
-            if config.assume_implicit_vr_switch and not (b'AA' <= VR <= b'ZZ'):
-                # invalid VR, must be two cap chrs
-                message = (
-                    "Explicit VR character(s) invalid. "
-                    "Assuming data element is implicit VR "
-                    "and attempting to continue"
-                )
-                warnings.warn(message, UserWarning)
+            if not (b'AA' <= VR <= b'ZZ') and config.assume_implicit_vr_switch:
+                # invalid VR, must be 2 cap chrs, assume implicit and continue
                 VR = None
                 group, elem, length = implicit_VR_struct.unpack(bytes_read)
             else:


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
Remove UserWarning when do implied switch to implicit VR; the need for this to be removed was noted in #1305. 

Also added line in release notes about the feature and config option (missing when it was originally introduced).

#### Tasks
- [ ] ~~Unit tests added that reproduce the issue or prove feature is working~~
- [x] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
