### PR TITLE
[MRG] Fix IS returning None for empty str

### DIFF
--- a/.github/workflows/pr-typing.yml
+++ b/.github/workflows/pr-typing.yml
@@ -26,7 +26,7 @@ jobs:
         pip install mypy
     - name: Enable typing
       run: |
-        touch pydicom/pydicom/py.typed
+        touch pydicom/py.typed
     - name: Run typing check with mypy
       run: |
         mypy

--- a/pydicom/tests/test_util.py
+++ b/pydicom/tests/test_util.py
@@ -85,7 +85,7 @@ class TestCodify:
         # DataElement(0x00080301, 'US', 1200)]
         out_str = ["ds.PatientName = # XXX Array of 7 bytes excluded",
                    "ds.CodingSchemeUID = '1.1'",
-                   'ds.SeriesNumber = "3"']
+                   "ds.SeriesNumber = '3'"]
         # Fails
         # "ds.PrivateGroupReference = 1200"]
         for elem, out in zip(input_elem, out_str):

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -701,10 +701,11 @@ class TestDSdecimal:
         # Not equal because float(1.2) != Decimal('1.2')
         assert DSdecimal('1.20') != 1.2
         assert DSdecimal('1.20') != 1.20
-        assert DSdecimal('1.20') == Decimal(1.2)
-        assert DSdecimal('1.20') == Decimal(1.20)
-        assert DSdecimal('1.20 ') == Decimal(1.2)
-        assert DSdecimal('1.20 ') == Decimal(1.20)
+        # Decimal(1.2) is different to Decimal('1.2')
+        assert DSdecimal('1.20') == Decimal('1.2')
+        assert DSdecimal('1.20') == Decimal('1.20')
+        assert DSdecimal('1.20 ') == Decimal('1.2')
+        assert DSdecimal('1.20 ') == Decimal('1.20')
         assert DSdecimal('1.20') != '1.2'
         assert DSdecimal('1.20') == '1.20'
         assert DSdecimal('1.20 ') == '1.20'

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -738,7 +738,7 @@ class TestIS:
     """Unit tests for IS"""
     def test_empty_value(self):
         assert IS(None) is None
-        assert IS("") is None
+        assert IS("") == ""
 
     def test_valid_value(self):
         assert 42 == IS(42)

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -17,7 +17,8 @@ import pydicom
 from pydicom import config
 from pydicom import valuerep
 from pydicom.data import get_testdata_file
-from pydicom.valuerep import DS, IS
+from pydicom.dataset import Dataset
+from pydicom.valuerep import DS, IS, DSfloat, DSdecimal
 import pytest
 
 from pydicom.valuerep import PersonName
@@ -488,10 +489,10 @@ class TestDS:
 
     def test_float_values(self):
         val = DS(0.9)
-        assert isinstance(val, pydicom.valuerep.DSfloat)
+        assert isinstance(val, DSfloat)
         assert 0.9 == val
         val = DS("0.9")
-        assert isinstance(val, pydicom.valuerep.DSfloat)
+        assert isinstance(val, DSfloat)
         assert 0.9 == val
 
 
@@ -499,33 +500,41 @@ class TestDSfloat:
     """Unit tests for pickling DSfloat"""
     def test_pickling(self):
         # Check that a pickled DSFloat is read back properly
-        x = pydicom.valuerep.DSfloat(9.0)
+        x = DSfloat(9.0)
         x.original_string = "hello"
         data1_string = pickle.dumps(x)
         x2 = pickle.loads(data1_string)
         assert x.real == x2.real
         assert x.original_string == x2.original_string
 
+    def test_new_empty(self):
+        """Test passing an empty value."""
+        assert isinstance(DSfloat(''), str)
+        assert DSfloat('') == ''
+        assert DSfloat(None) is None
+
     def test_str(self):
         """Test DSfloat.__str__()."""
-        val = pydicom.valuerep.DSfloat(1.1)
-        assert "1.1" == str(val)
+        val = DSfloat(1.1)
+        assert str(val) == '1.1'
 
-        val = pydicom.valuerep.DSfloat("1.1")
-        assert "1.1" == str(val)
+        val = DSfloat("1.1")
+        assert str(val) == '1.1'
 
     def test_repr(self):
         """Test DSfloat.__repr__()."""
-        val = pydicom.valuerep.DSfloat(1.1)
-        assert '"1.1"' == repr(val)
+        val = DSfloat(1.1)
+        assert repr(val) == "'1.1'"
 
-        val = pydicom.valuerep.DSfloat("1.1")
-        assert '"1.1"' == repr(val)
+        val = DSfloat("1.1")
+        assert repr(val) == "'1.1'"
+        assert repr(val) == repr("1.1")
+        assert repr(val) == repr('1.1')
 
     def test_DSfloat(self):
         """Test creating a value using DSfloat."""
-        x = pydicom.valuerep.DSfloat('1.2345')
-        y = pydicom.valuerep.DSfloat(x)
+        x = DSfloat('1.2345')
+        y = DSfloat(x)
         assert x == y
         assert y == x
         assert 1.2345 == y
@@ -533,54 +542,54 @@ class TestDSfloat:
 
     def test_DSdecimal(self):
         """Test creating a value using DSdecimal."""
-        x = pydicom.valuerep.DSdecimal('1.2345')
-        y = pydicom.valuerep.DSfloat(x)
+        x = DSdecimal('1.2345')
+        y = DSfloat(x)
         assert 1.2345 == y
         assert "1.2345" == y.original_string
 
     def test_auto_format(self, enforce_valid_both_fixture):
         """Test truncating floats"""
-        x = pydicom.valuerep.DSfloat(math.pi, auto_format=True)
+        x = DSfloat(math.pi, auto_format=True)
 
         # Float representation should be unaltered by truncation
         assert x == math.pi
         # String representations should be correctly formatted
         assert str(x) == '3.14159265358979'
-        assert repr(x) == '"3.14159265358979"'
+        assert repr(x) == repr('3.14159265358979')
 
     def test_auto_format_from_invalid_DS(self):
         """Test truncating floats"""
         # A DSfloat that has a non-valid string representation
-        x = pydicom.valuerep.DSfloat(math.pi)
+        x = DSfloat(math.pi)
 
         # Use this to initialise another with auto_format set to true
-        y = pydicom.valuerep.DSfloat(x, auto_format=True)
+        y = DSfloat(x, auto_format=True)
 
         # Float representation should be unaltered by truncation
         assert y == math.pi
         # String representations should be correctly formatted
         assert str(y) == '3.14159265358979'
-        assert repr(y) == '"3.14159265358979"'
+        assert repr(y) == repr("3.14159265358979")
 
     def test_auto_format_invalid_string(self, enforce_valid_both_fixture):
         """If the user supplies an invalid string, this should be formatted."""
