### PR TITLE
[MRG] Person Name Constructors

### DIFF
--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -650,6 +650,111 @@ class TestPersonName:
         assert ("o" in pn1) == True
         assert ("x" in pn1) == False
 
+    def test_from_named_components(self):
+        # Example from DICOM standard, part 5, sect 6.2.1.1
+        pn = PersonName.from_named_components(
+            family_name='Adams',
+            given_name='John Robert Quincy',
+            name_prefix='Rev.',
+            name_suffix='B.A. M.Div.'
+        )
+        assert pn == 'Adams^John Robert Quincy^^Rev.^B.A. M.Div.'
+        assert pn.family_name == 'Adams'
+        assert pn.given_name == 'John Robert Quincy'
+        assert pn.name_prefix == 'Rev.'
+        assert pn.name_suffix == 'B.A. M.Div.'
+
+    def test_from_named_components_kr_from_bytes(self):
+        # Example name from PS3.5-2008 section I.2 p. 108
+        pn = PersonName.from_named_components(
+            family_name='Hong',
+            given_name='Gildong',
+            family_name_ideographic=b'\033$)C\373\363',
+            given_name_ideographic=b'\033$)C\321\316\324\327',
+            family_name_phonetic=b'\033$)C\310\253',
+            given_name_phonetic=b'\033$)C\261\346\265\277',
+            encodings=[default_encoding, 'euc_kr'],
+        )
+        pn = pn.decode()
+        assert ("Hong", "Gildong") == (pn.family_name, pn.given_name)
+        assert "洪^吉洞" == pn.ideographic
+        assert "홍^길동" == pn.phonetic
+
+    def test_from_named_components_kr_from_unicode(self):
+        # Example name from PS3.5-2008 section I.2 p. 108
+        pn = PersonName.from_named_components(
+            family_name='Hong',
+            given_name='Gildong',
+            family_name_ideographic='洪',
+            given_name_ideographic='吉洞',
+            family_name_phonetic='홍',
+            given_name_phonetic='길동',
+            encodings=[default_encoding, 'euc_kr'],
+        )
+        pn = pn.decode()
+        assert ("Hong", "Gildong") == (pn.family_name, pn.given_name)
+        assert "洪^吉洞" == pn.ideographic
+        assert "홍^길동" == pn.phonetic
+
+    def test_from_named_components_jp_from_bytes(self):
+        # Example name from PS3.5-2008 section H  p. 98
+        pn = PersonName.from_named_components(
+            family_name='Yamada',
+            given_name='Tarou',
+            family_name_ideographic=b'\033$B;3ED\033(B',
+            given_name_ideographic=b'\033$BB@O:\033(B',
+            family_name_phonetic=b'\033$B$d$^$@\033(B',
+            given_name_phonetic=b'\033$B$?$m$&\033(B',
+            encodings=[default_encoding, 'iso2022_jp'],
+        )
+        pn = pn.decode()
+        assert ("Yamada", "Tarou") == (pn.family_name, pn.given_name)
+        assert "山田^太郎" == pn.ideographic
+        assert "やまだ^たろう" == pn.phonetic
+
+    def test_from_named_components_jp_from_unicode(self):
+        # Example name from PS3.5-2008 section H  p. 98
+        pn = PersonName.from_named_components(
+            family_name='Yamada',
+            given_name='Tarou',
+            family_name_ideographic='山田',
+            given_name_ideographic='太郎',
+            family_name_phonetic='やまだ',
+            given_name_phonetic='たろう',
+            encodings=[default_encoding, 'iso2022_jp'],
+        )
+        pn = pn.decode()
+        assert ("Yamada", "Tarou") == (pn.family_name, pn.given_name)
+        assert "山田^太郎" == pn.ideographic
+        assert "やまだ^たろう" == pn.phonetic
+
+    def test_from_named_components_veterinary(self):
+        # Example from DICOM standard, part 5, sect 6.2.1.1
+        # A horse whose responsible organization is named ABC Farms, and whose
+        # name is "Running On Water"
+        pn = PersonName.from_named_components_veterinary(
+            responsible_party_name='ABC Farms',
+            patient_name='Running on Water',
+        )
+        assert pn == 'ABC Farms^Running on Water'
+        assert pn.family_name == 'ABC Farms'
+        assert pn.given_name == 'Running on Water'
+
+    def test_from_named_components_with_separator(self):
+        # If the names already include separator chars
+        # a ValueError should be raised
+        with pytest.raises(ValueError):
+            PersonName.from_named_components(given_name='Yamada^Tarou')
+
+    def test_from_named_components_with_separator_from_bytes(self):
+        # If the names already include separator chars
+        # a ValueError should be raised
+        with pytest.raises(ValueError):
+            PersonName.from_named_components(
+                family_name_ideographic=b'\033$B;3ED\033(B^\033$BB@O:\033(B',
+                encodings=[default_encoding, 'iso2022_jp'],
+            )
+
 
 class TestDateTime:
     """Unit tests for DA, DT, TM conversion to datetime objects"""

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -996,7 +996,7 @@ class PersonName:
         name_suffix_phonetic: Union[str, bytes] = '',
         encodings: Optional[List[str]] = None,
     ) -> 'PersonName':
