### PR TITLE
[MRG] Improve test robustness

### DIFF
--- a/pydicom/tests/test_pylibjpeg.py
+++ b/pydicom/tests/test_pylibjpeg.py
@@ -818,7 +818,7 @@ class TestRLEEncoding:
         ds.compress(RLELossless, ref, encoding_plugin='pylibjpeg')
         assert expected > len(ds.PixelData)
         assert np.array_equal(ref, ds.pixel_array)
-        assert id(ref) != id(ds.pixel_array)
+        assert ref is not ds.pixel_array
 
     def test_encode_bit(self):
         """Test encoding big-endian src"""

--- a/pydicom/tests/test_pylibjpeg.py
+++ b/pydicom/tests/test_pylibjpeg.py
@@ -815,6 +815,7 @@ class TestRLEEncoding:
         assert expected == len(ds.PixelData)
         ref = ds.pixel_array
         del ds.PixelData
+        del ds._pixel_array
         ds.compress(RLELossless, ref, encoding_plugin='pylibjpeg')
         assert expected > len(ds.PixelData)
         assert np.array_equal(ref, ds.pixel_array)
@@ -824,6 +825,7 @@ class TestRLEEncoding:
         """Test encoding big-endian src"""
         ds = dcmread(IMPL)
         ref = ds.pixel_array
+        del ds._pixel_array
         ds.compress(
             RLELossless,
             ds.PixelData,
@@ -831,4 +833,4 @@ class TestRLEEncoding:
             encoding_plugin='pylibjpeg'
         )
         assert np.array_equal(ref.newbyteorder('>'), ds.pixel_array)
-        assert id(ref) != id(ds.pixel_array)
+        assert ref is not ds.pixel_array


### PR DESCRIPTION
Trial fix for intermittently failing test:
```python
_________________________ TestRLEEncoding.test_encode __________________________

self = <pydicom.tests.test_pylibjpeg.TestRLEEncoding object at 0x7f6c4cd1acd0>

    def test_encode(self):
        """Test encoding"""
        ds = dcmread(EXPL)
        assert 'PlanarConfiguration' not in ds
        expected = get_expected_length(ds, 'bytes')
        assert expected == len(ds.PixelData)
        ref = ds.pixel_array
        del ds.PixelData
        ds.compress(RLELossless, ref, encoding_plugin='pylibjpeg')
        assert expected > len(ds.PixelData)
        assert np.array_equal(ref, ds.pixel_array)
>       assert id(ref) != id(ds.pixel_array)
E       AssertionError: assert 140103122488560 != 140103122488560
E        +  where 140103122488560 = id(array([[244, 244, 244, ..., 244, 244, 244],\n       [244, 244, 244, ..., 244, 244, 244],\n       [244, 244, 244, ..., 24...,   0,   0,   0],\n       [  0,   0,   0, ...,   0,   0,   0],\n       [  0,   0,   0, ...,   0,   0,   0]], dtype=uint8))
E        +  and   140103122488560 = id(array([[244, 244, 244, ..., 244, 244, 244],\n       [244, 244, 244, ..., 244, 244, 244],\n       [244, 244, 244, ..., 24...,   0,   0,   0],\n       [  0,   0,   0, ...,   0,   0,   0],\n       [  0,   0,   0, ...,   0,   0,   0]], dtype=uint8))
E        +    where array([[244, 244, 244, ..., 244, 244, 244],\n       [244, 244, 244, ..., 244, 244, 244],\n       [244, 244, 244, ..., 24...,   0,   0,   0],\n       [  0,   0,   0, ...,   0,   0,   0],\n       [  0,   0,   0, ...,   0,   0,   0]], dtype=uint8) = Dataset.file_meta -------------------------------\n(0002, 0000) File Meta Information Group Length  UL: 190\n(0002, 0001...UT Shape              CS: 'IDENTITY'\n(7fe0, 0010) Pixel Data                          OB or OW: Array of 46576 elements.pixel_array

pydicom/tests/test_pylibjpeg.py:821: AssertionError
```
No idea why this sometimes fails