-        x = pydicom.valuerep.DSfloat('3.141592653589793', auto_format=True)
+        x = DSfloat('3.141592653589793', auto_format=True)
 
         # Float representation should be unaltered by truncation
         assert x == float('3.141592653589793')
         # String representations should be correctly formatted
         assert str(x) == '3.14159265358979'
-        assert repr(x) == '"3.14159265358979"'
+        assert repr(x) == repr("3.14159265358979")
 
     def test_auto_format_valid_string(self, enforce_valid_both_fixture):
         """If the user supplies a valid string, this should not be altered."""
-        x = pydicom.valuerep.DSfloat('1.234e-1', auto_format=True)
+        x = DSfloat('1.234e-1', auto_format=True)
 
         # Float representation should be correct
         assert x == 0.1234
         # String representations should be unaltered
         assert str(x) == '1.234e-1'
-        assert repr(x) == '"1.234e-1"'
+        assert repr(x) == repr("1.234e-1")
 
     def test_enforce_valid_values_length(self, enforce_valid_true_fixture):
         """Test that errors are raised when length is too long."""
@@ -589,14 +598,14 @@ class TestDSfloat:
 
     def test_DSfloat_auto_format(self):
         """Test creating a value using DSfloat copies auto_format"""
-        x = pydicom.valuerep.DSfloat(math.pi, auto_format=True)
-        y = pydicom.valuerep.DSfloat(x)
+        x = DSfloat(math.pi, auto_format=True)
+        y = DSfloat(x)
         assert x == y
         assert y == x
         assert y.auto_format
         assert math.pi == y
         assert str(y) == '3.14159265358979'