-        """Construct a PersonName from explicit named components
+        """Construct a PersonName from explicit named components.
 
         The DICOM standard describes human names using five components:
         family name, given name, middle name, name prefix, and name suffix.
@@ -1023,7 +1023,7 @@ class PersonName:
         name_prefix: Union[str, bytes]
             Name prefix in alphabetic form, e.g. 'Mrs.', 'Dr.', 'Sr.', 'Rev.'.
         name_suffix: Union[str, bytes]
-            Name prefix in alphabetic form, e.g. 'M.D.', 'B.A., M.Div.'.
+            Name prefix in alphabetic form, e.g. 'M.D.', 'B.A., M.Div.',
             'Chief Executive Officer'.
         family_name_ideographic: Union[str, bytes]
             Family name in ideographic form.
@@ -1053,10 +1053,35 @@ class PersonName:
         PersonName:
             PersonName constructed from the supplied components.
 
+        Example
+        -------
+        A case with multiple given names and suffixes (DICOM standard,
+        part 5, sect 6.2.1.1):
+
+        >>> pn = PersonName.from_named_components(
+                family_name='Adams',
+                given_name='John Robert Quincy',
+                name_prefix='Rev.',
+                name_suffix='B.A. M.Div.'
+            )
+
+        A Korean case with phonetic and ideographic representations (PS3.5-2008
+        section I.2 p. 108):
+
+        >>> pn = PersonName.from_named_components(
+                family_name='Hong',
+                given_name='Gildong',
+                family_name_ideographic='洪',
+                given_name_ideographic='吉洞',
+                family_name_phonetic='홍',
+                given_name_phonetic='길동',
+                encodings=[default_encoding, 'euc_kr']
+            )
+
         Notes
         -----
         Strings may not contain the following characters: '^', '=',
-        '\\' (single backslash).
+        or the backslash character.
 
         """  # noqa: E501
         # Alphatic component group
@@ -1148,10 +1173,21 @@ class PersonName:
         PersonName:
             PersonName constructed from the supplied components
 
+        Example
+        -------
+        Example from the DICOM standard, part 5, sect 6.2.1.1: A horse whose
+        responsible organization is named ABC Farms, and whose name
+        is "Running On Water"
+
+        >>> pn = PersonName.from_named_components_veterinary(
+                responsible_party_name='ABC Farms',
+                patient_name='Running on Water'
+            )
+
         Notes
         -----
         Strings may not contain the following characters: '^', '=',
-        '\\' (single backslash)
+        or the backslash character.
 
         """  # noqa: E501
         # Alphatic component group

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -653,6 +653,13 @@ class PersonName:
         original_string: str, optional
             When creating a ``PersonName`` using a decoded string, this is the
             original encoded value.
