### PR TITLE
[MRG] Check for invalid DSs and add function to correctly truncate

### DIFF
--- a/doc/reference/elem.valuerep.rst
+++ b/doc/reference/elem.valuerep.rst
@@ -12,6 +12,8 @@ or TM and utilities.
    :toctree: generated/
 
    DA
+   is_valid_ds
+   format_number_as_ds
    DS
    DSdecimal
    DSfloat

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -29,3 +29,4 @@ This API reference guide details the functions, modules and objects included in
    fileio
    misc
    uid
+   valuerep

--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -14,6 +14,7 @@ Enhancements
     * ``show``: display all or part of a DICOM file
     * ``codify`` to produce Python code for writing files or sequence items
       from scratch.
+
   Please see the :ref:`cli_guide` for examples and details
   of all the options for each command.
 * A field containing an invalid number of bytes will result in a warning
@@ -24,6 +25,20 @@ Enhancements
 * while reading explicit VR, a switch to implicit VR will be silently attempted
   if the VR bytes are not valid VR characters, and config option
   :attr:`~pydicom.config.assume_implicit_vr_switch` is ``True`` (default)
+* New functionality to help with correct formatting of decimal strings (DS)
+    * Added :func:`~pydicom.valuerep.is_valid_ds` to check whether a string is
+      valid as a DICOM decimal string (DS) and
+      :func:`~pydicom.valuerep.format_number_as_ds` to format a given ``float``
+      or ``Decimal`` as a DS while retaining the highest possible level of
+      precision
+    * If :attr:`~pydicom.config.enforce_valid_values` is set to ``True``, all
+      DS objects created will be checked for the validity of their string
+      representations.
+    * Added optional ``auto_format`` parameter to the init methods of
+      :class:`~pydicom.valuerep.DSfloat` and
+      :class:`~pydicom.valuerep.DSdecimal` and the :func:`~pydicom.valuerep.DS`
+      factory function to allow explicitly requesting automatic formatting of
+      the string representations of these objects when they are constructed.
 
 
 Changes

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -309,9 +309,17 @@ class TestTruncateFloatForDS:
         'val', [float('-nan'), float('nan'), float('-inf'), float('inf')]
     )
     def test_invalid(self, val: float):
-        """Test non-finite floating point number raise an error"""
+        """Test non-finite floating point numbers raise an error"""
         with pytest.raises(ValueError):
             pydicom.valuerep.truncate_float_for_ds(val)
+
+    def test_wrong_type(self):
+        """Test calling with a string raises an error"""
+        with pytest.raises(
+            TypeError,
+            match="'val' must be of type float or decimal.Decimal"
+        ):
+            pydicom.valuerep.truncate_float_for_ds('1.0')
 
 
 class TestDS:

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -283,9 +283,9 @@ class TestTruncateFloatForDS:
             [1.7976931348623157e+308, '1.797693135e+308'],
         ]
     )
-    def test_truncate(self, val: float, expected_str: str):
+    def test_auto_format(self, val: float, expected_str: str):
         """Test truncation of some basic values."""