-        assert repr(y) == '"3.14159265358979"'
+        assert repr(y) == repr("3.14159265358979")
 
     @pytest.mark.parametrize(
         'val',
@@ -621,7 +630,7 @@ class TestDSdecimal:
         # Check that a pickled DSdecimal is read back properly
         # DSdecimal actually prefers original_string when
         # reading back
-        x = pydicom.valuerep.DSdecimal(19)
+        x = DSdecimal(19)
         x.original_string = "19"
         data1_string = pickle.dumps(x)
         x2 = pickle.loads(data1_string)
@@ -633,18 +642,20 @@ class TestDSdecimal:
         with pytest.raises(
                 TypeError, match="cannot be instantiated with a float value"
         ):
-            pydicom.valuerep.DSdecimal(9.0)
+            DSdecimal(9.0)
         config.allow_DS_float = True
-        assert 9 == pydicom.valuerep.DSdecimal(9.0)
+        assert 9 == DSdecimal(9.0)
 
-    def test_new_empty_str(self):
-        """Test passing an empty string."""
-        assert pydicom.valuerep.DSdecimal('') is None
+    def test_new_empty(self):
+        """Test passing an empty value."""
+        assert isinstance(DSdecimal(''), str)
+        assert DSdecimal('') == ''
+        assert DSdecimal(None) is None
 
     def test_DSfloat(self):
         """Test creating a value using DSfloat."""
-        x = pydicom.valuerep.DSdecimal('1.2345')
-        y = pydicom.valuerep.DSdecimal(x)
+        x = DSdecimal('1.2345')
+        y = DSdecimal(x)
         assert x == y
         assert y == x
         assert Decimal("1.2345") == y
@@ -652,49 +663,49 @@ class TestDSdecimal:
 
     def test_DSdecimal(self):
         """Test creating a value using DSdecimal."""
-        x = pydicom.valuerep.DSfloat('1.2345')
-        y = pydicom.valuerep.DSdecimal(x)
+        x = DSfloat('1.2345')
+        y = DSdecimal(x)
         assert Decimal(1.2345) == y
         assert "1.2345" == y.original_string
 
     def test_repr(self):
         """Test repr(DSdecimal)."""
-        x = pydicom.valuerep.DSdecimal('1.2345')
-        assert '"1.2345"' == repr(x)
+        x = DSdecimal('1.2345')
+        assert repr(x) == repr('1.2345')
 
     def test_auto_format(self, enforce_valid_both_fixture):
         """Test truncating decimal"""
-        x = pydicom.valuerep.DSdecimal(Decimal(math.pi), auto_format=True)
+        x = DSdecimal(Decimal(math.pi), auto_format=True)
 
         # Decimal representation should be unaltered by truncation
         assert x == Decimal(math.pi)
         # String representations should be correctly formatted
         assert str(x) == '3.14159265358979'
-        assert repr(x) == '"3.14159265358979"'
+        assert repr(x) == repr("3.14159265358979")
 
     def test_auto_format_from_invalid_DS(self):
         """Test truncating floats"""
         # A DSdecimal that has a non-valid string representation
-        x = pydicom.valuerep.DSdecimal(math.pi)
+        x = DSdecimal(math.pi)
 
         # Use this to initialise another with auto_format set to true
-        y = pydicom.valuerep.DSdecimal(x, auto_format=True)
+        y = DSdecimal(x, auto_format=True)
 
         # Float representation should be unaltered by truncation
         assert y == math.pi
         # String representations should be correctly formatted
         assert str(y) == '3.14159265358979'
-        assert repr(y) == '"3.14159265358979"'
+        assert repr(y) == repr("3.14159265358979")
 
     def test_auto_format_invalid_string(self, enforce_valid_both_fixture):
         """If the user supplies an invalid string, this should be formatted."""
-        x = pydicom.valuerep.DSdecimal('3.141592653589793', auto_format=True)
+        x = DSdecimal('3.141592653589793', auto_format=True)
 
         # Decimal representation should be unaltered by truncation
         assert x == Decimal('3.141592653589793')
         # String representations should be correctly formatted
         assert str(x) == '3.14159265358979'
-        assert repr(x) == '"3.14159265358979"'
+        assert repr(x) == repr("3.14159265358979")
 
     @pytest.mark.parametrize(
         'val',
@@ -714,24 +725,24 @@ class TestDSdecimal:
 
     def test_auto_format_valid_string(self, enforce_valid_both_fixture):
         """If the user supplies a valid string, this should not be altered."""
-        x = pydicom.valuerep.DSdecimal('1.234e-1', auto_format=True)
+        x = DSdecimal('1.234e-1', auto_format=True)
 
         # Decimal representation should be correct
         assert x == Decimal('1.234e-1')
         # String representations should be unaltered
         assert str(x) == '1.234e-1'
-        assert repr(x) == '"1.234e-1"'
+        assert repr(x) == repr("1.234e-1")
 
     def test_DSdecimal_auto_format(self):
         """Test creating a value using DSdecimal copies auto_format"""
-        x = pydicom.valuerep.DSdecimal(math.pi, auto_format=True)
-        y = pydicom.valuerep.DSdecimal(x)
+        x = DSdecimal(math.pi, auto_format=True)
+        y = DSdecimal(x)
         assert x == y
         assert y == x
         assert y.auto_format
         assert math.pi == y
         assert str(y) == '3.14159265358979'
-        assert repr(y) == '"3.14159265358979"'
+        assert repr(y) == repr("3.14159265358979")
 
 
 class TestIS:
@@ -756,7 +767,7 @@ class TestIS:
 
     def test_pickling(self):
         # Check that a pickled IS is read back properly
-        x = pydicom.valuerep.IS(921)
+        x = IS(921)
         x.original_string = "hello"
         data1_string = pickle.dumps(x)
         x2 = pickle.loads(data1_string)
@@ -766,7 +777,7 @@ class TestIS:
     def test_longint(self, allow_invalid_values):
         # Check that a long int is read properly
         # Will not work with enforce_valid_values
-        x = pydicom.valuerep.IS(3103050000)
+        x = IS(3103050000)
         data1_string = pickle.dumps(x)
         x2 = pickle.loads(data1_string)
         assert x.real == x2.real
@@ -778,29 +789,61 @@ class TestIS:
             r"to override the value check"
         )
         with pytest.raises(OverflowError, match=msg):
-            pydicom.valuerep.IS(3103050000)
+            IS(3103050000)
 
     def test_str(self):
         """Test IS.__str__()."""
-        val = pydicom.valuerep.IS(1)
-        assert "1" == str(val)
+        val = IS(1)
+        assert str(val) == '1'
 
-        val = pydicom.valuerep.IS("1")
-        assert "1" == str(val)
+        val = IS("1")
+        assert str(val) == '1'
 
-        val = pydicom.valuerep.IS("1.0")
-        assert "1.0" == str(val)
+        val = IS("1.0")
+        assert str(val) == '1.0'
 
     def test_repr(self):
         """Test IS.__repr__()."""
-        val = pydicom.valuerep.IS(1)
-        assert '"1"' == repr(val)
+        val = IS(1)
+        assert repr(val) == repr('1')
 
-        val = pydicom.valuerep.IS("1")
-        assert '"1"' == repr(val)
+        val = IS("1")
+        assert repr(val) == repr('1')
+        assert repr(val) == repr("1")
 
-        val = pydicom.valuerep.IS("1.0")
-        assert "1.0" == str(val)
+        val = IS("1.0")
+        assert str(val) == '1.0'
+
+    def test_comparison_operators(self):
+        """Tests for the comparison operators"""
+        for val in (IS("1234"), IS(1234)):
+            assert val == 1234
+            assert val != 1235
+            assert val < 1235
+            assert val <= 1235
+            assert val > 1233
+            assert val >= 1233
+
+            assert 1234 == val
+            assert 1235 != val
+            assert 1235 > val
+            assert 1235 >= val
+            assert 1233 < val
+            assert 1233 <= val
+
+            assert val == "1234"
+            assert val != "1235"
+            assert val < "1235"
+            assert val <= "1235"
+            assert val > "1233"
+            assert val >= "1233"
+
+            assert "1234" == val
+            assert "1235" != val
+            assert "1235" > val
+            assert "1235" >= val
+            assert "1233" < val
+            assert "1233" <= val
 
 
 class TestBadValueRead:
@@ -1282,3 +1325,92 @@ def test_person_name_unicode_warns():
             from pydicom.valuerep import PersonNameUnicode
 
         assert PersonNameUnicode == PersonName
+
+
+VALUE_REFERENCE = [
+    # (VR, Python setter type, (VM 0 values), (VM >= 1 values), keyword)
+    ("AE", str, (None, ""), ("foo", "bar"), 'Receiver'),
+    ("AS", str, (None, ""), ("foo", "bar"), 'PatientAge'),
+    ("AT", int, (None, ), (0, 2**32 - 1), 'OffendingElement'),
+    ("CS", str, (None, ""), ("foo", "bar"), 'QualityControlSubject'),
+    ("DA", str, (None, ""), ("20010203", "20020304"), 'PatientBirthDate'),
+    ("DS", str, (None, ""), ("-1.5", "3.2"), 'PatientWeight'),
+    ("DT", str, (None, ""), ("20010203040506", "2000"), 'AcquisitionDateTime'),
+    ("FD", float, (None, ), (-1.5, 3.2), 'RealWorldValueLUTData'),
+    ("FL", float, (None, ), (-1.5, 3.2), 'VectorAccuracy'),
+    ("IS", str, (None, ""), ("0", "25"), 'BeamNumber'),
+    ("LO", str, (None, ""), ("foo", "bar"), 'DataSetSubtype'),
+    ("LT", str, (None, ""), ("foo", "bar"), 'ExtendedCodeMeaning'),
+    ("OB", bytes, (None, b""), (b"\x00\x01", ), 'FillPattern'),
+    ("OD", bytes, (None, b""), (b"\x00\x01", ), 'DoubleFloatPixelData'),
+    ("OF", bytes, (None, b""), (b"\x00\x01", ), 'UValueData'),
+    ("OL", bytes, (None, b""), (b"\x00\x01", ), 'TrackPointIndexList'),
+    ("OV", bytes, (None, b""), (b"\x00\x01", ), 'SelectorOVValue'),
+    ("OW", bytes, (None, b""), (b"\x00\x01", ), 'TrianglePointIndexList'),
+    ("PN", str, (None, ""), ("foo", "bar"), 'PatientName'),
+    ("SH", str, (None, ""), ("foo", "bar"), 'CodeValue'),
+    ("SL", int, (None, ), (-2**31, 2**31 - 1), 'RationalNumeratorValue'),
+    ("SQ", list, ([], ), (Dataset(), Dataset()), 'BeamSequence'),
+    ("SS", int, (None, ), (-2**15, 2**15 - 1), 'SelectorSSValue'),
+    ("ST", str, (None, ""), ("foo", "bar"), 'InstitutionAddress'),
+    ("SV", int, (None, ), (-2**63, 2**63 - 1), 'SelectorSVValue'),
+    ("TM", str, (None, ""), ("123456", "000000"), 'StudyTime'),
+    ("UC", str, (None, ""), ("foo", "bar"), 'LongCodeValue'),
+    ("UI", str, (None, ""), ("foo", "bar"), 'SOPClassUID'),
+    ("UL", int, (None, ), (0, 2**32 - 1), 'SimpleFrameList'),
+    ("UN", bytes, (None, b""), (b"\x00\x01", ), 'SelectorUNValue'),
+    ("UR", str, (None, ""), ("foo", "bar"), 'CodingSchemeURL'),
+    ("US", int, (None, ), (0, 2**16 - 1), 'SourceAcquisitionBeamNumber'),
+    ("UT", str, (None, ""), ("foo", "bar"), 'StrainAdditionalInformation'),
+    ("UV", int, (None, ), (0, 2**64 - 1), 'SelectorUVValue')
+]
+
+
+class TestValueConsistency:
+    """Fundamental element value behaviour tests."""
+    @pytest.mark.parametrize("vr, pytype, vm0, vmN, keyword", VALUE_REFERENCE)
+    def test_set_value(self, vr, pytype, vm0, vmN, keyword):
+        """Test that element values are set consistently"""
+        # Test VM = 0
+        ds = Dataset()
+        for value in vm0:
+            setattr(ds, keyword, value)
+            elem = ds[keyword]
+            assert elem.VR == vr
+            assert elem.value == value
+            assert value == elem.value
+
+        # Test VM = 1
+        ds = Dataset()
+        value = vmN[0]
+        if vr == 'SQ':
+            setattr(ds, keyword, [value])
+            elem = ds[keyword]
+            assert elem.value[0] == value
+            assert value == elem.value[0]
+        else:
+            setattr(ds, keyword, value)
+            elem = ds[keyword]
+            assert elem.value == value
+            assert value == elem.value
+
+        if vr[0] == 'O':
+            return
+
+        # Test VM > 1
+        ds = Dataset()
+        value = vmN[0]
+        setattr(ds, keyword, list(vmN))
+        elem = ds[keyword]
+        assert elem.value == list(vmN)
+        assert list(vmN) == elem.value
+
+    def test_ds_consistency(self):
+        """Consistency tests for DS classes."""
+        val = DSfloat("-1.5")
+        assert val == "-1.5"
+        assert "-1.5" == val
+
+        val = DSdecimal("-1.5")
+        assert val == "-1.5"
+        assert "-1.5" == val

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -1463,10 +1463,14 @@ VALUE_REFERENCE = [
     ("CS", str, (None, ""), ("foo", "bar"), 'QualityControlSubject'),
     ("DA", str, (None, ""), ("20010203", "20020304"), 'PatientBirthDate'),
     ("DS", str, (None, ""), ("-1.5", "3.2"), 'PatientWeight'),
+    ("DS", int, (None, ""), (-1, 3), 'PatientWeight'),
+    ("DS", float, (None, ""), (-1.5, 3.2), 'PatientWeight'),
     ("DT", str, (None, ""), ("20010203040506", "2000"), 'AcquisitionDateTime'),
     ("FD", float, (None, ), (-1.5, 3.2), 'RealWorldValueLUTData'),
     ("FL", float, (None, ), (-1.5, 3.2), 'VectorAccuracy'),
     ("IS", str, (None, ""), ("0", "25"), 'BeamNumber'),
+    ("IS", int, (None, ""), (0, 25), 'BeamNumber'),
+    ("IS", float, (None, ""), (0.0, 25.0), 'BeamNumber'),
     ("LO", str, (None, ""), ("foo", "bar"), 'DataSetSubtype'),
     ("LT", str, (None, ""), ("foo", "bar"), 'ExtendedCodeMeaning'),
     ("OB", bytes, (None, b""), (b"\x00\x01", ), 'FillPattern'),
@@ -1532,13 +1536,3 @@ class TestValueConsistency:
         elem = ds[keyword]
         assert elem.value == list(vmN)
         assert list(vmN) == elem.value
-
-    def test_ds_consistency(self):
-        """Consistency tests for DS classes."""
-        val = DSfloat("-1.5")
-        assert val == "-1.5"
-        assert "-1.5" == val
-
-        val = DSdecimal("-1.5")
-        assert val == "-1.5"
-        assert "-1.5" == val

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -485,7 +485,8 @@ class TestDS:
     """Unit tests for DS values"""
     def test_empty_value(self):
         assert DS(None) is None
-        assert "" == DS("")
+        assert DS("") == ""
+        assert DS("   ") == "   "
 
     def test_float_values(self):
         val = DS(0.9)
@@ -642,13 +643,6 @@ class TestDSfloat:
             assert val > Decimal(1233)
             assert val >= Decimal(1233)
 
-            assert Decimal(1234.5) == val
-            assert Decimal(1235) != val
-            assert Decimal(1235) > val
-            assert Decimal(1235) >= val
-            assert Decimal(1233) < val
-            assert Decimal(1233) <= val
-
             assert val == 1234.5
             assert val != 1235.0
             assert val < 1235.0
@@ -656,26 +650,23 @@ class TestDSfloat:
             assert val > 1233.0
             assert val >= 1233.0
 
-            assert 1234.5 == val
-            assert 1235.0 != val
-            assert 1235.0 > val
-            assert 1235.0 >= val
-            assert 1233.0 < val
-            assert 1233.0 <= val
-
             assert val == "1234.5"
+            assert val != " 1234.5"
+            assert val != "1234.50"
+            assert val != "1234.5 "
             assert val != "1235"
-            assert val < "1235"
-            assert val <= "1235"
-            assert val > "1233"
-            assert val >= "1233"
 
-            assert "1234.5" == val
-            assert "1235" != val
-            assert "1235" > val
-            assert "1235" >= val
-            assert "1233" < val
-            assert "1233" <= val
+            with pytest.raises(TypeError, match="'<' not supported"):
+                val < "1235"
+
+            with pytest.raises(TypeError, match="'<=' not supported"):
+                val <= "1235"
+
+            with pytest.raises(TypeError, match="'>' not supported"):
+                val > "1233"
+
+            with pytest.raises(TypeError, match="'>=' not supported"):
+                val >= "1233"
 
 
 class TestDSdecimal:
@@ -693,17 +684,16 @@ class TestDSdecimal:
 
     def test_float_value(self):
         config.allow_DS_float = False
-        with pytest.raises(
-                TypeError, match="cannot be instantiated with a float value"
-        ):
+        msg = "cannot be instantiated with a float value"
+        with pytest.raises(TypeError, match=msg):
             DSdecimal(9.0)
         config.allow_DS_float = True
         assert 9 == DSdecimal(9.0)
 
     def test_new_empty(self):
         """Test passing an empty value."""
-        assert isinstance(DSdecimal(''), str)
         assert DSdecimal('') == ''
+        assert DSdecimal('  ') == '  '
         assert DSdecimal(None) is None
 
     def test_str_value(self):
@@ -776,9 +766,7 @@ class TestDSdecimal:
         ]
     )
     def test_enforce_valid_values_value(
-            self,
-            val: Union[Decimal, str],
-            enforce_valid_true_fixture
+        self, val: Union[Decimal, str], enforce_valid_true_fixture
     ):
         """Test that errors are raised when value is invalid."""
         with pytest.raises(ValueError):
