### PR TITLE
[MRG] Copy auto_format attribute when constructing DS objects

### DIFF
--- a/pydicom/tests/test_dataelem.py
+++ b/pydicom/tests/test_dataelem.py
@@ -3,6 +3,7 @@
 """Unit tests for the pydicom.dataelem module."""
 
 # Many tests of DataElement class are implied in test_dataset also
+import math
 
 import pytest
 
@@ -101,6 +102,13 @@ class TestDataElement:
         self.data_elementMulti.value[3] = '123.4'
         assert isinstance(self.data_elementMulti.value[3], DSfloat)
         assert DSfloat('123.4') == self.data_elementMulti.value[3]
+
+    def test_DSFloat_conversion_auto_format(self):
+        """Test that strings are being auto-formatted correctly."""
+        data_element = DataElement((1, 2), "DS",
+                                   DSfloat(math.pi, auto_format=True))
+        assert math.pi == data_element.value
+        assert '3.14159265358979' == str(data_element.value)
 
     def test_backslash(self):
         """DataElement: String with '\\' sets multi-valued data_element."""

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -2,6 +2,7 @@
 """Unit tests for the pydicom.dataset module."""
 
 import copy
+import math
 import pickle
 import weakref
 
@@ -27,6 +28,7 @@ from pydicom.uid import (
     JPEGBaseline8Bit,
     PYDICOM_IMPLEMENTATION_UID
 )
+from pydicom.valuerep import DS
 
 
 class BadRepr:
@@ -1640,6 +1642,14 @@ class TestDatasetElements:
         # check also that assigning proper sequence *does* work
         self.ds.ConceptCodeSequence = [self.sub_ds1, self.sub_ds2]
         assert isinstance(self.ds.ConceptCodeSequence, Sequence)
+
+    def test_formatted_DS_assigment(self):
+        """Assigning an auto-formatted decimal string works as expected."""
+        ds = pydicom.Dataset()
+        ds.PatientWeight = DS(math.pi, auto_format=True)
+        assert ds.PatientWeight.auto_format
+        # Check correct 16-character string representation
+        assert str(ds.PatientWeight) == '3.14159265358979'
 
     def test_ensure_file_meta(self):
         assert not hasattr(self.ds, 'file_meta')

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -391,6 +391,20 @@ class TestDSfloat:
         assert str(x) == '3.14159265358979'
         assert repr(x) == '"3.14159265358979"'
 
+    def test_auto_format_from_invalid_DS(self):
+        """Test truncating floats"""
+        # A DSfloat that has a non-valid string representation
+        x = pydicom.valuerep.DSfloat(math.pi)
+
+        # Use this to initialise another with auto_format set to true
+        y = pydicom.valuerep.DSfloat(x, auto_format=True)
+
+        # Float representation should be unaltered by truncation
+        assert y == math.pi
+        # String representations should be correctly formatted
+        assert str(y) == '3.14159265358979'
+        assert repr(y) == '"3.14159265358979"'
+
     def test_auto_format_invalid_string(self, enforce_valid_both_fixture):
         """If the user supplies an invalid string, this should be formatted."""
         x = pydicom.valuerep.DSfloat('3.141592653589793', auto_format=True)
@@ -500,6 +514,20 @@ class TestDSdecimal:
         # String representations should be correctly formatted
         assert str(x) == '3.14159265358979'
         assert repr(x) == '"3.14159265358979"'
+
+    def test_auto_format_from_invalid_DS(self):
+        """Test truncating floats"""
+        # A DSdecimal that has a non-valid string representation
+        x = pydicom.valuerep.DSdecimal(math.pi)
+
+        # Use this to initialise another with auto_format set to true
+        y = pydicom.valuerep.DSdecimal(x, auto_format=True)
+
+        # Float representation should be unaltered by truncation
+        assert y == math.pi
+        # String representations should be correctly formatted
+        assert str(y) == '3.14159265358979'
+        assert repr(y) == '"3.14159265358979"'
 
     def test_auto_format_invalid_string(self, enforce_valid_both_fixture):
         """If the user supplies an invalid string, this should be formatted."""

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -416,6 +416,17 @@ class TestDSfloat:
         with pytest.raises(OverflowError):
             valuerep.DSfloat('3.141592653589793')
 
