### PR TITLE
[MRG] Add support for RLE to the pylibjpeg handler

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -110,7 +110,7 @@ jobs:
         python -m pip install pylibjpeg
         python -m pip uninstall -y pylibjpeg-openjpeg
         pytest ${{ matrix.pytest-args }} pydicom/tests/test_pylibjpeg.py
-        python -m pip install pylibjpeg-openjpeg pylibjpeg-libjpeg
+        python -m pip install pylibjpeg-openjpeg pylibjpeg-libjpeg pylibjpeg-rle
         pytest ${{ matrix.pytest-args }} pydicom/tests/test_pylibjpeg.py
 
     - name: Test external sources using pydicom-data

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -175,7 +175,7 @@ jobs:
         python -m pip install pylibjpeg
         python -m pip uninstall -y pylibjpeg-openjpeg
         pytest ${{ matrix.pytest-args }} pydicom/tests/test_pylibjpeg.py
-        python -m pip install pylibjpeg-openjpeg pylibjpeg-libjpeg
+        python -m pip install pylibjpeg-openjpeg pylibjpeg-libjpeg pylibjpeg-rle
         pytest ${{ matrix.pytest-args }} pydicom/tests/test_pylibjpeg.py
 
     - name: Test external sources using pydicom-data

--- a/doc/old/image_data_handlers.rst
+++ b/doc/old/image_data_handlers.rst
@@ -89,7 +89,7 @@ handled by the given packages:
 | :sup:`1` *only with JpegImagePlugin*
 | :sup:`2` *only with Jpeg2KImagePlugin*
 | :sup:`3` *only if (0028,0100) Bits Allocated = 8*
-| :sup:`4` *with the pylibjpeg-rle plugin and using the* :meth:`~pydicom.dataset.Dataset.decompress` *method*
+| :sup:`4` *with the pylibjpeg-rle plugin and using the* :meth:`~pydicom.dataset.Dataset.decompress` *method*, 4-5x faster than default
 | :sup:`5` *with the pylibjpeg-libjpeg plugin*
 | :sup:`6` *with the pylibjpeg-openjpeg plugin*
 

--- a/doc/old/image_data_handlers.rst
+++ b/doc/old/image_data_handlers.rst
@@ -89,7 +89,7 @@ handled by the given packages:
 | :sup:`1` *only with JpegImagePlugin*
 | :sup:`2` *only with Jpeg2KImagePlugin*
 | :sup:`3` *only if (0028,0100) Bits Allocated = 8*
-| :sup:`4` *with the pylibjpeg-rle plugin and using the :meth:`~pydicom.dataset.Dataset.decompress` method*
+| :sup:`4` *with the pylibjpeg-rle plugin and using the* :meth:`~pydicom.dataset.Dataset.decompress` *method*
 | :sup:`5` *with the pylibjpeg-libjpeg plugin*
 | :sup:`6` *with the pylibjpeg-openjpeg plugin*
 

--- a/doc/old/image_data_handlers.rst
+++ b/doc/old/image_data_handlers.rst
@@ -23,8 +23,8 @@ The following packages can be used with *pydicom*:
 * `Pillow <http://pillow.readthedocs.io/en/latest/>`_, ideally with
   ``jpeg`` and ``jpeg2000`` plugins
 * `jpeg_ls <https://github.com/Who8MyLunch/CharPyLS>`_
-* `pylibjpeg <https://github.com/pydicom/pylibjpeg>`_, with the ``-libjpeg``
-  and ``-openjpeg`` plugins
+* `pylibjpeg <https://github.com/pydicom/pylibjpeg>`_, with the ``-libjpeg``,
+  ``-openjpeg`` and ``-rle`` plugins
 
 Note that you always need the `NumPy <http://numpy.org/>`_ package to be able
 to handle pixel data.