@@ -816,13 +804,6 @@ class TestDSdecimal:
             assert val > Decimal(1233)
             assert val >= Decimal(1233)
 
-            assert Decimal(1234.5) == val
-            assert Decimal(1235) != val
-            assert Decimal(1235) > val
-            assert Decimal(1235) >= val
-            assert Decimal(1233) < val
-            assert Decimal(1233) <= val
-
             assert val == 1234.5
             assert val != 1235.0
             assert val < 1235.0
@@ -830,26 +811,23 @@ class TestDSdecimal:
             assert val > 1233.0
             assert val >= 1233.0
 
-            assert 1234.5 == val
-            assert 1235.0 != val
-            assert 1235.0 > val
-            assert 1235.0 >= val
-            assert 1233.0 < val
-            assert 1233.0 <= val
-
             assert val == "1234.5"
+            assert val != " 1234.5"
+            assert val != "1234.50"
+            assert val != "1234.5 "
             assert val != "1235"
-            assert val < "1235"
-            assert val <= "1235"
-            assert val > "1233"
-            assert val >= "1233"
 
-            assert "1234.5" == val
-            assert "1235" != val
-            assert "1235" > val
-            assert "1235" >= val
-            assert "1233" < val
-            assert "1233" <= val
+            with pytest.raises(TypeError, match="'<' not supported"):
+                val < "1235"
+
+            with pytest.raises(TypeError, match="'<=' not supported"):
+                val <= "1235"
+
+            with pytest.raises(TypeError, match="'>' not supported"):
+                val > "1233"
+
+            with pytest.raises(TypeError, match="'>=' not supported"):
+                val >= "1233"
 
 
 class TestIS:
@@ -857,6 +835,7 @@ class TestIS:
     def test_empty_value(self):
         assert IS(None) is None
         assert IS("") == ""
+        assert IS("  ") == "  "
 
     def test_str_value(self):
         """Test creating using str"""
@@ -938,13 +917,6 @@ class TestIS:
             assert val > 1233
             assert val >= 1233
 
-            assert 1234 == val
-            assert 1235 != val
-            assert 1235 > val
-            assert 1235 >= val
-            assert 1233 < val
-            assert 1233 <= val
-
             assert val == 1234.0
             assert val != 1235.0
             assert val < 1235.0
@@ -952,26 +924,23 @@ class TestIS:
             assert val > 1233.0
             assert val >= 1233.0
 
-            assert 1234.0 == val
-            assert 1235.0 != val
-            assert 1235.0 > val
-            assert 1235.0 >= val
-            assert 1233.0 < val
-            assert 1233.0 <= val
-
             assert val == "1234"
+            assert val != "1234.0"
             assert val != "1235"
-            assert val < "1235"
-            assert val <= "1235"
-            assert val > "1233"
-            assert val >= "1233"
+            assert val != "1234 "
+            assert val != " 1234"
 
-            assert "1234" == val
-            assert "1235" != val
-            assert "1235" > val
-            assert "1235" >= val
-            assert "1233" < val
-            assert "1233" <= val
+            with pytest.raises(TypeError, match="'<' not supported"):
+                val < "1235"
+
+            with pytest.raises(TypeError, match="'<=' not supported"):
+                val <= "1235"
+
+            with pytest.raises(TypeError, match="'>' not supported"):
+                val > "1233"
+
+            with pytest.raises(TypeError, match="'>=' not supported"):
+                val >= "1233"
 
 
 class TestBadValueRead:

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -513,6 +513,14 @@ class TestDSfloat:
         assert DSfloat('') == ''
         assert DSfloat(None) is None
 
+    def test_str_value(self):
+        """Test creating using str"""
+        assert DSfloat('1.20') == 1.2
+        assert DSfloat('1.20 ') == 1.2
+        assert DSfloat('1.20') != '1.2'
+        assert DSfloat('1.20') == '1.20'
+        assert DSfloat('1.20 ') == '1.20'
+
     def test_str(self):
         """Test DSfloat.__str__()."""
         val = DSfloat(1.1)
@@ -623,6 +631,52 @@ class TestDSfloat:
         with pytest.raises(ValueError):
             valuerep.DSfloat(val)
 
+    def test_comparison_operators(self):
+        """Tests for the comparison operators"""
+        float_decimal = DSfloat(Decimal(1234.5))
+        for val in (DSfloat("1234.5"), DSfloat(1234.5), float_decimal):
+            assert val == Decimal(1234.5)
+            assert val != Decimal(1235)
+            assert val < Decimal(1235)
+            assert val <= Decimal(1235)
+            assert val > Decimal(1233)
+            assert val >= Decimal(1233)
+
+            assert Decimal(1234.5) == val
+            assert Decimal(1235) != val
+            assert Decimal(1235) > val
+            assert Decimal(1235) >= val
+            assert Decimal(1233) < val
+            assert Decimal(1233) <= val
+
+            assert val == 1234.5
+            assert val != 1235.0
+            assert val < 1235.0
+            assert val <= 1235.0
+            assert val > 1233.0
+            assert val >= 1233.0
+
+            assert 1234.5 == val
+            assert 1235.0 != val
+            assert 1235.0 > val
+            assert 1235.0 >= val
+            assert 1233.0 < val
+            assert 1233.0 <= val
+
+            assert val == "1234.5"
+            assert val != "1235"
+            assert val < "1235"
+            assert val <= "1235"
+            assert val > "1233"
+            assert val >= "1233"
+
+            assert "1234.5" == val
+            assert "1235" != val
+            assert "1235" > val
+            assert "1235" >= val
+            assert "1233" < val
+            assert "1233" <= val
+
 
 class TestDSdecimal:
     """Unit tests for pickling DSdecimal"""
@@ -651,6 +705,13 @@ class TestDSdecimal:
         assert isinstance(DSdecimal(''), str)
         assert DSdecimal('') == ''
         assert DSdecimal(None) is None
+
+    def test_str_value(self):
+        """Test creating using str"""
+        assert DSdecimal('1.20') == '1.20'
+        assert DSdecimal('1.20 ') == '1.20'
+        assert DSdecimal('1.20') != '1.2'
+        assert DSdecimal('1.20 ') == Decimal('1.2')
 
     def test_DSfloat(self):
         """Test creating a value using DSfloat."""
@@ -744,12 +805,65 @@ class TestDSdecimal:
         assert str(y) == '3.14159265358979'
         assert repr(y) == repr("3.14159265358979")
 
+    def test_comparison_operators(self):
+        """Tests for the comparison operators"""
+        decimal_decimal = DSdecimal(Decimal(1234.5))
+        for val in (DSdecimal("1234.5"), DSdecimal(1234.5), decimal_decimal):
+            assert val == Decimal(1234.5)
+            assert val != Decimal(1235)
+            assert val < Decimal(1235)
+            assert val <= Decimal(1235)
+            assert val > Decimal(1233)
+            assert val >= Decimal(1233)
+
+            assert Decimal(1234.5) == val
+            assert Decimal(1235) != val
+            assert Decimal(1235) > val
+            assert Decimal(1235) >= val
+            assert Decimal(1233) < val
+            assert Decimal(1233) <= val
+
+            assert val == 1234.5
+            assert val != 1235.0
+            assert val < 1235.0
+            assert val <= 1235.0
+            assert val > 1233.0
+            assert val >= 1233.0
+
+            assert 1234.5 == val
+            assert 1235.0 != val
+            assert 1235.0 > val
+            assert 1235.0 >= val
+            assert 1233.0 < val
+            assert 1233.0 <= val
+
+            assert val == "1234.5"
+            assert val != "1235"
+            assert val < "1235"
+            assert val <= "1235"
+            assert val > "1233"
+            assert val >= "1233"
+
+            assert "1234.5" == val
+            assert "1235" != val
+            assert "1235" > val
+            assert "1235" >= val
+            assert "1233" < val
+            assert "1233" <= val
+
 
 class TestIS:
     """Unit tests for IS"""
     def test_empty_value(self):
         assert IS(None) is None
         assert IS("") == ""
