### PR TITLE
[WIP] When the user encounters the problem of downloading the testfile,

### DIFF
--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -47,6 +47,7 @@ Enhancements
   not only through ``urllib.request`` but also through the ``requests`` package.
   If you run into problems using ``urllib.request``,
   a more powerful ``requests`` package will be recommended via log messages.
+  (:pr:`1340`)
 
 
 Changes

--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -43,6 +43,10 @@ Enhancements
   from individual components of names (``family_name``, ``given_name``, etc.).
   See :meth:`~pydicom.valuerep.PersonName.from_named_components` and
   :meth:`~pydicom.valuerep.PersonName.from_named_components_veterinary`.
+* Added library support so that files can be downloaded
+  not only through ``urllib.request`` but also through the ``requests`` package.
+  If you run into problems using ``urllib.request``,
+  a more powerful ``requests`` package will be recommended via log messages.
 
 
 Changes

--- a/pydicom/data/download.py
+++ b/pydicom/data/download.py
@@ -3,7 +3,6 @@
 # Copyright 2018-2019 Cancer Care Associates.
 # Relicensed under pydicom LICENSE by Simon Biggs.
 
-import contextlib
 import functools
 import hashlib
 import json
@@ -15,13 +14,21 @@ import urllib.error
 import warnings
 
 try:
+    import requests
+
+    IMPORTED_REQUESTS = True
+except ImportError:
+    IMPORTED_REQUESTS = False
+
+try:
     import tqdm
 
-    class DownloadProgressBar(tqdm.tqdm):
-        def update_to(self, b=1, bsize=1, tsize=None):
-            if tsize is not None:
-                self.total = tsize
-            self.update(b * bsize - self.n)
+    if IMPORTED_REQUESTS is False:
+        class DownloadProgressBar(tqdm.tqdm):
+            def update_to(self, b=1, bsize=1, tsize=None):
+                if tsize is not None:
+                    self.total = tsize
+                self.update(b * bsize - self.n)
 
     USE_PROGRESS_BAR = True
 except ImportError:
@@ -70,7 +77,11 @@ def get_config_dir() -> os.PathLike:
     return config_dir
 
 
-@retry.retry(urllib.error.HTTPError)
+@retry.retry(
+    (urllib.error.HTTPError, urllib.error.URLError),
+    exception_msg=("Installing the `requests` package "
+                   "could be a possible solution to this problem.")
+)
 def download_with_progress(url: str, fpath: os.PathLike) -> None:
     """Download the file at `url` to `fpath` with a progress bar.
 
@@ -81,15 +92,32 @@ def download_with_progress(url: str, fpath: os.PathLike) -> None:
     fpath : os.PathLike
         The absolute path where the file will be written to.
     """
-    if USE_PROGRESS_BAR:
-        with DownloadProgressBar(
-            unit="B", unit_scale=True, miniters=1, desc=url.split("/")[-1]
-        ) as t:
-            urllib.request.urlretrieve(
-                url, os.fspath(fpath), reporthook=t.update_to
-            )
+    filename = os.fspath(fpath)
+
+    if IMPORTED_REQUESTS:
+        if USE_PROGRESS_BAR:
+            r = requests.get(url, stream=True)
+            total_size_in_bytes = int(r.headers.get("content-length", 0))
+            with open(fpath, "wb") as file:
+                for data in tqdm.tqdm(
+                    r.iter_content(), total=total_size_in_bytes,
+                    unit="B", unit_scale=True, miniters=1, desc=url.split("/")[-1]
+                ):
+                    file.write(data)
+        else:
+            r = requests.get(url)
+            with open(filename, "wb") as f:
+                f.write(r.content)
     else:
-        urllib.request.urlretrieve(url, os.fspath(fpath))
+        if USE_PROGRESS_BAR:
+            with DownloadProgressBar(
+                unit="B", unit_scale=True, miniters=1, desc=url.split("/")[-1]
+            ) as t:
+                urllib.request.urlretrieve(
+                    url, filename, reporthook=t.update_to
+                )
+        else:
+            urllib.request.urlretrieve(url, filename)
 
 
 def get_data_dir() -> os.PathLike:

--- a/pydicom/data/download.py
+++ b/pydicom/data/download.py
@@ -101,7 +101,8 @@ def download_with_progress(url: str, fpath: os.PathLike) -> None:
             with open(fpath, "wb") as file:
                 for data in tqdm.tqdm(
                     r.iter_content(), total=total_size_in_bytes,
-                    unit="B", unit_scale=True, miniters=1, desc=url.split("/")[-1]
+                    unit="B", unit_scale=True, miniters=1,
+                    desc=url.split("/")[-1]
                 ):
                     file.write(data)
         else:
@@ -111,7 +112,8 @@ def download_with_progress(url: str, fpath: os.PathLike) -> None:
     else:
         if USE_PROGRESS_BAR:
             with DownloadProgressBar(
-                unit="B", unit_scale=True, miniters=1, desc=url.split("/")[-1]
+                unit="B", unit_scale=True, miniters=1,
+                desc=url.split("/")[-1]
             ) as t:
                 urllib.request.urlretrieve(
                     url, filename, reporthook=t.update_to

--- a/pydicom/data/download.py
+++ b/pydicom/data/download.py
@@ -16,14 +16,14 @@ import warnings
 try:
     import requests
 
-    IMPORTED_REQUESTS = True
+    HAVE_REQUESTS = True
 except ImportError:
-    IMPORTED_REQUESTS = False
+    HAVE_REQUESTS = False
 
 try:
     import tqdm
 
-    if IMPORTED_REQUESTS is False:
+    if HAVE_REQUESTS is False:
         class DownloadProgressBar(tqdm.tqdm):
             def update_to(self, b=1, bsize=1, tsize=None):
                 if tsize is not None:
@@ -94,7 +94,7 @@ def download_with_progress(url: str, fpath: os.PathLike) -> None:
     """
     filename = os.fspath(fpath)
 
-    if IMPORTED_REQUESTS:
+    if HAVE_REQUESTS:
         if USE_PROGRESS_BAR:
             r = requests.get(url, stream=True)
             total_size_in_bytes = int(r.headers.get("content-length", 0))

--- a/pydicom/data/retry.py
+++ b/pydicom/data/retry.py
@@ -2,7 +2,8 @@ import time
 from functools import wraps
 
 
-def retry(ExceptionToCheck, exception_msg=None, tries=4, delay=3, backoff=2, logger=None):
+def retry(ExceptionToCheck, exception_msg=None,
+          tries=4, delay=3, backoff=2, logger=None):
     """Retry calling the decorated function using an exponential backoff.
 
     http://www.saltycrane.com/blog/2009/11/trying-out-retry-decorator-python/

--- a/pydicom/data/retry.py
+++ b/pydicom/data/retry.py
@@ -2,7 +2,7 @@ import time
 from functools import wraps
 
 
-def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
+def retry(ExceptionToCheck, exception_msg=None, tries=4, delay=3, backoff=2, logger=None):
     """Retry calling the decorated function using an exponential backoff.
 
     http://www.saltycrane.com/blog/2009/11/trying-out-retry-decorator-python/
@@ -31,6 +31,8 @@ def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
                     return f(*args, **kwargs)
                 except ExceptionToCheck as e:
                     msg = "%s, Retrying in %d seconds..." % (str(e), mdelay)
+                    if exception_msg:
+                        msg += "  %s" % exception_msg
                     if logger:
                         logger.warning(msg)
                     else:

--- a/pydicom/env_info.py
+++ b/pydicom/env_info.py
@@ -18,7 +18,8 @@ import importlib
 def main():
     version_rows = [("platform", platform.platform()), ("Python", sys.version)]
 
-    for module in ("pydicom", "gdcm", "jpeg_ls", "numpy", "PIL"):
+    for module in ("pydicom", "gdcm", "jpeg_ls", "numpy", "PIL",
+                   "pylibjpeg", "openjpeg", "libjpeg"):
         try:
             m = importlib.import_module(module)
         except ImportError:

--- a/pydicom/env_info.py
+++ b/pydicom/env_info.py
@@ -18,8 +18,7 @@ import importlib
 def main():
     version_rows = [("platform", platform.platform()), ("Python", sys.version)]
 
-    for module in ("pydicom", "gdcm", "jpeg_ls", "numpy", "PIL",
-                   "pylibjpeg", "openjpeg", "libjpeg"):
+    for module in ("pydicom", "gdcm", "jpeg_ls", "numpy", "PIL"):
         try:
             m = importlib.import_module(module)
         except ImportError:


### PR DESCRIPTION
it offers an additional solution (`requests`).

<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
This is an issue discussed at https://github.com/pydicom/pydicom/issues/1333, implemented as follows.
In some network environments, `urllib` cannot download testfile as follows.

```
$ pytest -k test_dataset.py -s
=================================== test session starts ===================================
platform darwin -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/youngkiu/src/pydicom
emri_small.dcm: 0.00B [00:00, ?B/s]
<urlopen error [Errno 54] Connection reset by peer>, Retrying in 3 seconds...
emri_small.dcm: 0.00B [00:00, ?B/s]
<urlopen error [Errno 54] Connection reset by peer>, Retrying in 6 seconds...
emri_small.dcm: 0.00B [00:00, ?B/s]
<urlopen error [Errno 54] Connection reset by peer>, Retrying in 12 seconds...
emri_small.dcm: 0.00B [00:00, ?B/s]
...
```

In this case, installing `requests` can solve the problem, and I have improved it as follows.

```
$ pytest -k test_dataset.py -s
=================================== test session starts ===================================
platform darwin -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/youngkiu/src/pydicom
emri_small.dcm: 0.00B [00:00, ?B/s]
<urlopen error [Errno 54] Connection reset by peer>, Retrying in 3 seconds...  Installing the `requests` package could be a possible solution to this problem.
emri_small.dcm: 0.00B [00:00, ?B/s]
<urlopen error [Errno 54] Connection reset by peer>, Retrying in 6 seconds...  Installing the `requests` package could be a possible solution to this problem.
emri_small.dcm: 0.00B [00:00, ?B/s]
<urlopen error [Errno 54] Connection reset by peer>, Retrying in 12 seconds...  Installing the `requests` package could be a possible solution to this problem.
emri_small.dcm: 0.00B [00:00, ?B/s]
...
```

If the `requests` package is installed, use it to download.

```
$ pip install requests
$ pytest -k test_dataset.py -s
=================================== test session starts ===================================
platform darwin -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/youngkiu/src/pydicom
emri_small.dcm: 100%|██████████████████████████████████| 84.3k/84.3k [00:00<00:00, 156kB/s]
emri_small_jpeg_ls_lossless.dcm: 100%|█████████████████| 42.8k/42.8k [00:00<00:00, 140kB/s]
emri_small_jpeg_2k_lossless.dcm: 100%|█████████████████| 40.3k/40.3k [00:00<00:00, 159kB/s]
JPEG-LL.dcm: 100%|███████████████████████████████████████| 119k/119k [00:00<00:00, 157kB/s]
color-px.dcm: 100%|████████████████████████████████████| 93.3k/93.3k [00:00<00:00, 158kB/s]
color-pl.dcm: 100%|████████████████████████████████████| 93.3k/93.3k [00:00<00:00, 150kB/s]
...
```

All of the above execution logs are those collected by the city public library where the problem occurred.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