+
+        Notes
+        -----
+        A :class:`PersonName` may also be constructed by specifying individual
+        components using the :meth:`from_named_components` and
+        :meth:`from_named_components_veterinary` classmethods.
+
         """
         self.original_string: Union[None, str, bytes] = None
         self._components = None
@@ -928,13 +935,13 @@ class PersonName:
             If any of the input strings contain disallowed characters:
             '\\' (single backslash), '^', '='.
         """
-        from pydicom.charset import encode_string, decode_string
+        from pydicom.charset import encode_string, decode_bytes
 
         def enc(s: str) -> bytes:
             return encode_string(s, encodings or [default_encoding])
 
         def dec(s: bytes) -> str:
-            return decode_string(s, encodings or [default_encoding], [])
+            return decode_bytes(s, encodings or [default_encoding], [])
 
         encoded_component_sep = enc('^')
         encoded_group_sep = enc('=')
@@ -963,7 +970,7 @@ class PersonName:
             return val_enc
 
         def make_component_group(components: List[Union[str, bytes]]):
-            encoded_components = map(standardize_encoding, components)
+            encoded_components = [standardize_encoding(c) for c in components]
             joined_components = encoded_component_sep.join(encoded_components)
             return joined_components.rstrip(encoded_component_sep)
 
@@ -1008,9 +1015,9 @@ class PersonName:
         phonetic form in addition to (or instead of) alphabetic form.
 
         For more information see the following parts of the DICOM standard:
-        - `Value Representations <http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html>`_
-        - `PN Examples <http://dicom.nema.org/dicom/2013/output/chtml/part05/sect_6.2.html#sect_6.2.1.1>`_
-        - `PN Precise semantics <http://dicom.nema.org/dicom/2013/output/chtml/part05/sect_6.2.html#sect_6.2.1.1>`_
+        - :dcm:`Value Representations <part05/sect_6.2.html>`
+        - :dcm:`PN Examples <part05/sect_6.2.html#sect_6.2.1.1>`
+        - :dcm:`PN Precise semantics <part05/sect_6.2.html#sect_6.2.1.2>`
 
         Parameters
         ----------
@@ -1138,8 +1145,7 @@ class PersonName:
         responsible party family name OR responsible party organization name,
         and patient name.
         Any component may be an empty string (the default) if not used.
-        A component may contain multiple space-separated words if there
-        are, for example, multiple given names, middle names, or titles.
+        A component may contain multiple space-separated words if necessary.
 
         Additionally, each component may be represented in ideographic or
         phonetic form in addition to (or instead of) alphabetic form.


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes

Two alternative constructors for the `pydicom.valuerep.PersonName` attribute are added using classmethods: `PersonName.from_named_components()` and `PersonName.from_named_components_veterinary()`. The purpose of these is to allow users to construct person names correctly in a more intuitive way than is currently possible, without having to understand or implement the low level details about how the parts of names are ordered and joined together. Here is an example taken from the [examples](http://dicom.nema.org/dicom/2013/output/chtml/part05/sect_6.2.html#sect_6.2.1.1) in the DICOM standard:

```python
from pydicom.valuerep import PersonName

# In the current version of pydicom, to construct this name correctly the user would have to do this:
pn = PersonName('Adams^John Robert Quincy^^Rev.^B.A. M.Div.')

# Now they have the option to instead do this, which is less error prone and makes user code much more readable
pn = PersonName.from_named_components(
    family_name='Adams',
    given_name='John Robert Quincy',
    name_prefix='Rev.',
    name_suffix='B.A. M.Div.'
)
assert pn == 'Adams^John Robert Quincy^^Rev.^B.A. M.Div.'  # passes
```

Since there are different uses for the components in the case of veterinary use, I have implemented an alternative constructor for this case.

I have added full tests and documentation with examples.

This PR was inspired by discussion [here](https://github.com/MGHComputationalPathology/highdicom/issues/56) with @darcymason  and others.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [x] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better

There are unrelated warnings during the documentation building process