+    def test_DSfloat_auto_format(self):
+        """Test creating a value using DSfloat copies auto_format"""
+        x = pydicom.valuerep.DSfloat(math.pi, auto_format=True)
+        y = pydicom.valuerep.DSfloat(x)
+        assert x == y
+        assert y == x
+        assert y.auto_format
+        assert math.pi == y
+        assert str(y) == '3.14159265358979'
+        assert repr(y) == '"3.14159265358979"'
+
     @pytest.mark.parametrize(
         'val',
         [
@@ -525,6 +536,17 @@ class TestDSdecimal:
         # String representations should be unaltered
         assert str(x) == '1.234e-1'
         assert repr(x) == '"1.234e-1"'
+
+    def test_DSdecimal_auto_format(self):
+        """Test creating a value using DSdecimal copies auto_format"""
+        x = pydicom.valuerep.DSdecimal(math.pi, auto_format=True)
+        y = pydicom.valuerep.DSdecimal(x)
+        assert x == y
+        assert y == x
+        assert y.auto_format
+        assert math.pi == y
+        assert str(y) == '3.14159265358979'
+        assert repr(y) == '"3.14159265358979"'
 
 
 class TestIS:

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -472,8 +472,10 @@ class DSfloat(float):
         has_attribute = hasattr(val, 'original_string')
         if isinstance(val, str):
             self.original_string = val
-        elif isinstance(val, (DSfloat, DSdecimal)) and has_attribute:
-            self.original_string = val.original_string
+        elif isinstance(val, (DSfloat, DSdecimal)):
+            auto_format = val.auto_format
+            if has_attribute:
+                self.original_string = val.original_string
 
         self.auto_format = auto_format
         if self.auto_format:
@@ -579,8 +581,10 @@ class DSdecimal(Decimal):
         has_str = hasattr(val, 'original_string')
         if isinstance(val, str):
             self.original_string = val
-        elif isinstance(val, (DSfloat, DSdecimal)) and has_str:
-            self.original_string = val.original_string
+        elif isinstance(val, (DSfloat, DSdecimal)):
+            auto_format = val.auto_format
+            if has_str:
+                self.original_string = val.original_string
 
         self.auto_format = auto_format
         if self.auto_format:

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -470,15 +470,18 @@ class DSfloat(float):
         # ... also if user changes a data element value, then will get
         # a different object, because float is immutable.
         has_attribute = hasattr(val, 'original_string')
+        pre_checked = False
         if isinstance(val, str):
             self.original_string = val
         elif isinstance(val, (DSfloat, DSdecimal)):
-            auto_format = val.auto_format
+            if val.auto_format:
+                auto_format = True  # override input parameter
+                pre_checked = True
             if has_attribute:
                 self.original_string = val.original_string
 
         self.auto_format = auto_format
-        if self.auto_format:
+        if self.auto_format and not pre_checked:
             # If auto_format is True, keep the float value the same, but change
             # the string representation stored in original_string if necessary
             if hasattr(self, 'original_string'):
@@ -579,15 +582,18 @@ class DSdecimal(Decimal):
         # ... also if user changes a data element value, then will get
         # a different Decimal, as Decimal is immutable.
         has_str = hasattr(val, 'original_string')
+        pre_checked = False
         if isinstance(val, str):
             self.original_string = val
         elif isinstance(val, (DSfloat, DSdecimal)):
-            auto_format = val.auto_format
+            if val.auto_format:
+                auto_format = True  # override input parameter
+                pre_checked = True
             if has_str:
                 self.original_string = val.original_string
 
         self.auto_format = auto_format
-        if self.auto_format:
+        if self.auto_format and not pre_checked:
             # If auto_format is True, keep the float value the same, but change
             # the string representation stored in original_string if necessary
             if hasattr(self, 'original_string'):


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes

Fixes an unexpected behaviour with the recently introduced DS formatting (#1334).

While using the recently-merged functionality for automatic DS formatting, I found a problem wherein the `auto_format` attribute is not correctly copied when constructing a `DSfloat`/`DSdecimal` from another `DSfloat`/`DSdecimal`. Since this process occurs when using the attribute assignment syntax on `Dataset`, the result is that the following does not work as expected:

```python
from pydicom import Dataset
from pydicom.valuerep import DS
import math

dataset = Dataset()
dataset.PatientWeight = DS(math.pi, auto_format=True) 

# In the above line, a new DSfloat is constructed from the constructed DSfloat
# but does not get the `auto_format` attribute copied correctly

# As a consequence, this does not work as expected...
print(dataset.PatientWeight)
# Get '3.141592653589793' (17 chars)
# Expect '3.14159265358979' (16 chars)
```

I have now fixed this issue such that:
- When a `DSfloat`/`DSdecimal` is constructed from another `DSfloat`/`DSdecimal`, its `auto_format` attribute is set to True if either the init method's `auto_format` parameter is set to True (previous behaviour) or the `val` parameter's auto_format attribute is set to True (new behaviour).
- Also in the situation that a `DSfloat`/`DSdecimal` is constructed from another `DSfloat`/`DSdecimal` that has `auto_format` equal to True, I removed the redundant check on the validity of the string representation of `val` for performance reasons.
- There are new unit tests that the `auto_format` attribute is correctly copied and now integration tests on `Dataset` and `DataElement` to check for the above high-level expected behaviour.

Sorry that I didn't notice this earlier...


#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ N/A ] Documentation updated (if relevant)
  - [x] No warnings during build
  - [x] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
