### PR TITLE
[WIP] Ensure that changing Specific Character Set is effective

### DIFF
--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -55,6 +55,8 @@ Enhancements
 * Ensured :func:`~pydicom.pixel_data_handlers.utils.convert_color_space` uses
   32-bit floats for calculation, added `per_frame` flag to allow frame-by-frame
   processing and improved the speed by ~20-60% (:issue:`1348`)
+* Make sure that changing the ``Specific Character Set`` in a dataset will
+  affect the following decoding (:issue:`1328`)
 
 
 Changes

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -2062,6 +2062,8 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
                         elem, self._character_set, self)
                 elem.private_creator = self[private_creator_tag].value
 
+        if elem_tag == 0x00080005:
+            self.read_encoding = None
         self._dict[elem_tag] = elem
 
     def _slice_dataset(

--- a/pydicom/tests/test_charset.py
+++ b/pydicom/tests/test_charset.py
@@ -101,7 +101,6 @@ class TestCharset:
     def test_invalid_character_set(self, allow_invalid_values):
         """charset: replace invalid encoding with default encoding"""
         ds = dcmread(get_testdata_file("CT_small.dcm"))
-        ds.read_encoding = None
         ds.SpecificCharacterSet = 'Unsupported'
         with pytest.warns(
             UserWarning,
@@ -114,7 +113,6 @@ class TestCharset:
     def test_invalid_character_set_enforce_valid(self, enforce_valid_values):
         """charset: raise on invalid encoding"""
         ds = dcmread(get_testdata_file("CT_small.dcm"))
-        ds.read_encoding = None
         ds.SpecificCharacterSet = 'Unsupported'
         with pytest.raises(LookupError,
                            match="Unknown encoding 'Unsupported'"):
@@ -128,6 +126,13 @@ class TestCharset:
         ds.decode()
         assert 2 == len(ds)  # specific character set is always decoded
         assert 'Люкceмбypг' == ds.PatientName
+
+    def test_change_specific_character_set(self):
+        """Changed specific character set is used"""
+        rus_file = get_charset_files("chrRuss.dcm")[0]
+        ds = dcmread(rus_file)
+        ds.SpecificCharacterSet = "ISO_IR 100"
+        assert '»îÚceÜÑypÓ' == ds.PatientName
 
     def test_bad_charset(self):
         """Test bad charset defaults to ISO IR 6"""


### PR DESCRIPTION
- invalidate the cached encoding if setting the Specific Character Set in a dataset
- see #1328

This is a minor change that makes changing the character set after reading a data set more convenient.
Note that after the tags are read, this will no more be effective.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Unit tests passing and overall coverage the same or better
