### PR TITLE
[MRG] Add option to suppress exception and continue serialization

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -2299,8 +2299,8 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
             JSON representation of the data element (dictionary including the
             "vr" key and either the "InlineBinary" or the "BulkDataURI" key).
         suppress_invalid_tags : bool, optional
-            Flag to specify if errors while serializing tags should be logged and the
-            tag dropped or if the error should be bubbled up.
+            Flag to specify if errors while serializing tags should be logged
+            and the tag dropped or if the error should be bubbled up.
 
         Returns
         -------
@@ -2356,8 +2356,8 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
                 Make sure to use a dump handler that sorts the keys (see
                 example below) to create DICOM-conformant JSON.
         suppress_invalid_tags : bool, optional
-            Flag to specify if errors while serializing tags should be logged and the
-            tag dropped or if the error should be bubbled up.
+            Flag to specify if errors while serializing tags should be logged
+            and the tag dropped or if the error should be bubbled up.
 
         Returns
         -------

--- a/pydicom/tests/test_json.py
+++ b/pydicom/tests/test_json.py
@@ -270,6 +270,18 @@ class TestDataSetToJson:
         assert ds_json.index('"00100020"') < ds_json.index('"00100030"')
         assert ds_json.index('"00100030"') < ds_json.index('"00100040"')
 
+    def test_suppress_invalid_tags(self):
+        """Test tags that raise exceptions don't raise if suppress_invalid_tags True."""
+        ds = Dataset()
+        ds.add_new(0x00100010, 'PN', ['Jane^Doe'])
+
+        with pytest.raises(Exception):
+            ds.to_json_dict()
+
+        ds_json = ds.to_json_dict(suppress_invalid_tags=True)
+
+        assert ds_json.get("00100010") is None
+
 
 class TestSequence:
     def test_nested_sequences(self):

--- a/pydicom/tests/test_json.py
+++ b/pydicom/tests/test_json.py
@@ -271,7 +271,8 @@ class TestDataSetToJson:
         assert ds_json.index('"00100030"') < ds_json.index('"00100040"')
 
     def test_suppress_invalid_tags(self):
-        """Test tags that raise exceptions don't raise if suppress_invalid_tags True."""
+        """Test tags that raise exceptions don't if suppress_invalid_tags True.
+        """
         ds = Dataset()
         ds.add_new(0x00100010, 'PN', ['Jane^Doe'])
 


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
Add an option to the `to_json` and `to_json_dict` methods for the dataset class that will catch the exception raised when a tag fails to be converted to a json dictionary, and drop the key from the result. An error level message is always logged.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [x] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
