### PR TITLE
[MRG] Allow to deepcopy a FileDataset object

### DIFF
--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -90,3 +90,4 @@ Fixes
   :class:`~pydicom.valuerep.PersonName` (:issue:`1338`)
 * Fixed handling of JPEG (10918-1) images compressed using RGB colourspace
   rather than YBR with the Pillow pixel data handler (:pr:`878`)
+* Allow to deepcopy a `~pydicom.dataset.FileDataset` object (:issue:`1147`)

--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -16,7 +16,10 @@ Changes
   :meth:`TM.__str__()<pydicom.valuerep.TM.__str__>` return valid DICOM
   strings instead of the formatted date and time representations
   (:issue:`1262`)
-
+* If comparing :class:`~pydicom.dataset.FileDataset` instances, the file
+  metadata is now ignored. This makes it possible to compare a
+  :class:`~pydicom.dataset.FileDataset` object with a
+  :class:`~pydicom.dataset.Dataset` object.
 
 Enhancements
 ------------

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -2561,6 +2561,9 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
     __repr__ = __str__
 
 
+_FileDataset = TypeVar("_FileDataset", bound="FileDataset")
+
+
 class FileDataset(Dataset):
     """An extension of :class:`Dataset` to make reading and writing to
     file-like easier.
@@ -2675,12 +2678,10 @@ class FileDataset(Dataset):
             return True
 
         if isinstance(other, self.__class__):
-            # exclude the filename from the comparison if both objects have
-            # a file-like or None as the file name
-            excludes = ['_dict']
-            if (not isinstance(self.filename, str) and
-                    not isinstance(other.filename, str)):
-                excludes.append('filename')
+            # exclude all metadata from the comparison
+            # only the actual dataset content shall be compared
+            excludes = ("_dict", 'filename', "preamble", "file_meta",
+                        "is_implicit_VR", "is_little_endian", "timestamp")
             return (
                     _dict_equal(self, other) and
                     _dict_equal(self.__dict__, other.__dict__,
@@ -2689,7 +2690,7 @@ class FileDataset(Dataset):
 
         return NotImplemented
 
-    def _copy_implementation(self, copy_function: Callable) -> "FileDataset":
+    def _copy_implementation(self, copy_function: Callable) -> _FileDataset:
         """Implementation of ``__copy__`` and ``__deepcopy__``.
         Sets the filename to ``None`` if it isn't a string,
         and copies all other attributes using `copy_function`.
@@ -2710,7 +2711,7 @@ class FileDataset(Dataset):
         self.filename = filename
         return copied
 
-    def __copy__(self) -> "FileDataset":
+    def __copy__(self) -> _FileDataset:
         """Return a shallow copy of the file dataset.
         Make sure that the filename is not copied in case it is a file-like
         object.
@@ -2722,7 +2723,7 @@ class FileDataset(Dataset):
         """
         return self._copy_implementation(copy.copy)
 
-    def __deepcopy__(self, _) -> "FileDataset":
+    def __deepcopy__(self, _) -> _FileDataset:
         """Return a deep copy of the file dataset.
         Make sure that the filename is not copied in case it is a file-like
         object.

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -2661,35 +2661,6 @@ class FileDataset(Dataset):
                 statinfo = os.stat(filename)
                 self.timestamp = statinfo.st_mtime
 
-    def __eq__(self, other: object) -> bool:
-        """Compare `self` and `other` for equality.
-
-        Returns
-        -------
-        bool
-            The result if `self` and `other` are the same class
-        NotImplemented
-            If `other` is not the same class as `self` then returning
-            :class:`NotImplemented` delegates the result to
-            ``superclass.__eq__(subclass)``.
-        """
-        # When comparing against self this will be faster
-        if other is self:
-            return True
-
-        if isinstance(other, self.__class__):
-            # exclude all metadata from the comparison
-            # only the actual dataset content shall be compared
-            excludes = ("_dict", 'filename', "preamble", "file_meta",
-                        "is_implicit_VR", "is_little_endian", "timestamp")
-            return (
-                    _dict_equal(self, other) and
-                    _dict_equal(self.__dict__, other.__dict__,
-                                exclude=excludes)
-            )
-
-        return NotImplemented
-
     def _copy_implementation(self, copy_function: Callable) -> _FileDataset:
         """Implementation of ``__copy__`` and ``__deepcopy__``.
         Sets the filename to ``None`` if it isn't a string,

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1866,6 +1866,8 @@ class TestFileDataset:
         ds = pydicom.dcmread(buff)
         buff.close()
         ds_copy = copy.copy(ds)