+
+    def test_str_value(self):
+        """Test creating using str"""
+        assert IS('1') == 1
+        assert IS('1 ') == 1
+        assert IS('1') == '1'
+        assert IS('1 ') == '1'
 
     def test_valid_value(self):
         assert 42 == IS(42)
@@ -816,7 +930,7 @@ class TestIS:
 
     def test_comparison_operators(self):
         """Tests for the comparison operators"""
-        for val in (IS("1234"), IS(1234)):
+        for val in (IS("1234"), IS(1234), IS(1234.0)):
             assert val == 1234
             assert val != 1235
             assert val < 1235
@@ -830,6 +944,20 @@ class TestIS:
             assert 1235 >= val
             assert 1233 < val
             assert 1233 <= val
+
+            assert val == 1234.0
+            assert val != 1235.0
+            assert val < 1235.0
+            assert val <= 1235.0
+            assert val > 1233.0
+            assert val >= 1233.0
+
+            assert 1234.0 == val
+            assert 1235.0 != val
+            assert 1235.0 > val
+            assert 1235.0 >= val
+            assert 1233.0 < val
+            assert 1233.0 <= val
 
             assert val == "1234"
             assert val != "1235"

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -517,7 +517,9 @@ class TestDSfloat:
     def test_str_value(self):
         """Test creating using str"""
         assert DSfloat('1.20') == 1.2
+        assert DSfloat('1.20') == 1.20
         assert DSfloat('1.20 ') == 1.2
+        assert DSfloat('1.20 ') == 1.20
         assert DSfloat('1.20') != '1.2'
         assert DSfloat('1.20') == '1.20'
         assert DSfloat('1.20 ') == '1.20'
@@ -624,9 +626,7 @@ class TestDSfloat:
         ]
     )
     def test_enforce_valid_values_value(
-            self,
-            val: Union[float, str],
-            enforce_valid_true_fixture
+        self, val: Union[float, str], enforce_valid_true_fixture
     ):
         """Test that errors are raised when value is invalid."""
         with pytest.raises(ValueError):
@@ -698,10 +698,16 @@ class TestDSdecimal:
 
     def test_str_value(self):
         """Test creating using str"""
+        # Not equal because float(1.2) != Decimal('1.2')
+        assert DSdecimal('1.20') != 1.2
+        assert DSdecimal('1.20') != 1.20
+        assert DSdecimal('1.20') == Decimal(1.2)
+        assert DSdecimal('1.20') == Decimal(1.20)
+        assert DSdecimal('1.20 ') == Decimal(1.2)
+        assert DSdecimal('1.20 ') == Decimal(1.20)
+        assert DSdecimal('1.20') != '1.2'
         assert DSdecimal('1.20') == '1.20'
         assert DSdecimal('1.20 ') == '1.20'
-        assert DSdecimal('1.20') != '1.2'
-        assert DSdecimal('1.20 ') == Decimal('1.2')
 
     def test_DSfloat(self):
         """Test creating a value using DSfloat."""
@@ -841,8 +847,7 @@ class TestIS:
         """Test creating using str"""
         assert IS('1') == 1
         assert IS('1 ') == 1
-        assert IS('1') == '1'
-        assert IS('1 ') == '1'
+        assert IS(' 1 ') == 1
 
     def test_valid_value(self):
         assert 42 == IS(42)
@@ -1489,41 +1494,39 @@ VALUE_REFERENCE = [
 ]
 
 
-class TestValueConsistency:
-    """Fundamental element value behaviour tests."""
-    @pytest.mark.parametrize("vr, pytype, vm0, vmN, keyword", VALUE_REFERENCE)
-    def test_set_value(self, vr, pytype, vm0, vmN, keyword):
-        """Test that element values are set consistently"""
-        # Test VM = 0
-        ds = Dataset()
-        for value in vm0:
-            setattr(ds, keyword, value)
-            elem = ds[keyword]
-            assert elem.VR == vr
-            assert elem.value == value
-            assert value == elem.value
-
-        # Test VM = 1
-        ds = Dataset()
-        value = vmN[0]
-        if vr == 'SQ':
-            setattr(ds, keyword, [value])
-            elem = ds[keyword]
-            assert elem.value[0] == value
-            assert value == elem.value[0]
-        else:
-            setattr(ds, keyword, value)
-            elem = ds[keyword]
-            assert elem.value == value
-            assert value == elem.value
-
-        if vr[0] == 'O':
-            return
-
-        # Test VM > 1
-        ds = Dataset()
-        value = vmN[0]
-        setattr(ds, keyword, list(vmN))
+@pytest.mark.parametrize("vr, pytype, vm0, vmN, keyword", VALUE_REFERENCE)
+def test_set_value(vr, pytype, vm0, vmN, keyword):
+    """Test that element values are set consistently"""
+    # Test VM = 0
+    ds = Dataset()
+    for value in vm0:
+        setattr(ds, keyword, value)
         elem = ds[keyword]
-        assert elem.value == list(vmN)
-        assert list(vmN) == elem.value
+        assert elem.VR == vr
+        assert elem.value == value
+        assert value == elem.value
+
+    # Test VM = 1
+    ds = Dataset()
+    value = vmN[0]
+    if vr == 'SQ':
+        setattr(ds, keyword, [value])
+        elem = ds[keyword]
+        assert elem.value[0] == value
+        assert value == elem.value[0]
+    else:
+        setattr(ds, keyword, value)
+        elem = ds[keyword]
+        assert elem.value == value
+        assert value == elem.value
+
+    if vr[0] == 'O':
+        return
+
+    # Test VM > 1
+    ds = Dataset()
+    value = vmN[0]
+    setattr(ds, keyword, list(vmN))
+    elem = ds[keyword]
+    assert elem.value == list(vmN)
+    assert list(vmN) == elem.value

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -473,7 +473,13 @@ class DSfloat(float):
             cls,
             val: Union[str, int, float, Decimal],
             auto_format: bool = False
-    ) -> [_DSfloat]:
+    ) -> Optional[Union[str, _DSfloat]]:
+        if val is None:
+            return None
+
+        if val == '':
+            return val
+
         return super().__new__(cls, val)
 
     def __init__(
@@ -525,6 +531,32 @@ class DSfloat(float):
                     'of DS'
                 )
 
