### PR TITLE
[MRG] Do not load external data sources until needed

### DIFF
--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -58,3 +58,5 @@ Fixes
 * Fixed JSON export of numeric values
 * Fixed handling of sequences of unknown length that switch to implicit
   encoding, and sequences with VR ``UN`` (:issue:`1312`)
+* Do not load external data sources until needed - fixes problems with
+  standard workflow if `setuptools` are not installed (:issue:`1341`)

--- a/pydicom/data/__init__.py
+++ b/pydicom/data/__init__.py
@@ -3,7 +3,7 @@
 
 from .data_manager import (
     get_charset_files, get_testdata_file, get_testdata_files,
-    get_palette_files, DATA_ROOT, EXTERNAL_DATA_SOURCES, fetch_data_files
+    get_palette_files, DATA_ROOT, external_data_sources, fetch_data_files
 )
 
 __all__ = [

--- a/pydicom/tests/test_data_manager.py
+++ b/pydicom/tests/test_data_manager.py
@@ -172,7 +172,8 @@ class TestExternalDataSource:
 
     def test_get_testdata_file_external_ignore_hash(self):
         """Test that non-pydicom-data external source ignores hash check."""
-        external_data_sources()['mylib'] = external_data_sources()['pydicom-data']
+        external_data_sources()['mylib'] = external_data_sources()[
+            'pydicom-data']
         p = self.dpath / "693_UNCI.dcm"
         with open(p, 'wb') as f:
             f.write(b"\x00\x01")
@@ -235,7 +236,8 @@ class TestExternalDataSource:
 
     def test_get_testdata_files_external_ignore_hash(self):
         """Test that non-pydicom-data external source ignores hash check."""
-        external_data_sources()['mylib'] = external_data_sources()['pydicom-data']
+        external_data_sources()['mylib'] = external_data_sources()[
+            'pydicom-data']
         p = self.dpath / "693_UNCI.dcm"
         with open(p, 'wb') as f:
             f.write(b"\x00\x01")

--- a/pydicom/tests/test_data_manager.py
+++ b/pydicom/tests/test_data_manager.py
@@ -13,7 +13,7 @@ from pydicom.data import (
     get_charset_files, get_testdata_files, get_palette_files, fetch_data_files
 )
 from pydicom.data.data_manager import (
-    DATA_ROOT, get_testdata_file, EXTERNAL_DATA_SOURCES
+    DATA_ROOT, get_testdata_file, external_data_sources
 )
 from pydicom.data import download
 from pydicom.data.download import (
@@ -22,7 +22,7 @@ from pydicom.data.download import (
 
 
 EXT_PYDICOM = False
-if 'pydicom-data' in EXTERNAL_DATA_SOURCES:
+if 'pydicom-data' in external_data_sources():
     EXT_PYDICOM = True
 
 
@@ -42,9 +42,9 @@ class TestGetData:
 
         # If pydicom-data is available locally
         ext_path = None
-        if 'pydicom-data' in EXTERNAL_DATA_SOURCES:
+        if 'pydicom-data' in external_data_sources():
             ext_path = os.fspath(
-                EXTERNAL_DATA_SOURCES['pydicom-data'].data_path
+                external_data_sources()['pydicom-data'].data_path
             )
 
         # Test base locations
@@ -117,7 +117,7 @@ class TestGetData:
 class TestExternalDataSource:
     """Tests for the external data sources."""
     def setup(self):
-        self.dpath = EXTERNAL_DATA_SOURCES["pydicom-data"].data_path
+        self.dpath = external_data_sources()["pydicom-data"].data_path
 
         # Backup the 693_UNCI.dcm file
         p = self.dpath / "693_UNCI.dcm"
@@ -129,8 +129,8 @@ class TestExternalDataSource:
         shutil.copy(self.dpath / "PYTEST_BACKUP", p)
         os.remove(self.dpath / "PYTEST_BACKUP")
 
-        if 'mylib' in EXTERNAL_DATA_SOURCES:
-            del EXTERNAL_DATA_SOURCES['mylib']
+        if 'mylib' in external_data_sources():
+            del external_data_sources()['mylib']
 
     def as_posix(self, path):
         """Return `path` as a posix path"""
@@ -172,7 +172,7 @@ class TestExternalDataSource:
 
     def test_get_testdata_file_external_ignore_hash(self):
         """Test that non-pydicom-data external source ignores hash check."""
-        EXTERNAL_DATA_SOURCES['mylib'] = EXTERNAL_DATA_SOURCES['pydicom-data']
+        external_data_sources()['mylib'] = external_data_sources()['pydicom-data']
         p = self.dpath / "693_UNCI.dcm"
         with open(p, 'wb') as f:
             f.write(b"\x00\x01")
@@ -235,7 +235,7 @@ class TestExternalDataSource:
 
     def test_get_testdata_files_external_ignore_hash(self):
         """Test that non-pydicom-data external source ignores hash check."""
-        EXTERNAL_DATA_SOURCES['mylib'] = EXTERNAL_DATA_SOURCES['pydicom-data']
+        external_data_sources()['mylib'] = external_data_sources()['pydicom-data']
         p = self.dpath / "693_UNCI.dcm"
         with open(p, 'wb') as f:
             f.write(b"\x00\x01")


### PR DESCRIPTION
- fixes exception while reading DICOM data if `setuptools` are not installed
- see #1341

This just makes the offending import of `pkg_resources` into a local import, and replaces the global variable that always loads the data sources on import with a function. As this code is seldom needed, I think this would be ok, not sure if it breaks any external code, though.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