@@ -62,24 +62,24 @@ handled by the given packages:
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
 | Deflated Explicit VR Little Endian | 1.2.840.10008.1.2.1.99 | |chk| | |chk|       | |chk|    |     |chk|       | |chk|           |
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
-| RLE Lossless                       | 1.2.840.10008.1.2.5    | |chk| | |chk|       | |chk|    |     |chk|       | |chk|           |
+| RLE Lossless                       | 1.2.840.10008.1.2.5    | |chk| | |chk|       | |chk|    |     |chk|       | |chk|\ :sup:`4` |
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
-| JPEG Baseline (Process 1)          | 1.2.840.10008.1.2.4.50 |       |             | |chk|    | |chk|\ :sup:`1` | |chk|\ :sup:`4` |
+| JPEG Baseline (Process 1)          | 1.2.840.10008.1.2.4.50 |       |             | |chk|    | |chk|\ :sup:`1` | |chk|\ :sup:`5` |
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
-| JPEG Extended (Process 2 and 4)    | 1.2.840.10008.1.2.4.51 |       |             | |chk|    | |chk|\          | |chk|\ :sup:`4` |
+| JPEG Extended (Process 2 and 4)    | 1.2.840.10008.1.2.4.51 |       |             | |chk|    | |chk|\          | |chk|\ :sup:`5` |
 |                                    |                        |       |             |          | :sup:`1,3`      |                 |
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
-| JPEG Lossless (Process 14)         | 1.2.840.10008.1.2.4.57 |       |             | |chk|    |                 | |chk|\ :sup:`4` |
+| JPEG Lossless (Process 14)         | 1.2.840.10008.1.2.4.57 |       |             | |chk|    |                 | |chk|\ :sup:`5` |
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
-| JPEG Lossless (Process 14, SV1)    | 1.2.840.10008.1.2.4.70 |       |             | |chk|    |                 | |chk|\ :sup:`4` |
+| JPEG Lossless (Process 14, SV1)    | 1.2.840.10008.1.2.4.70 |       |             | |chk|    |                 | |chk|\ :sup:`5` |
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
-| JPEG LS Lossless                   | 1.2.840.10008.1.2.4.80 |       | |chk|       | |chk|    |                 | |chk|\ :sup:`4` |
+| JPEG LS Lossless                   | 1.2.840.10008.1.2.4.80 |       | |chk|       | |chk|    |                 | |chk|\ :sup:`5` |
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
-| JPEG LS Lossy                      | 1.2.840.10008.1.2.4.81 |       | |chk|       | |chk|    |                 | |chk|\ :sup:`4` |
+| JPEG LS Lossy                      | 1.2.840.10008.1.2.4.81 |       | |chk|       | |chk|    |                 | |chk|\ :sup:`5` |
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
-| JPEG2000 Lossless                  | 1.2.840.10008.1.2.4.90 |       |             | |chk|    | |chk|\ :sup:`2` | |chk|\ :sup:`5` |
+| JPEG2000 Lossless                  | 1.2.840.10008.1.2.4.90 |       |             | |chk|    | |chk|\ :sup:`2` | |chk|\ :sup:`6` |
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
-| JPEG2000                           | 1.2.840.10008.1.2.4.91 |       |             | |chk|    | |chk|\ :sup:`2` | |chk|\ :sup:`5` |
+| JPEG2000                           | 1.2.840.10008.1.2.4.91 |       |             | |chk|    | |chk|\ :sup:`2` | |chk|\ :sup:`6` |
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
 | JPEG2000 Multi-component Lossless  | 1.2.840.10008.1.2.4.92 |       |             |          |                 |                 |
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
@@ -89,8 +89,9 @@ handled by the given packages:
 | :sup:`1` *only with JpegImagePlugin*
 | :sup:`2` *only with Jpeg2KImagePlugin*
 | :sup:`3` *only if (0028,0100) Bits Allocated = 8*
-| :sup:`4` *with the pylibjpeg-libjpeg plugin*
-| :sup:`5` *with the pylibjpeg-openjpeg plugin*
+| :sup:`4` *with the pylibjpeg-rle plugin and using the :meth:`~pydicom.dataset.Dataset.decompress` method*
+| :sup:`5` *with the pylibjpeg-libjpeg plugin*
+| :sup:`6` *with the pylibjpeg-openjpeg plugin*
 
 Usage
 .....

--- a/doc/old/image_data_handlers.rst
+++ b/doc/old/image_data_handlers.rst
@@ -89,7 +89,7 @@ handled by the given packages:
 | :sup:`1` *only with JpegImagePlugin*
 | :sup:`2` *only with Jpeg2KImagePlugin*
 | :sup:`3` *only if (0028,0100) Bits Allocated = 8*
