### PR TITLE
[MRG] Fix for pylibjpeg-rle changing byte order of returned data

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -173,7 +173,7 @@ jobs:
       if: ${{ matrix.pylibjpeg-dep == 'pylibjpeg' }}
       run: |
         python -m pip install pylibjpeg
-        python -m pip uninstall -y pylibjpeg-openjpeg
+        python -m pip uninstall -y pylibjpeg-openjpeg pylibjpeg-rle
         pytest ${{ matrix.pytest-args }} pydicom/tests/test_pylibjpeg.py
         python -m pip install pylibjpeg-openjpeg pylibjpeg-libjpeg pylibjpeg-rle
         pytest ${{ matrix.pytest-args }} pydicom/tests/test_pylibjpeg.py

--- a/pydicom/pixel_data_handlers/pylibjpeg_handler.py
+++ b/pydicom/pixel_data_handlers/pylibjpeg_handler.py
@@ -254,10 +254,6 @@ def generate_frames(ds: "Dataset", reshape: bool = True) -> "np.ndarray":
     pixel_module = ds.group_dataset(0x0028)
     dtype = pixel_dtype(ds)
 
-    # RLE Lossless is big-endian encoding
-    if tsyntax == RLELossless:
-        dtype = dtype.newbyteorder('>')
-
     for frame in generate_pixel_data_frame(ds.PixelData, nr_frames):
         arr = decoder(frame, pixel_module)
 


### PR DESCRIPTION
#### Describe the changes
pylibjpeg-rle v1.1 changes the byte order from big to little endian for returned decoded data. See also #1364

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
