### PR TITLE
[MRG] Add pylibjpeg libraries and versions to the env_info output

### DIFF
--- a/pydicom/env_info.py
+++ b/pydicom/env_info.py
@@ -18,7 +18,8 @@ import importlib
 def main():
     version_rows = [("platform", platform.platform()), ("Python", sys.version)]
 
-    for module in ("pydicom", "gdcm", "jpeg_ls", "numpy", "PIL"):
+    for module in ("pydicom", "gdcm", "jpeg_ls", "numpy", "PIL",
+                   "pylibjpeg", "openjpeg", "libjpeg"):
         try:
             m = importlib.import_module(module)
         except ImportError:

--- a/pydicom/tests/test_env_info.py
+++ b/pydicom/tests/test_env_info.py
@@ -35,4 +35,7 @@ platform     |""".lstrip()
             "jpeg_ls",
             "numpy",
             "PIL",
+            "pylibjpeg",
+            "openjpeg",
+            "libjpeg",
         ]


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
While creating issue https://github.com/pydicom/pydicom/issues/1346, I commit the updated `env_info.py`.
Now you know the installed version of all optional libraries. https://pydicom.github.io/pydicom/stable/tutorials/installation.html#install-the-optional-libraries

```
$ python -m pydicom.env_info
module       | version
------       | -------
platform     | macOS-10.16-x86_64-i386-64bit
Python       | 3.8.8 | packaged by conda-forge | (default, Feb 20 2021, 16:12:38)  [Clang 11.0.1 ]
pydicom      | 2.2.0.dev0
gdcm         | _module not found_
jpeg_ls      | _module not found_
numpy        | 1.20.2
PIL          | _module not found_
pylibjpeg    | 1.2.0
openjpeg     | 1.1.1
libjpeg      | 1.2.0
```

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `[...]/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