+    def __eq__(self, other: Any) -> bool:
+        """Override to allow string equality comparisons."""
+        if isinstance(other, str):
+            return str(self) == other
+
+        return super().__eq__(other)
+
+    def __ne__(self, other: Any) -> bool:
+        return not self == other
+
+    def __lt__(self, other: Any) -> bool:
+        """Override to allow string equality comparisons."""
+        if isinstance(other, str):
+            return str(self) < other
+
+        return super().__lt__(other)
+
+    def __le__(self, other: Any) -> bool:
+        return self == other or self < other
+
+    def __ge__(self, other: Any) -> bool:
+        return self == other or self > other
+
+    def __gt__(self, other: Any) -> bool:
+        return not (self == other or self < other)
+
     def __str__(self) -> str:
         if hasattr(self, 'original_string') and not self.auto_format:
             return self.original_string
@@ -534,8 +566,9 @@ class DSfloat(float):
 
     def __repr__(self) -> str:
         if self.auto_format and hasattr(self, 'original_string'):
-            return f'"{self.original_string}"'
-        return f'"{super().__repr__()}"'
+            return f"'{self.original_string}'"
+
+        return f"'{super().__repr__()}'"
 
 
 class DSdecimal(Decimal):
@@ -560,7 +593,7 @@ class DSdecimal(Decimal):
         cls: Type[_DSdecimal],
         val: Union[str, int, float, Decimal],
         auto_format: bool = False
-    ) -> Optional[_DSdecimal]:
+    ) -> Optional[Union[str, _DSdecimal]]:
         """Create an instance of DS object, or return a blank string if one is
         passed in, e.g. from a type 2 DICOM blank value.
 
@@ -569,6 +602,12 @@ class DSdecimal(Decimal):
         val : str or numeric
             A string or a number type which can be converted to a decimal.
         """
+        if val is None:
+            return None
+
+        if val == '':
+            return val
+
         if isinstance(val, float) and not config.allow_DS_float:
             raise TypeError(
                 "'DS' cannot be instantiated with a float value unless "
@@ -577,14 +616,7 @@ class DSdecimal(Decimal):
                 "or use 'Decimal.quantize()' and pass a 'Decimal' instance."
             )
 
-        if isinstance(val, str):
-            val = val.strip()
-            if val == '':
-                return None
-
-        val = super().__new__(cls, val)
-
-        return val
+        return super().__new__(cls, val)
 
     def __init__(
         self,
@@ -637,6 +669,32 @@ class DSdecimal(Decimal):
                     'of DS'
                 )
 
+    def __eq__(self, other: Any) -> bool:
+        """Override to allow string equality comparisons."""
+        if isinstance(other, str):
+            return str(self) == other
+
+        return super().__eq__(other)
+
+    def __ne__(self, other: Any) -> bool:
+        return not self == other
+
+    def __lt__(self, other: Any) -> bool:
+        """Override to allow string equality comparisons."""
+        if isinstance(other, str):
+            return str(self) < other
+
+        return super().__lt__(other)
+
+    def __le__(self, other: Any) -> bool:
+        return self == other or self < other
+
+    def __ge__(self, other: Any) -> bool:
+        return self == other or self > other
+
+    def __gt__(self, other: Any) -> bool:
+        return not (self == other or self < other)
+
     def __str__(self) -> str:
         has_str = hasattr(self, 'original_string')
         if has_str and len(self.original_string) <= 16:
@@ -646,8 +704,8 @@ class DSdecimal(Decimal):
 
     def __repr__(self) -> str:
         if self.auto_format and hasattr(self, 'original_string'):
-            return f'"{self.original_string}"'
-        return f'"{str(self)}"'
+            return f"'{self.original_string}'"
+        return f"'{str(self)}'"
 
 
 # CHOOSE TYPE OF DS
@@ -689,19 +747,19 @@ class IS(int):
 
     def __new__(
         cls: Type[_IS], val: Union[None, str, int, float, Decimal]
-    ) -> Optional[_IS]:
+    ) -> Optional[Union[str, _IS]]:
         """Create instance if new integer string"""
         if val is None:
             return val
 
-        if isinstance(val, str) and val.strip() == '':
-            return ''
+        if val == '':
+            return val
 
         try:
-            newval: _IS = super().__new__(cls, val)
+            newval = super().__new__(cls, val)
         except ValueError:
             # accept float strings when no integer loss, e.g. "1.0"
-            newval: _IS = super().__new__(cls, float(val))
+            newval = super().__new__(cls, float(val))
 
         # check if a float or Decimal passed in, then could have lost info,
         # and will raise error. E.g. IS(Decimal('1')) is ok, but not IS(1.23)
@@ -726,6 +784,32 @@ class IS(int):
         elif isinstance(val, IS) and hasattr(val, 'original_string'):
             self.original_string = val.original_string
 
+    def __eq__(self, other: Any) -> bool:
+        """Override to allow string equality comparisons."""
+        if isinstance(other, str):
+            return str(self) == other
+
+        return super().__eq__(other)
+
+    def __ne__(self, other: Any) -> bool:
+        return not self == other
+
+    def __lt__(self, other: Any) -> bool:
+        """Override to allow string equality comparisons."""
+        if isinstance(other, str):
+            return str(self) < other
+
+        return super().__lt__(other)
+
+    def __le__(self, other: Any) -> bool:
+        return self == other or self < other
+
+    def __ge__(self, other: Any) -> bool:
+        return self == other or self > other
+
+    def __gt__(self, other: Any) -> bool:
+        return not (self == other or self < other)
+
     def __str__(self) -> str:
         if hasattr(self, 'original_string'):
             return self.original_string
@@ -734,7 +818,7 @@ class IS(int):
         return repr(self)[1:-1]
 
     def __repr__(self) -> str:
-        return f'"{super().__repr__()}"'
+        return f"'{super().__repr__()}'"
 
 
 def _as_str(s: str):

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -477,10 +477,8 @@ class DSfloat(float):
         if val is None:
             return val
 
-        if isinstance(val, str):
-            val = val.strip()
-            if val == '':
-                return val
+        if isinstance(val, str) and val.strip() == '':
+            return val
 
         return super().__new__(cls, val)
 
@@ -544,22 +542,6 @@ class DSfloat(float):
     def __ne__(self, other: Any) -> bool:
         return not self == other
 
-    def __lt__(self, other: Any) -> bool:
-        """Override to allow string equality comparisons."""
-        if isinstance(other, str):
-            return str(self) < other
-
-        return super().__lt__(other)
-
-    def __le__(self, other: Any) -> bool:
-        return self == other or self < other
-
-    def __ge__(self, other: Any) -> bool:
-        return self == other or self > other
-
-    def __gt__(self, other: Any) -> bool:
-        return not (self == other or self < other)
-
     def __str__(self) -> str:
         if hasattr(self, 'original_string') and not self.auto_format:
             return self.original_string