-| :sup:`4` *with the pylibjpeg-rle plugin and using the* :meth:`~pydicom.dataset.Dataset.decompress` *method*, 4-5x faster than default
+| :sup:`4` *with the pylibjpeg-rle plugin and using the* :meth:`~pydicom.dataset.Dataset.decompress` *method, 4-5x faster than default*
 | :sup:`5` *with the pylibjpeg-libjpeg plugin*
 | :sup:`6` *with the pylibjpeg-openjpeg plugin*
 

--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -55,6 +55,8 @@ Enhancements
 * Ensured :func:`~pydicom.pixel_data_handlers.utils.convert_color_space` uses
   32-bit floats for calculation, added `per_frame` flag to allow frame-by-frame
   processing and improved the speed by ~20-60% (:issue:`1348`)
+* Added support for faster decoding of *RLE Lossless* encoded *Pixel Data* via
+  the `pylibjpeg-rle<https://github.com/pydicom/pylibjpeg-rle>`_ plugin.
 
 
 Changes

--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -56,7 +56,7 @@ Enhancements
   32-bit floats for calculation, added `per_frame` flag to allow frame-by-frame
   processing and improved the speed by ~20-60% (:issue:`1348`)
 * Added support for faster decoding of *RLE Lossless* encoded *Pixel Data* via
-  the `pylibjpeg-rle<https://github.com/pydicom/pylibjpeg-rle>`_ plugin.
+  the `pylibjpeg-rle <https://github.com/pydicom/pylibjpeg-rle>`_ plugin.
 
 
 Changes

--- a/doc/tutorials/installation.rst
+++ b/doc/tutorials/installation.rst
@@ -146,12 +146,12 @@ Installing pylibjpeg
 --------------------
 
 `pylibjpeg <https://github.com/pydicom/pylibjpeg>`_ is a Python framework for
-decompressing JPEG, JPEG-LS and JPEG 2000 images provided a suitable plugin
+decompressing JPEG, JPEG-LS, JPEG 2000 and RLE images provided a suitable plugin
 is installed.
 
 Using pip::
 
-  pip install pylibjpeg pylibjpeg-libjpeg pylibjpeg-openjpeg
+  pip install pylibjpeg pylibjpeg-libjpeg pylibjpeg-openjpeg pylibjpeg-rle
 
 
 .. _tut_install_dev:

--- a/pydicom/pixel_data_handlers/pylibjpeg_handler.py
+++ b/pydicom/pixel_data_handlers/pylibjpeg_handler.py
@@ -41,6 +41,10 @@ values given in the table below.
 | (0028,0103) | PixelRepresentation       | 1    | 0, 1          | Required |
 +-------------+---------------------------+------+---------------+----------+
 