-        assert pydicom.valuerep.truncate_float_for_ds(val) == expected_str
+        assert pydicom.valuerep.format_number_as_ds(val) == expected_str
 
     @pytest.mark.parametrize(
         'exp', [-101, -100, 100, 101] + list(range(-16, 17))
@@ -293,7 +293,7 @@ class TestTruncateFloatForDS:
     def test_powers_of_pi(self, exp: int):
         """Raise pi to various powers to test truncation."""
         val = math.pi * 10 ** exp
-        s = pydicom.valuerep.truncate_float_for_ds(val)
+        s = pydicom.valuerep.format_number_as_ds(val)
         assert self.check_valid(s)
 
     @pytest.mark.parametrize(
@@ -302,7 +302,7 @@ class TestTruncateFloatForDS:
     def test_powers_of_negative_pi(self, exp: int):
         """Raise negative pi to various powers to test truncation."""
         val = -math.pi * 10 ** exp
-        s = pydicom.valuerep.truncate_float_for_ds(val)
+        s = pydicom.valuerep.format_number_as_ds(val)
         assert self.check_valid(s)
 
     @pytest.mark.parametrize(
@@ -311,7 +311,7 @@ class TestTruncateFloatForDS:
     def test_invalid(self, val: float):
         """Test non-finite floating point numbers raise an error"""
         with pytest.raises(ValueError):
-            pydicom.valuerep.truncate_float_for_ds(val)
+            pydicom.valuerep.format_number_as_ds(val)
 
     def test_wrong_type(self):
         """Test calling with a string raises an error"""
@@ -319,7 +319,7 @@ class TestTruncateFloatForDS:
             TypeError,
             match="'val' must be of type float or decimal.Decimal"
         ):
-            pydicom.valuerep.truncate_float_for_ds('1.0')
+            pydicom.valuerep.format_number_as_ds('1.0')
 
 
 class TestDS:
@@ -380,29 +380,29 @@ class TestDSfloat:
         assert 1.2345 == y
         assert "1.2345" == y.original_string
 
-    def test_truncate(self, enforce_valid_both_fixture):
+    def test_auto_format(self, enforce_valid_both_fixture):
         """Test truncating floats"""
-        x = pydicom.valuerep.DSfloat(math.pi, truncate=True)
+        x = pydicom.valuerep.DSfloat(math.pi, auto_format=True)
 
         # Float representation should be unaltered by truncation
         assert x == math.pi
-        # String representations should be correctly truncated
+        # String representations should be correctly formatted
         assert str(x) == '3.14159265358979'
         assert repr(x) == '"3.14159265358979"'
 
-    def test_truncate_invalid_string(self, enforce_valid_both_fixture):
-        """If the user supplies an invalid string, this should be truncated."""
-        x = pydicom.valuerep.DSfloat('3.141592653589793', truncate=True)
+    def test_auto_format_invalid_string(self, enforce_valid_both_fixture):
+        """If the user supplies an invalid string, this should be formatted."""
+        x = pydicom.valuerep.DSfloat('3.141592653589793', auto_format=True)
 
         # Float representation should be unaltered by truncation
         assert x == float('3.141592653589793')
-        # String representations should be correctly truncated
+        # String representations should be correctly formatted
         assert str(x) == '3.14159265358979'
         assert repr(x) == '"3.14159265358979"'
 
-    def test_truncate_valid_string(self, enforce_valid_both_fixture):
+    def test_auto_format_valid_string(self, enforce_valid_both_fixture):
         """If the user supplies a valid string, this should not be altered."""
-        x = pydicom.valuerep.DSfloat('1.234e-1', truncate=True)
+        x = pydicom.valuerep.DSfloat('1.234e-1', auto_format=True)
 
         # Float representation should be correct
         assert x == 0.1234
@@ -479,23 +479,23 @@ class TestDSdecimal:
         x = pydicom.valuerep.DSdecimal('1.2345')
         assert '"1.2345"' == repr(x)
 
-    def test_truncate(self, enforce_valid_both_fixture):
+    def test_auto_format(self, enforce_valid_both_fixture):
         """Test truncating decimal"""
-        x = pydicom.valuerep.DSdecimal(Decimal(math.pi), truncate=True)
+        x = pydicom.valuerep.DSdecimal(Decimal(math.pi), auto_format=True)
 
         # Decimal representation should be unaltered by truncation
         assert x == Decimal(math.pi)
-        # String representations should be correctly truncated
+        # String representations should be correctly formatted
         assert str(x) == '3.14159265358979'
         assert repr(x) == '"3.14159265358979"'
 
-    def test_truncate_invalid_string(self, enforce_valid_both_fixture):
-        """If the user supplies an invalid string, this should be truncated."""
-        x = pydicom.valuerep.DSdecimal('3.141592653589793', truncate=True)
+    def test_auto_format_invalid_string(self, enforce_valid_both_fixture):
+        """If the user supplies an invalid string, this should be formatted."""
+        x = pydicom.valuerep.DSdecimal('3.141592653589793', auto_format=True)
 
         # Decimal representation should be unaltered by truncation
         assert x == Decimal('3.141592653589793')
-        # String representations should be correctly truncated
+        # String representations should be correctly formatted
         assert str(x) == '3.14159265358979'
         assert repr(x) == '"3.14159265358979"'
 
@@ -515,9 +515,9 @@ class TestDSdecimal:
         with pytest.raises(ValueError):
             valuerep.DSdecimal(val)
 
-    def test_truncate_valid_string(self, enforce_valid_both_fixture):
+    def test_auto_format_valid_string(self, enforce_valid_both_fixture):
         """If the user supplies a valid string, this should not be altered."""
-        x = pydicom.valuerep.DSdecimal('1.234e-1', truncate=True)
+        x = pydicom.valuerep.DSdecimal('1.234e-1', auto_format=True)
 
         # Decimal representation should be correct
         assert x == Decimal('1.234e-1')

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -243,6 +243,7 @@ class TestIsValidDS:
             '1 000',              # no embedded spaces
             '127.0.0.1',          # not a number
             '1.e',                # not a number
+            '',
         ]
     )
     def test_invalid(self, s: str):

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -647,13 +647,6 @@ class TestDecimalString:
         assert isinstance(ds, valuerep.DSdecimal)
         assert len(str(ds)) <= 16
 