@@ -608,10 +590,8 @@ class DSdecimal(Decimal):
         if val is None:
             return val
 
-        if isinstance(val, str):
-            val = val.strip()
-            if val == '':
-                return val
+        if isinstance(val, str) and val.strip() == '':
+            return val
 
         if isinstance(val, float) and not config.allow_DS_float:
             raise TypeError(
@@ -684,22 +664,6 @@ class DSdecimal(Decimal):
     def __ne__(self, other: Any) -> bool:
         return not self == other
 
-    def __lt__(self, other: Any) -> bool:
-        """Override to allow string equality comparisons."""
-        if isinstance(other, str):
-            return str(self) < other
-
-        return super().__lt__(other)
-
-    def __le__(self, other: Any) -> bool:
-        return self == other or self < other
-
-    def __ge__(self, other: Any) -> bool:
-        return self == other or self > other
-
-    def __gt__(self, other: Any) -> bool:
-        return not (self == other or self < other)
-
     def __str__(self) -> str:
         has_str = hasattr(self, 'original_string')
         if has_str and len(self.original_string) <= 16:
@@ -734,10 +698,10 @@ def DS(
     Similarly the string clean and check can be avoided and :class:`DSfloat`
     called directly if a string has already been processed.
     """
-    if isinstance(val, str):
-        val = val.strip()
+    if val is None:
+        return val
 
-    if val == '' or val is None:
+    if isinstance(val, str) and val.strip() == '':
         return val
 
     return DSclass(val, auto_format=auto_format)
@@ -757,10 +721,8 @@ class IS(int):
         if val is None:
             return val
 
-        if isinstance(val, str):
-            val = val.strip()
-            if val == '':
-                return val
+        if isinstance(val, str) and val.strip() == '':
+            return val
 
         try:
             newval = super().__new__(cls, val)
@@ -800,22 +762,6 @@ class IS(int):
 
     def __ne__(self, other: Any) -> bool:
         return not self == other
-
-    def __lt__(self, other: Any) -> bool:
-        """Override to allow string equality comparisons."""
-        if isinstance(other, str):
-            return str(self) < other
-
-        return super().__lt__(other)
-
-    def __le__(self, other: Any) -> bool:
-        return self == other or self < other
-
-    def __ge__(self, other: Any) -> bool:
-        return self == other or self > other
-
-    def __gt__(self, other: Any) -> bool:
-        return not (self == other or self < other)
 
     def __str__(self) -> str:
         if hasattr(self, 'original_string'):

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -695,7 +695,7 @@ class IS(int):
             return val
 
         if isinstance(val, str) and val.strip() == '':
-            return None
+            return ''
 
         try:
             newval: _IS = super().__new__(cls, val)

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -475,10 +475,12 @@ class DSfloat(float):
             auto_format: bool = False
     ) -> Optional[Union[str, _DSfloat]]:
         if val is None:
-            return None
-
-        if val == '':
             return val
+
+        if isinstance(val, str):
+            val = val.strip()
+            if val == '':
+                return val
 
         return super().__new__(cls, val)
 
@@ -494,7 +496,7 @@ class DSfloat(float):
         has_attribute = hasattr(val, 'original_string')
         pre_checked = False
         if isinstance(val, str):
-            self.original_string = val
+            self.original_string = val.strip()
         elif isinstance(val, (DSfloat, DSdecimal)):
             if val.auto_format:
                 auto_format = True  # override input parameter
@@ -534,6 +536,7 @@ class DSfloat(float):
     def __eq__(self, other: Any) -> bool:
         """Override to allow string equality comparisons."""
         if isinstance(other, str):
+            print(type(other), str(self), other, str(self) == other)
             return str(self) == other
 
         return super().__eq__(other)
@@ -603,10 +606,12 @@ class DSdecimal(Decimal):
             A string or a number type which can be converted to a decimal.
         """
         if val is None:
-            return None
-
-        if val == '':
             return val
+
+        if isinstance(val, str):
+            val = val.strip()
+            if val == '':
+                return val
 
         if isinstance(val, float) and not config.allow_DS_float:
             raise TypeError(
@@ -632,7 +637,7 @@ class DSdecimal(Decimal):
         has_str = hasattr(val, 'original_string')
         pre_checked = False
         if isinstance(val, str):
-            self.original_string = val
+            self.original_string = val.strip()
         elif isinstance(val, (DSfloat, DSdecimal)):
             if val.auto_format:
                 auto_format = True  # override input parameter
@@ -653,7 +658,7 @@ class DSdecimal(Decimal):
                 self.original_string = format_number_as_ds(self)
 
         if config.enforce_valid_values:
-            if len(repr(self).strip('"')) > 16:
+            if len(repr(self).strip("'")) > 16:
                 raise OverflowError(
                     "Values for elements with a VR of 'DS' values must be "
                     "<= 16 characters long. Use a smaller string, set "
@@ -662,7 +667,7 @@ class DSdecimal(Decimal):
                     "with a 'Decimal' instance, or explicitly construct a DS "
                     "instance with 'auto_format' set to True"
                 )
-            if not is_valid_ds(repr(self).strip('"')):
+            if not is_valid_ds(repr(self).strip("'")):
                 # This will catch nan and inf
                 raise ValueError(
                     f'Value "{str(self)}" is not valid for elements with a VR '
@@ -752,8 +757,10 @@ class IS(int):
         if val is None:
             return val
 
-        if val == '':
-            return val
+        if isinstance(val, str):
+            val = val.strip()
+            if val == '':
+                return val
 
         try:
             newval = super().__new__(cls, val)
@@ -780,7 +787,7 @@ class IS(int):
     def __init__(self, val: Union[str, int, float, Decimal]) -> None:
         # If a string passed, then store it
         if isinstance(val, str):
-            self.original_string = val
+            self.original_string = val.strip()
         elif isinstance(val, IS) and hasattr(val, 'original_string'):
             self.original_string = val.original_string
 

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -629,7 +629,6 @@ class DSdecimal(Decimal):
         """
         # ... also if user changes a data element value, then will get
         # a different Decimal, as Decimal is immutable.
-        has_str = hasattr(val, 'original_string')
         pre_checked = False
         if isinstance(val, str):
             self.original_string = val.strip()
@@ -637,7 +636,8 @@ class DSdecimal(Decimal):
             if val.auto_format:
                 auto_format = True  # override input parameter
                 pre_checked = True
-            if has_str:
+
+            if hasattr(val, 'original_string'):
                 self.original_string = val.original_string
 
         self.auto_format = auto_format


### PR DESCRIPTION
#### Describe the changes
* Return `""` for `IS("")` rather than `None` (reverts change in #1213, should be consistent with all other elements except SQ)
* Change `repr` format to match Python
* Add `__eq__` and `__ne__` operators and allow string comparison
* Add `mypy.ini` and typing workflow for PRs

Closes #1398

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