+        assert ds.filename is not None
+        assert ds_copy.filename is None
         assert ds_copy == ds
 
     def test_deepcopy_filedataset(self):
@@ -1874,8 +1876,10 @@ class TestFileDataset:
             data = fb.read()
         buff = io.BytesIO(data)
         ds = pydicom.dcmread(buff)
-        # buff.close()
+        buff.close()
         ds_copy = copy.deepcopy(ds)
+        assert ds.filename is not None
+        assert ds_copy.filename is None
         assert ds_copy == ds
 
 

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -2,6 +2,7 @@
 """Unit tests for the pydicom.dataset module."""
 
 import copy
+import io
 import math
 import pickle
 import weakref
@@ -1857,6 +1858,25 @@ class TestFileDataset:
         di = dict()
         expected_diff = {'__class__', '__doc__', '__hash__'}
         assert expected_diff == set(dir(di)) - set(dir(ds))
+
+    def test_copy_filedataset(self):
+        with open(get_testdata_file('CT_small.dcm'), 'rb') as fb:
+            data = fb.read()
+        buff = io.BytesIO(data)
+        ds = pydicom.dcmread(buff)
+        buff.close()
+        ds_copy = copy.copy(ds)
+        assert ds_copy == ds
+
+    def test_deepcopy_filedataset(self):
+        # regression test for #1147
+        with open(get_testdata_file('CT_small.dcm'), 'rb') as fb:
+            data = fb.read()
+        buff = io.BytesIO(data)
+        ds = pydicom.dcmread(buff)
+        # buff.close()
+        ds_copy = copy.deepcopy(ds)
+        assert ds_copy == ds
 
 
 class TestDatasetOverlayArray:

--- a/pydicom/tests/test_fileset.py
+++ b/pydicom/tests/test_fileset.py
@@ -1375,15 +1375,14 @@ class TestFileSet:
         root = os.fspath(Path(*Path(tdir.name).parts[-2:]))
         assert root in s
         assert 1 == len(paths)
-        # Only want to compare Dataset rather than FileDataset
-        assert Dataset(ct) == dcmread(paths[0])
+        assert ct == dcmread(paths[0])
 
         # Calling write() again shouldn't change anything
         ds2, paths = write_fs(fs)
-        assert Dataset(ds) == ds2
+        assert ds == ds2
         assert ds2.filename == ds.filename
         assert 1 == len(paths)
-        assert Dataset(ct) == dcmread(paths[0])
+        assert ct == dcmread(paths[0])
 
     def test_add_bad_dataset(self, ct):
         """Test adding a dataset missing Type 1 element value."""

--- a/pydicom/tests/test_json.py
+++ b/pydicom/tests/test_json.py
@@ -160,7 +160,7 @@ class TestAT:
 
 class TestDataSetToJson:
     def test_json_from_dicom_file(self, no_numpy_use):
-        ds1 = Dataset(dcmread(get_testdata_file("CT_small.dcm")))
+        ds1 = dcmread(get_testdata_file("CT_small.dcm"))
         ds_json = ds1.to_json()
         ds2 = Dataset.from_json(ds_json)
         assert ds1 == ds2


### PR DESCRIPTION
- avoids copying the filename which can be a file-like object
- fixes #1147

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