-        # Now the input string is too long but decimal.Decimal can convert it
-        # to a valid 16-character string
-        long_str = "-0.000000981338674"
-        ds = valuerep.DS(long_str)
-        assert isinstance(ds, valuerep.DSdecimal)
-        assert len(str(ds)) <= 16
-
     def test_invalid_decimal_strings(self, enforce_valid_values):
         # Now the input string truly is invalid
         invalid_string = "-9.813386743e-006"

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -364,7 +364,7 @@ def is_valid_ds(s: str) -> bool:
 
     # Check that the string can be successfully cast to float
     try:
-        val = float(s)
+        float(s)
     except ValueError:
         return False
 
@@ -372,7 +372,7 @@ def is_valid_ds(s: str) -> bool:
     return True
 
 
-def truncate_float_for_ds(val: float) -> str:
+def truncate_float_for_ds(val: Union[float, Decimal]) -> str:
     """Truncate a float's representation to give a valid Decimal String (DS).
 
     DICOM's decimal string (DS) representation is limited to strings with 16
@@ -388,7 +388,7 @@ def truncate_float_for_ds(val: float) -> str:
 
     Parameters
     ----------
-    val: float
+    val: Union[float, Decimal]
         The floating point value whose representation is required.
 
     Returns
@@ -403,10 +403,12 @@ def truncate_float_for_ds(val: float) -> str:
         If val does not represent a finite value
 
     """
+    if not isinstance(val, (float, Decimal)):
+        raise TypeError("'val' must be of type float or decimal.Decimal")
     if not isfinite(val):
         raise ValueError(
             "Cannot encode non-finite floats as DICOM decimal strings. "
-            f"Got {val}"
+            f"Got '{val}'"
         )
 
     valstr = str(val)
@@ -456,43 +458,70 @@ class DSfloat(float):
     If constructed from an empty string, return the empty string,
     not an instance of this class.
 
