### PR TITLE
[MRG] Change representation of DA, DT and TM to be a DICOM-conform string

### DIFF
--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -65,6 +65,11 @@ Changes
 * :meth:`BaseTag.__eq__()<pydicom.tag.BaseTag.__eq__>` returns ``False`` rather
   than raising an exception when the operand cannot be converted to
   :class:`~pydicom.tag.BaseTag` (:pr:`1327`)
+* :meth:`DA.__str__()<pydicom.valuerep.DA.__str__>`,
+  :meth:`DT.__str__()<pydicom.valuerep.DT.__str__>` and
+  :meth:`TM.__str__()<pydicom.valuerep.TM.__str__>` return valid DICOM
+  strings instead of the formatted date and time representations
+  (:issue:`1262`)
 
 Fixes
 -----

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -300,8 +300,7 @@ class TestScratchWriteDateTime(TestWriteFile):
         DA_expected = date(1961, 8, 4)
         tzinfo = timezone(timedelta(seconds=-21600), '-0600')
         multi_DT_expected = (datetime(1961, 8, 4), datetime(
-            1963, 11, 22, 12, 30, 0, 0,
-            timezone(timedelta(seconds=-21600), '-0600')))
+            1963, 11, 22, 12, 30, 0, 0, tzinfo))
         multi_TM_expected = (time(1, 23, 45), time(11, 11, 11))
         TM_expected = time(11, 11, 11, 1)
         ds = dcmread(datetime_name)

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -69,11 +69,15 @@ class TestTM:
 
     def test_str(self):
         """Test str(TM)."""
-        x = pydicom.valuerep.TM("212223")
-        assert "212223" == str(x)
-        del x.original_string
-        assert not hasattr(x, 'original_string')
-        assert "21:22:23" == str(x)
+        assert "212223.1234" == str(pydicom.valuerep.TM("212223.1234"))
+        assert "212223" == str(pydicom.valuerep.TM("212223"))
+        assert "212223" == str(pydicom.valuerep.TM("212223"))
+        assert "2122" == str(pydicom.valuerep.TM("2122"))
+        assert "21" == str(pydicom.valuerep.TM("21"))
+        assert "212223" == str(pydicom.valuerep.TM(time(21, 22, 23)))
+        assert "212223.000024" == str(
+            pydicom.valuerep.TM(time(21, 22, 23, 24)))
+        assert "010203" == str(pydicom.valuerep.TM(time(1, 2, 3)))
 
     def test_new_empty_str(self):
         """Test converting an empty string."""
@@ -185,6 +189,18 @@ class TestDT:
         with pytest.raises(ValueError, match=msg):
             pydicom.valuerep.DT("a2000,00,00")
 
+    def test_str(self):
+        dt = datetime(1911, 12, 13, 21, 21, 23)
+        assert "19111213212123" == str(pydicom.valuerep.DT(dt))
+        assert "19111213212123" == str(pydicom.valuerep.DT("19111213212123"))
+        assert "1001.02.03" == str(pydicom.valuerep.DA("1001.02.03"))
+        tz_info = timezone(timedelta(seconds=21600), '+0600')
+        dt = datetime(2022, 1, 2, 8, 9, 7, 123456, tzinfo=tz_info)
+        assert "20220102080907.123456+0600" == str(pydicom.valuerep.DT(dt))
+        tz_info = timezone(timedelta(seconds=-23400), '-0630')
+        dt = datetime(2022, 12, 31, 23, 59, 59, 42, tzinfo=tz_info)
+        assert "20221231235959.000042-0630" == str(pydicom.valuerep.DT(dt))
+
 
 class TestDA:
     """Unit tests for pickling DA"""
@@ -212,6 +228,11 @@ class TestDA:
         msg = r"Unable to convert '123456' to 'DA' object"
         with pytest.raises(ValueError, match=msg):
             pydicom.valuerep.DA(123456)
+
+    def test_str(self):
+        assert "10010203" == str(pydicom.valuerep.DA(date(1001, 2, 3)))
+        assert "10010203" == str(pydicom.valuerep.DA("10010203"))
+        assert "1001.02.03" == str(pydicom.valuerep.DA("1001.02.03"))
 
 
 class TestIsValidDS:

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -135,6 +135,8 @@ class DA(_DateTimeBase, datetime.date):
             self.original_string = val
         elif isinstance(val, DA) and hasattr(val, 'original_string'):
             self.original_string = val.original_string
+        elif isinstance(val, datetime.date):
+            self.original_string = f"{val.year}{val.month:02}{val.day:02}"
 
 
 class DT(_DateTimeBase, datetime.datetime):
@@ -242,6 +244,22 @@ class DT(_DateTimeBase, datetime.datetime):
             self.original_string = val
         elif isinstance(val, DT) and hasattr(val, 'original_string'):
             self.original_string = val.original_string
+        elif isinstance(val, datetime.datetime):
+            self.original_string = (
+                f"{val.year:04}{val.month:02}{val.day:02}"
+                f"{val.hour:02}{val.minute:02}{val.second:02}"
+            )
+            # milliseconds are seldom used, add them only if needed
+            if val.microsecond > 0:
+                self.original_string += f".{val.microsecond:06}"
+            if val.tzinfo is not None:
+                offset = val.tzinfo.utcoffset(val)
+                offset_min = offset.days * 24 * 60 + offset.seconds // 60
+                sign = "+" if offset_min >= 0 else "-"
+                offset_min = abs(offset_min)
+                self.original_string += (
+                    f"{sign}{offset_min // 60:02}{offset_min % 60:02}"
+                )
 
 
 class TM(_DateTimeBase, datetime.time):
@@ -318,6 +336,13 @@ class TM(_DateTimeBase, datetime.time):
             self.original_string = val
         elif isinstance(val, TM) and hasattr(val, 'original_string'):
             self.original_string = val.original_string
+        elif isinstance(val, datetime.time):
+            self.original_string = (
+                f"{val.hour:02}{val.minute:02}{val.second:02}"
+            )
+            # milliseconds are seldom used, add them only if needed
+            if val.microsecond > 0:
+                self.original_string += f".{val.microsecond:06}"
 
     if platform.python_implementation() == "PyPy":
         # Workaround for CPython/PyPy bug in time.__reduce_ex__()


### PR DESCRIPTION
- use original_string to save the DICOM-conform representation
- fixes #1262

Please check if this change would be ok now, or we need a configurable option, or shall defer the change until 3.0 (if we want to make it at all).

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Unit tests passing and overall coverage the same or better