+.. versionchanged:: 2.2
+
+    Added support for *RLE Lossless* via the `pylibjpeg-rle` plugin.
+
 """
 
 import logging
@@ -80,6 +84,12 @@ try:
 except ImportError:
     HAVE_LIBJPEG = False
 
+try:
+    import rle
+    HAVE_RLE = True
+except ImportError:
+    HAVE_RLE = False
+
 from pydicom import config
 from pydicom.encaps import generate_pixel_data_frame
 from pydicom.pixel_data_handlers.util import (
@@ -94,6 +104,7 @@ from pydicom.uid import (
     JPEGLSNearLossless,
     JPEG2000Lossless,
     JPEG2000,
+    RLELossless,
     UID
 )
 
@@ -114,11 +125,12 @@ _LIBJPEG_SYNTAXES = [
     JPEGLSNearLossless
 ]
 _OPENJPEG_SYNTAXES = [JPEG2000Lossless, JPEG2000]
-SUPPORTED_TRANSFER_SYNTAXES = _LIBJPEG_SYNTAXES + _OPENJPEG_SYNTAXES
+_RLE_SYNTAXES = [RLELossless]
+SUPPORTED_TRANSFER_SYNTAXES = (
+    _LIBJPEG_SYNTAXES + _OPENJPEG_SYNTAXES + _RLE_SYNTAXES
+)
 
-DEPENDENCIES = {
-    "numpy": ("http://www.numpy.org/", "NumPy"),
-}
+DEPENDENCIES = {"numpy": ("http://www.numpy.org/", "NumPy")}
 
 
 def is_available() -> bool:
@@ -213,8 +225,10 @@ def generate_frames(ds: "Dataset", reshape: bool = True) -> "np.ndarray":
     if tsyntax not in _DECODERS:
         if tsyntax in _OPENJPEG_SYNTAXES:
             plugin = "pylibjpeg-openjpeg"
-        else:
+        elif tsyntax in _LIBJPEG_SYNTAXES:
             plugin = "pylibjpeg-libjpeg"
+        else:
+            plugin = "pylibjpeg-rle"
 
         raise RuntimeError(
             f"Unable to convert the Pixel Data as the '{plugin}' plugin is "
@@ -239,6 +253,11 @@ def generate_frames(ds: "Dataset", reshape: bool = True) -> "np.ndarray":
     nr_frames = getattr(ds, "NumberOfFrames", 1)
     pixel_module = ds.group_dataset(0x0028)
     dtype = pixel_dtype(ds)
+
+    # RLE Lossless is big-endian encoding
+    if tsyntax == RLELossless:
+        dtype = dtype.newbyteorder('>')
+
     for frame in generate_pixel_data_frame(ds.PixelData, nr_frames):
         arr = decoder(frame, pixel_module)
 
@@ -270,8 +289,13 @@ def generate_frames(ds: "Dataset", reshape: bool = True) -> "np.ndarray":
         if ds.SamplesPerPixel == 1:
             yield arr.reshape(ds.Rows, ds.Columns)
         else:
-            # JPEG, JPEG-LS and JPEG 2000 are all Planar Configuration 0
-            yield arr.reshape(ds.Rows, ds.Columns, ds.SamplesPerPixel)
+            if tsyntax == RLELossless:
+                # RLE Lossless is Planar Configuration 1
+                arr = arr.reshape(ds.SamplesPerPixel, ds.Rows, ds.Columns)
+                yield arr.transpose(1, 2, 0)
+            else:
+                # JPEG, JPEG-LS and JPEG 2000 are all Planar Configuration 0
+                yield arr.reshape(ds.Rows, ds.Columns, ds.SamplesPerPixel)
 
 
 def get_pixeldata(ds: "Dataset") -> "np.ndarray":

--- a/pydicom/tests/test_pylibjpeg.py
+++ b/pydicom/tests/test_pylibjpeg.py
@@ -84,6 +84,20 @@ REFERENCE_DATA_UNSUPPORTED = [
     (DEFL, ('1.2.840.10008.1.2.1.99', '^^^^')),
 ]
 
+# RLE Lossless - PackBits algorithm
+RLE_8_1_1F = get_testdata_file("OBXXXX1A_rle.dcm")
+RLE_8_1_2F = get_testdata_file("OBXXXX1A_rle_2frame.dcm")
+RLE_8_3_1F = get_testdata_file("SC_rgb_rle.dcm")
+RLE_8_3_2F = get_testdata_file("SC_rgb_rle_2frame.dcm")
+RLE_16_1_1F = get_testdata_file("MR_small_RLE.dcm")
+RLE_16_1_10F = get_testdata_file("emri_small_RLE.dcm")
+RLE_16_3_1F = get_testdata_file("SC_rgb_rle_16bit.dcm")
+RLE_16_3_2F = get_testdata_file("SC_rgb_rle_16bit_2frame.dcm")
+RLE_32_1_1F = get_testdata_file("rtdose_rle_1frame.dcm")
+RLE_32_1_15F = get_testdata_file("rtdose_rle.dcm")
+RLE_32_3_1F = get_testdata_file("SC_rgb_rle_32bit.dcm")
+RLE_32_3_2F = get_testdata_file("SC_rgb_rle_32bit_2frame.dcm")
+
 # JPEG - ISO/IEC 10918 Standard
 # FMT_BA_BV_SPX_PR_FRAMESF_PI
 # JPGB: 1.2.840.10008.1.2.4.50 - JPEG Baseline (8-bit only)
@@ -346,7 +360,9 @@ class TestHandler:
             with pytest.raises((NotImplementedError, RuntimeError)):
                 ds.pixel_array
 
-    @pytest.mark.skipif(HAVE_LJ and HAVE_OJ, reason="plugins available")
+    @pytest.mark.skipif(
+        HAVE_LJ and HAVE_OJ and HAVE_RLE, reason="plugins available"
+    )
     def test_no_plugins_raises(self):
         """Test exception raised if required plugin missing."""
         ds = dcmread(JPGB_08_08_3_0_1F_YBR_FULL)
@@ -360,6 +376,14 @@ class TestHandler:
         ds = dcmread(J2KI_08_08_3_0_1F_RGB)
         msg = (
             r"Unable to convert the Pixel Data as the 'pylibjpeg-openjpeg' "
+            r"plugin is not installed"
+        )
+        with pytest.raises(RuntimeError, match=msg):
+            ds.pixel_array
+
+        ds = dcmread(RLE_8_1_1F)
+        msg = (
+            r"Unable to convert the Pixel Data as the 'pylibjpeg-rle' "
             r"plugin is not installed"
         )
         with pytest.raises(RuntimeError, match=msg):
@@ -678,19 +702,6 @@ class TestJPEG2K:
             arr[328:338, 106].tolist()
         )
 
-
-RLE_8_1_1F = get_testdata_file("OBXXXX1A_rle.dcm")
-RLE_8_1_2F = get_testdata_file("OBXXXX1A_rle_2frame.dcm")
-RLE_8_3_1F = get_testdata_file("SC_rgb_rle.dcm")
-RLE_8_3_2F = get_testdata_file("SC_rgb_rle_2frame.dcm")
-RLE_16_1_1F = get_testdata_file("MR_small_RLE.dcm")
-RLE_16_1_10F = get_testdata_file("emri_small_RLE.dcm")
-RLE_16_3_1F = get_testdata_file("SC_rgb_rle_16bit.dcm")
-RLE_16_3_2F = get_testdata_file("SC_rgb_rle_16bit_2frame.dcm")
-RLE_32_1_1F = get_testdata_file("rtdose_rle_1frame.dcm")
-RLE_32_1_15F = get_testdata_file("rtdose_rle.dcm")
-RLE_32_3_1F = get_testdata_file("SC_rgb_rle_32bit.dcm")
-RLE_32_3_2F = get_testdata_file("SC_rgb_rle_32bit_2frame.dcm")
 
 RLE_REFERENCE_DATA = [
     # fpath, (bits, nr samples, pixel repr, nr frames, shape, dtype)

--- a/pydicom/tests/test_pylibjpeg.py
+++ b/pydicom/tests/test_pylibjpeg.py
@@ -20,6 +20,7 @@ from pydicom.uid import (
     JPEGLSNearLossless,
     JPEG2000Lossless,
     JPEG2000,
+    RLELossless,
     AllTransferSyntaxes
 )
 
@@ -39,17 +40,20 @@ try:
     HAVE_PYLIBJPEG = LJ_HANDLER.HAVE_PYLIBJPEG
     HAVE_LJ = LJ_HANDLER.HAVE_LIBJPEG
     HAVE_OJ = LJ_HANDLER.HAVE_OPENJPEG
+    HAVE_RLE = LJ_HANDLER.HAVE_RLE
 except ImportError:
     LJ_HANDLER = None
     HAVE_PYLIBJPEG = False
     HAVE_LJ = False
     HAVE_OJ = False
+    HAVE_RLE = False
 
 
 TEST_HANDLER = HAVE_NP and HAVE_PYLIBJPEG  # Run handler tests
 TEST_JPEG = TEST_HANDLER and HAVE_LJ  # Run 10918 JPEG tests
 TEST_JPEGLS = TEST_HANDLER and HAVE_LJ  # Run 14495 JPEG-LS tests
 TEST_JPEG2K = TEST_HANDLER and HAVE_OJ  # Run 15444 JPEG 2000 tests
+TEST_RLE = TEST_HANDLER and HAVE_RLE  # Run RLE Lossless tests
 
 
 SUPPORTED_SYNTAXES = [
@@ -60,7 +64,8 @@ SUPPORTED_SYNTAXES = [
     JPEGLSLossless,
     JPEGLSNearLossless,
     JPEG2000Lossless,
-    JPEG2000
+    JPEG2000,
+    RLELossless,
 ]
 UNSUPPORTED_SYNTAXES = list(
     set(AllTransferSyntaxes) ^ set(SUPPORTED_SYNTAXES)
@@ -71,14 +76,12 @@ IMPL = get_testdata_file("MR_small_implicit.dcm")
 EXPL = get_testdata_file("OBXXXX1A.dcm")
 EXPB = get_testdata_file("OBXXXX1A_expb.dcm")
 DEFL = get_testdata_file("image_dfl.dcm")
-RLE = get_testdata_file("MR_small_RLE.dcm")
 
 REFERENCE_DATA_UNSUPPORTED = [
     (IMPL, ('1.2.840.10008.1.2', 'CompressedSamples^MR1')),
     (EXPL, ('1.2.840.10008.1.2.1', 'OB^^^^')),
     (EXPB, ('1.2.840.10008.1.2.2', 'OB^^^^')),
     (DEFL, ('1.2.840.10008.1.2.1.99', '^^^^')),
-    (RLE, ('1.2.840.10008.1.2.5', 'CompressedSamples^MR1')),
 ]
 
 # JPEG - ISO/IEC 10918 Standard
@@ -674,3 +677,116 @@ class TestJPEG2K:
         assert [-377, -121, 141, 383, 633, 910, 1198, 1455, 1638, 1732] == (
             arr[328:338, 106].tolist()
         )
+
+
+RLE_8_1_1F = get_testdata_file("OBXXXX1A_rle.dcm")
+RLE_8_1_2F = get_testdata_file("OBXXXX1A_rle_2frame.dcm")
+RLE_8_3_1F = get_testdata_file("SC_rgb_rle.dcm")
+RLE_8_3_2F = get_testdata_file("SC_rgb_rle_2frame.dcm")
+RLE_16_1_1F = get_testdata_file("MR_small_RLE.dcm")
+RLE_16_1_10F = get_testdata_file("emri_small_RLE.dcm")
+RLE_16_3_1F = get_testdata_file("SC_rgb_rle_16bit.dcm")
+RLE_16_3_2F = get_testdata_file("SC_rgb_rle_16bit_2frame.dcm")
+RLE_32_1_1F = get_testdata_file("rtdose_rle_1frame.dcm")
+RLE_32_1_15F = get_testdata_file("rtdose_rle.dcm")
+RLE_32_3_1F = get_testdata_file("SC_rgb_rle_32bit.dcm")
+RLE_32_3_2F = get_testdata_file("SC_rgb_rle_32bit_2frame.dcm")
+
+RLE_REFERENCE_DATA = [
+    # fpath, (bits, nr samples, pixel repr, nr frames, shape, dtype)
+    (RLE_8_1_1F, (8, 1, 0, 1, (600, 800), 'uint8')),
+    (RLE_8_1_2F, (8, 1, 0, 2, (2, 600, 800), 'uint8')),
+    (RLE_8_3_1F, (8, 3, 0, 1, (100, 100, 3), 'uint8')),
+    (RLE_8_3_2F, (8, 3, 0, 2, (2, 100, 100, 3), 'uint8')),
+    (RLE_16_1_1F, (16, 1, 1, 1, (64, 64), 'int16')),
+    (RLE_16_1_10F, (16, 1, 0, 10, (10, 64, 64), 'uint16')),
+    (RLE_16_3_1F, (16, 3, 0, 1, (100, 100, 3), 'uint16')),
+    (RLE_16_3_2F, (16, 3, 0, 2, (2, 100, 100, 3), 'uint16')),
+    (RLE_32_1_1F, (32, 1, 0, 1, (10, 10), 'uint32')),
+    (RLE_32_1_15F, (32, 1, 0, 15, (15, 10, 10), 'uint32')),
+    (RLE_32_3_1F, (32, 3, 0, 1, (100, 100, 3), 'uint32')),
+    (RLE_32_3_2F, (32, 3, 0, 2, (2, 100, 100, 3), 'uint32')),
+]
+RLE_MATCHING_DATASETS = [
+    # (compressed, reference)
+    pytest.param(RLE_8_1_1F, get_testdata_file("OBXXXX1A.dcm")),
+    pytest.param(RLE_8_1_2F, get_testdata_file("OBXXXX1A_2frame.dcm")),
+    pytest.param(RLE_8_3_1F, get_testdata_file("SC_rgb.dcm")),
+    pytest.param(RLE_8_3_2F, get_testdata_file("SC_rgb_2frame.dcm")),
+    pytest.param(RLE_16_1_1F, get_testdata_file("MR_small.dcm")),
+    pytest.param(RLE_16_1_10F, get_testdata_file("emri_small.dcm")),
+    pytest.param(RLE_16_3_1F, get_testdata_file("SC_rgb_16bit.dcm")),
+    pytest.param(RLE_16_3_2F, get_testdata_file("SC_rgb_16bit_2frame.dcm")),
+    pytest.param(RLE_32_1_1F, get_testdata_file("rtdose_1frame.dcm")),
+    pytest.param(RLE_32_1_15F, get_testdata_file("rtdose.dcm")),
+    pytest.param(RLE_32_3_1F, get_testdata_file("SC_rgb_32bit.dcm")),
+    pytest.param(RLE_32_3_2F, get_testdata_file("SC_rgb_32bit_2frame.dcm")),
+]
+
+
+@pytest.mark.skipif(not TEST_RLE, reason="no -rle plugin")
+class TestRLE:
+    def test_decompress_using_pylibjpeg(self):
+        """Test decompressing RLE with pylibjpeg handler succeeds."""
+        ds = dcmread(RLE_8_3_1F)
+        ds.decompress(handler_name='pylibjpeg')
+        arr = ds.pixel_array
+
+        ds = dcmread(get_testdata_file("SC_rgb.dcm"))
+        ref = ds.pixel_array
+        assert np.array_equal(arr, ref)
+
+    @pytest.mark.parametrize('fpath, data', RLE_REFERENCE_DATA)
+    def test_properties_as_array(self, fpath, data):
+        """Test dataset, pixel_array and as_array() are as expected."""
+        ds = dcmread(fpath)
+        assert RLELossless == ds.file_meta.TransferSyntaxUID
+        assert ds.BitsAllocated == data[0]
+        assert ds.SamplesPerPixel == data[1]
+        assert ds.PixelRepresentation == data[2]
+        assert getattr(ds, 'NumberOfFrames', 1) == data[3]
+
+        # Note: decompress modifies the dataset inplace
+        ds.decompress("pylibjpeg")
+
+        # Check Dataset.pixel_array
+        arr = ds.pixel_array
+        assert arr.flags.writeable
+        assert data[4] == arr.shape
+        assert arr.dtype == data[5]
+
+        # Check handler's as_array() function
+        ds = dcmread(fpath)
+        arr = as_array(ds)
+        assert arr.flags.writeable
+        assert data[4] == arr.shape
+        assert arr.dtype == data[5]
+
+    @pytest.mark.parametrize('fpath, rpath', RLE_MATCHING_DATASETS)
+    def test_array(self, fpath, rpath):
+        """Test pixel_array returns correct values."""
+        ds = dcmread(fpath)
+        ds.decompress("pylibjpeg")
+        arr = ds.pixel_array
+
+        ref = dcmread(rpath).pixel_array
+        assert np.array_equal(arr, ref)
+
+    @pytest.mark.parametrize('fpath, rpath', RLE_MATCHING_DATASETS)
+    def test_generate_frames(self, fpath, rpath):
+        """Test pixel_array returns correct values."""
+        ds = dcmread(fpath)
+        frame_generator = generate_frames(ds)
+        ref = dcmread(rpath).pixel_array
+
+        nr_frames = getattr(ds, 'NumberOfFrames', 1)
+        for ii in range(nr_frames):
+            arr = next(frame_generator)
+
+            if nr_frames > 1:
+                assert np.array_equal(arr, ref[ii, ...])
+            else:
+                assert np.array_equal(arr, ref)
+
+        with pytest.raises(StopIteration):
+            next(frame_generator)


### PR DESCRIPTION
#### Describe the changes
Add support for RLE decoding (via pylibjpeg-rle plugin) to the pylibjpeg handler, generally about 4-5x faster than the default for real world data

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://2766-14006067-gh.circle-artifacts.com/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
