### PR TITLE
[MRG] Updates for pylibjpeg changes

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -23,7 +23,7 @@ jobs:
           - { pymedphys-dep: pymedphys, gdcm-dep: gdcm, os: ubuntu-latest, python-version: 3.8, jpeg-deps: pillow-jpegls }
           # Test all pixel data handlers for code coverage
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
             jpeg-deps: pillow-jpegls
             gdcm-dep: gdcm
             pylibjpeg-dep: pylibjpeg

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -89,7 +89,7 @@ jobs:
         python-version:  [3.6, 3.7, 3.8, 3.9]
         include:
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
             jpeg-deps: pillow-jpegls
             gdcm-dep: gdcm
             pylibjpeg-dep: pylibjpeg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/pydicom/pixel_data_handlers/pylibjpeg_handler.py
+++ b/pydicom/pixel_data_handlers/pylibjpeg_handler.py
@@ -57,10 +57,16 @@ except ImportError:
 
 try:
     import pylibjpeg
-    from pylibjpeg.pydicom.utils import get_pixel_data_decoders
     HAVE_PYLIBJPEG = True
 except ImportError:
     HAVE_PYLIBJPEG = False
+
+if HAVE_PYLIBJPEG:
+    try:
+        from pylibjpeg.utils import get_pixel_data_decoders
+    except ImportError:
+        # Old import, deprecated in 1.2, removal in 2.0
+        from pylibjpeg.pydicom.utils import get_pixel_data_decoders
 
 try:
     import openjpeg

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -710,10 +710,10 @@ def _convert_YBR_FULL_to_RGB(arr: "np.ndarray") -> "np.ndarray":
         [[1.000, 1.000, 1.000],
          [0.000, -0.114 * 1.772 / 0.587, 1.772],
          [1.402, -0.299 * 1.402 / 0.587, 0.000]],
-        dtype=np.float
+        dtype=float
     )
 
-    arr = arr.astype(np.float)
+    arr = arr.astype(float)
     arr -= [0, 128, 128]
     arr = np.dot(arr, ybr_to_rgb)
 


### PR DESCRIPTION
#### Describe the changes
* Updates for pylibjpeg changes (different import path, changed warning message)
* Capture warnings in pylibjpeg tests
* Use `float` rather than np.float due to [upcoming removal](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated)
* Bump CI workflows to Python 3.9 now that it's supported by pylibjpeg

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