+    Parameters
+    ----------
+    val: Union[str, int, float, Decimal]
+        Value to store as a DS.
+    truncate: bool
+        If True, automatically truncate the string representation of this
+        number to ensure it satisfies the constraints in the DICOM standard.
+        Note that this will lead to loss of precision for some numbers.
+
     """
     def __init__(
         self, val: Union[str, int, float, Decimal],
-        truncate_on_write: bool = False
+        truncate: bool = False
     ) -> None:
         """Store the original string if one given, for exact write-out of same
         value later.
         """
         # ... also if user changes a data element value, then will get
         # a different object, because float is immutable.
-        self.truncate_on_write = truncate_on_write
         has_attribute = hasattr(val, 'original_string')
         if isinstance(val, str):
             self.original_string = val
         elif isinstance(val, (DSfloat, DSdecimal)) and has_attribute:
             self.original_string = val.original_string
 
-        if not is_valid_ds(str(self)) and config.enforce_valid_values:
-            if not truncate_on_write:
+        self.truncate = truncate
+        if self.truncate:
+            # If truncate is True, keep the float value the same, but change
+            # the string representation stored in original_string if necessary
+            if hasattr(self, 'original_string'):
+                if not is_valid_ds(self.original_string):
+                    self.original_string = truncate_float_for_ds(
+                        float(self.original_string)
+                    )
+            else:
+                self.original_string = truncate_float_for_ds(self)
+
+        if config.enforce_valid_values:
+            if len(repr(self).strip('"')) > 16:
                 raise OverflowError(
                     "Values for elements with a VR of 'DS' must be <= 16 "
                     "characters long, but the float provided requires > 16 "
                     "characters to be accurately represented. Use a smaller "
                     "string, set 'config.enforce_valid_values' to False to "
                     "override the length check, or explicitly construct a DS "
-                    "object with truncate_on_write set to True"
+                    "object with 'truncate' set to True"
+                )
+            if not is_valid_ds(repr(self).strip('"')):
+                # This will catch nan and inf
+                raise ValueError(
+                    f'Value "{str(self)}" is not valid for elements with a VR '
+                    'of DS'
                 )
 
     def __str__(self) -> str:
-        if hasattr(self, 'original_string'):
+        if hasattr(self, 'original_string') and not self.truncate:
             return self.original_string
 
         # Issue #937 (Python 3.8 compatibility)
         return repr(self)[1:-1]
 
     def __repr__(self) -> str:
-        # TODO truncate on write
+        if self.truncate and hasattr(self, 'original_string'):
+            return f'"{self.original_string}"'
         return f'"{super().__repr__()}"'
 
 
@@ -506,7 +535,8 @@ class DSdecimal(Decimal):
     """
     def __new__(
         cls: Type[_DSdecimal],
-        val: Union[str, int, float, Decimal]
+        val: Union[str, int, float, Decimal],
+        truncate: bool = False
     ) -> Optional[_DSdecimal]:
         """Create an instance of DS object, or return a blank string if one is
         passed in, e.g. from a type 2 DICOM blank value.
@@ -530,19 +560,13 @@ class DSdecimal(Decimal):
                 return None
 
         val = super().__new__(cls, val)
-        if len(str(val)) > 16 and config.enforce_valid_values:
-            raise OverflowError(
-                "Values for elements with a VR of 'DS' values must be <= 16 "
-                "characters long. Use a smaller string, set "
-                "'config.enforce_valid_values' to False to override the "
-                "length check, or use 'Decimal.quantize()' and initialize "
-                "with a 'Decimal' instance."
-            )
 
         return val
 
     def __init__(
-        self, val: Union[str, int, float, Decimal]
+        self,
+        val: Union[str, int, float, Decimal],
+        truncate: bool = False
     ) -> None:
         """Store the original string if one given, for exact write-out of same
         value later. E.g. if set ``'1.23e2'``, :class:`~decimal.Decimal` would
@@ -556,6 +580,35 @@ class DSdecimal(Decimal):
         elif isinstance(val, (DSfloat, DSdecimal)) and has_str:
             self.original_string = val.original_string
 
+        self.truncate = truncate
+        if self.truncate:
+            # If truncate is True, keep the float value the same, but change
+            # the string representation stored in original_string if necessary
+            if hasattr(self, 'original_string'):
+                if not is_valid_ds(self.original_string):
+                    self.original_string = truncate_float_for_ds(
+                        float(self.original_string)
+                    )
+            else:
+                self.original_string = truncate_float_for_ds(self)
+
+        if config.enforce_valid_values:
+            if len(repr(self).strip('"')) > 16:
+                raise OverflowError(
+                    "Values for elements with a VR of 'DS' values must be "
+                    "<= 16 characters long. Use a smaller string, set "
+                    "'config.enforce_valid_values' to False to override the "
+                    "length check, use 'Decimal.quantize()' and initialize "
+                    "with a 'Decimal' instance, or explicitly construct a DS "
+                    "instance with 'truncate' set to True"
+                )
+            if not is_valid_ds(repr(self).strip('"')):
+                # This will catch nan and inf
+                raise ValueError(
+                    f'Value "{str(self)}" is not valid for elements with a VR '
+                    'of DS'
+                )
+
     def __str__(self) -> str:
         has_str = hasattr(self, 'original_string')
         if has_str and len(self.original_string) <= 16:
@@ -564,6 +617,8 @@ class DSdecimal(Decimal):
         return super().__str__()
 
     def __repr__(self) -> str:
+        if self.truncate and hasattr(self, 'original_string'):
+            return f'"{self.original_string}"'
         return f'"{str(self)}"'
 
 
@@ -575,7 +630,8 @@ else:
 
 
 def DS(
-    val: Union[None, str, int, float, Decimal]
+    val: Union[None, str, int, float, Decimal],
+    truncate: bool = False
 ) -> Union[None, str, DSfloat, DSdecimal]:
     """Factory function for creating DS class instances.
 
@@ -593,7 +649,7 @@ def DS(
     if val == '' or val is None:
         return val
 
-    return DSclass(val)
+    return DSclass(val, truncate=truncate)
 
 
 class IS(int):

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -468,6 +468,13 @@ class DSfloat(float):
         Note that this will lead to loss of precision for some numbers.
 
     """
+    def __new__(
+            cls,
+            val: Union[str, int, float, Decimal],
+            truncate: bool = False
+    ) -> [_DSfloat]:
+        return super().__new__(cls, val)
+
     def __init__(
         self, val: Union[str, int, float, Decimal],
         truncate: bool = False

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -528,10 +528,20 @@ class DSfloat(float):
 class DSdecimal(Decimal):
     """Store value for an element with VR **DS** as :class:`decimal.Decimal`.
 
+    Parameters
+    ----------
+    val: Union[str, int, float, Decimal]
+        Value to store as a DS.
+    truncate: bool
+        If True, automatically truncate the string representation of this
+        number to ensure it satisfies the constraints in the DICOM standard.
+        Note that this will lead to loss of precision for some numbers.
+
     Notes
     -----
     If constructed from an empty string, returns the empty string, not an
     instance of this class.
+
     """
     def __new__(
         cls: Type[_DSdecimal],


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
As described in #1264, decimal strings (DS) must be 16 characters or fewer per the standard, but when using `DSfloat` pydicom will silently allow longer decimal strings even when `config.enforce_valid_values` is set to `True`. (There is an existing test for `DSdecimal`). Furthermore, though it is not mentioned in #1264, non-finite float values (`inf`, `nan`) can be silently stored as decimal strings even when `config.enforce_valid_values` is set to `True` even though this is also disallowed by the standard. This is also true for the non-finite values of `Decimal` (`Infinity` and `NaN`). There is also no functionality to allow users to format their DSs correctly, which I argue would be very useful for users as the process is not especially straightforward to do for arbitrary floats.

This PR attempts to fix all the above problems while being backwards compatible by:
- Adding a new function (`pydicom.valuerep.is_valid_ds`) to test whether a string is a valid DS
- Using this function to raise errors when `config.enforce_valid_values` is set to `True` and the user attempts to store an invalid decimal string (this is the one change that may break existing user code but arguably was always the expected behaviour).
- Adding a function (`pydicom.valuerep.truncate_float_for_ds`) to correctly truncate a `float` or `Decimal` into a valid DS while retaining as much precision in this representation as possible (through judicious use of scientific notation). This functionality would be available to users who want it, but they must explicitly call it (or use the new `truncate` parameter, next bullet point).
- Adding a new optional boolean parameter (default False) to the `DSfloat` and `DSdecimal` class `__init__` methods and the `DS` factory function that allow the user to construct these classes and explicitly request that the string representation be truncated in the correct way. In this case, the underlying float/Decimal value is unchanged but the string representations returned by `__str__` and `__repr__` are valid DSs. As a result, an pydicom file stored from a dataset containing the DS will be standards-compliant. Even when `truncate` is set to `True`, the classes will not change a string representation provided by the user if that string representation is valid.
- Adding full tests for the above changes.

I also removed one test that claimed to test the truncation behaviour of DSdecimal but instead just relied on the `__repr__` method of built-in `float` by chance giving a representation of < 16 characters in that one case. I felt this test may cause considerable confusion for other developers going forward.

Closes #1264 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [ ] No warnings during build (some unrelated warnings)
  - [x] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
