### PR TITLE
[MRG] Don't inherit Dataset from dict

### DIFF
--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -29,6 +29,7 @@ Changes
 * :func:`~pydicom.filewriter.write_file` is deprecated and will be removed in
   v3.0, use :func:`~pydicom.filewriter.dcmwrite` instead.
 * Data dictionaries updated to version 2021b of the DICOM Standard
+* :class:`~pydicom.dataset.Dataset` no longer inherits from :class:`dict`
 
 Enhancements
 ------------

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -714,7 +714,7 @@ class Dataset:
 
     @overload
     def get(self, key: str, default: Optional[Any] = None) -> Any:
-        pass
+        pass  # pragma: no cover
 
     @overload
     def get(
@@ -722,7 +722,7 @@ class Dataset:
         key: Union[int, Tuple[int, int], BaseTag],
         default: Optional[Any] = None
     ) -> DataElement:
-        pass
+        pass  # pragma: no cover
 
     def get(
         self,
@@ -845,11 +845,11 @@ class Dataset:
 
     @overload
     def __getitem__(self, key: slice) -> "Dataset":
-        pass
+        pass  # pragma: no cover
 
     @overload
     def __getitem__(self, key: TagType) -> DataElement:
-        pass
+        pass  # pragma: no cover
 
     def __getitem__(
         self, key: Union[slice, TagType]
@@ -1106,11 +1106,11 @@ class Dataset:
 
     @overload
     def get_item(self, key: slice) -> "Dataset":
-        pass
+        pass  # pragma: no cover
 
     @overload
     def get_item(self, key: TagType) -> DataElement:
-        pass
+        pass  # pragma: no cover
 
     def get_item(
         self, key: Union[slice, TagType]

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -33,12 +33,10 @@ from typing import (
 import warnings
 import weakref
 
-if TYPE_CHECKING:  # pragma: no cover
-    try:
-        import numpy  # type: ignore[import]
-        import numpy as np
-    except ImportError:
-        pass
+try:
+    import numpy  # type: ignore[import]
+except ImportError:
+    pass
 
 import pydicom  # for dcmwrite
 import pydicom.charset
@@ -220,18 +218,11 @@ def _dict_equal(
 
 _Dataset = TypeVar("_Dataset", bound="Dataset")
 _DatasetValue = Union[DataElement, RawDataElement]
+_DatasetType = Union[_Dataset, MutableMapping[BaseTag, _DatasetValue]]
 
 
-class Dataset(Dict[BaseTag, _DatasetValue]):
-    """Contains a collection (dictionary) of DICOM Data Elements.
-
-    Behaves like a :class:`dict`.
-
-    .. note::
-
-        :class:`Dataset` is only derived from :class:`dict` to make it work in
-        a NumPy :class:`~numpy.ndarray`. The parent :class:`dict` class
-        is never called, as all :class:`dict` methods are overridden.
+class Dataset:
+    """A DICOM dataset as a mutable mapping of DICOM Data Elements.
 
     Examples
     --------
@@ -374,9 +365,7 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
     """
     indent_chars = "   "
 
-    def __init__(
-        self, *args: MutableMapping[BaseTag, _DatasetValue], **kwargs
-    ) -> None:
+    def __init__(self, *args: _DatasetType, **kwargs) -> None:
         """Create a new :class:`Dataset` instance."""
         self._parent_encoding = kwargs.get('parent_encoding', default_encoding)
 
@@ -410,6 +399,8 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
 
         self._pixel_array: Optional["numpy.ndarray"] = None
         self._pixel_id: Dict[str, int] = {}
+
+        self.file_meta: FileMetaDataset
 
     def __enter__(self) -> "Dataset":
         """Method invoked on entry to a with statement."""
@@ -463,6 +454,10 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
         # use data_element.tag since DataElement verified it
         self._dict[data_element.tag] = data_element
 
+    def __array__(self) -> "numpy.ndarray":
+        """Support accessing the dataset from a numpy array."""
+        return numpy.asarray(self._dict)
+
     def data_element(self, name: str) -> Optional[DataElement]:
         """Return the element corresponding to the element keyword `name`.
 
@@ -484,7 +479,7 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
             return self[tag]
         return None
 
-    def __contains__(self, name: TagType) -> bool:  # type: ignore[override]
+    def __contains__(self, name: TagType) -> bool:
         """Simulate dict.__contains__() to handle DICOM keywords.
 
         Examples
@@ -774,9 +769,7 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
         except KeyError:
             return default
 
-    def items(  # type: ignore[override]
-        self
-    ) -> AbstractSet[Tuple[BaseTag, _DatasetValue]]:
+    def items(self) -> AbstractSet[Tuple[BaseTag, _DatasetValue]]:
         """Return the :class:`Dataset` items to simulate :meth:`dict.items`.
 
         Returns
@@ -788,7 +781,7 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
         """
         return self._dict.items()
 
-    def keys(self) -> AbstractSet[BaseTag]:  # type: ignore[override]
+    def keys(self) -> AbstractSet[BaseTag]:
         """Return the :class:`Dataset` keys to simulate :meth:`dict.keys`.
 
         Returns
@@ -1218,7 +1211,7 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
         """
         return self[(group, 0x0000):(group + 1, 0x0000)]  # type: ignore[misc]
 
-    def __iter__(self) -> Iterator[DataElement]:  # type: ignore[override]
+    def __iter__(self) -> Iterator[DataElement]:
         """Iterate through the top-level of the Dataset, yielding DataElements.
 
         Examples
@@ -1468,9 +1461,7 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
 
         handler = getattr(pydicom.config, handler_name)
 
-        file_meta = cast("FileDataset", self).file_meta
-        file_meta = cast("FileMetaDataset", file_meta)
-        tsyntax = file_meta.TransferSyntaxUID
+        tsyntax = self.file_meta.TransferSyntaxUID
         if not handler.supports_transfer_syntax(tsyntax):
             raise NotImplementedError(
                 "Unable to decode pixel data with a transfer syntax UID"
@@ -1492,8 +1483,7 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
         See :meth:`~Dataset.convert_pixel_data` for more information.
         """
         # Find all possible handlers that support the transfer syntax
-        file_meta = cast("FileDataset", self).file_meta
-        ts = cast("FileMetaDataset", file_meta).TransferSyntaxUID
+        ts = self.file_meta.TransferSyntaxUID
         possible_handlers = [
             hh for hh in pydicom.config.pixel_data_handlers
             if hh is not None
@@ -1802,7 +1792,7 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
             # All is as expected, updated the Transfer Syntax
             self.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
 
-    def overlay_array(self, group: int) -> "np.ndarray":
+    def overlay_array(self, group: int) -> "numpy.ndarray":
         """Return the *Overlay Data* in `group` as a :class:`numpy.ndarray`.
 
         .. versionadded:: 1.4
@@ -1874,7 +1864,7 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
         raise last_exception  # type: ignore[misc]
 
     @property
-    def pixel_array(self) -> "np.ndarray":
+    def pixel_array(self) -> "numpy.ndarray":
         """Return the pixel data as a :class:`numpy.ndarray`.
 
         .. versionchanged:: 1.4
@@ -1891,7 +1881,7 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
         self.convert_pixel_data()
         return cast("numpy.ndarray", self._pixel_array)
 
-    def waveform_array(self, index: int) -> "np.ndarray":
+    def waveform_array(self, index: int) -> "numpy.ndarray":
         """Return an :class:`~numpy.ndarray` for the multiplex group at
         `index` in the (5400,0100) *Waveform Sequence*.
 
@@ -2318,14 +2308,7 @@ class Dataset(Dict[BaseTag, _DatasetValue]):
         """
         return dir(self)
 
-    def update(  # type: ignore[override]
-        self,
-        d: Union[
-            Dict[str, Any],
-            MutableMapping[BaseTag, _DatasetValue],
-            MutableMapping[TagType, _DatasetValue]
-        ]
-    ) -> None:
+    def update(self, d: _DatasetType) -> None:
         """Extend :meth:`dict.update` to handle DICOM tags and keywords.
 
         Parameters
@@ -2619,7 +2602,7 @@ class FileDataset(Dataset):
     def __init__(
         self,
         filename_or_obj: Union[str, "os.PathLike[AnyStr]", BinaryIO],
-        dataset: Dataset,
+        dataset: _DatasetType,
         preamble: Optional[bytes] = None,
         file_meta: Optional["FileMetaDataset"] = None,
         is_implicit_VR: bool = True,
@@ -2651,7 +2634,7 @@ class FileDataset(Dataset):
         """
         Dataset.__init__(self, dataset)
         self.preamble = preamble
-        self.file_meta: Optional["FileMetaDataset"] = file_meta
+        self.file_meta: "FileMetaDataset" = file_meta or FileMetaDataset()
         self.is_implicit_VR: bool = is_implicit_VR
         self.is_little_endian: bool = is_little_endian
 
@@ -2810,9 +2793,7 @@ class FileMetaDataset(Dataset):
     Group 2 (File Meta Information) data elements
     """
 
-    def __init__(
-        self, *args: MutableMapping[BaseTag, _DatasetValue], **kwargs
-    ) -> None:
+    def __init__(self, *args: _DatasetType, **kwargs) -> None:
         """Initialize a FileMetaDataset
 
         Parameters are as per :class:`Dataset`; this overrides the super class
@@ -2845,7 +2826,9 @@ class FileMetaDataset(Dataset):
         self.PrivateInformation: bytes  # OB, 1C
 
     @staticmethod
-    def validate(init_value: MutableMapping[BaseTag, _DatasetValue]) -> None:
+    def validate(
+        init_value: Union[Dataset, MutableMapping[BaseTag, _DatasetValue]]
+    ) -> None:
         """Raise errors if initialization value is not acceptable for file_meta
 
         Parameters

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -2634,7 +2634,9 @@ class FileDataset(Dataset):
         """
         Dataset.__init__(self, dataset)
         self.preamble = preamble
-        self.file_meta: "FileMetaDataset" = file_meta or FileMetaDataset()
+        self.file_meta: "FileMetaDataset" = (
+            file_meta if file_meta is not None else FileMetaDataset()
+        )
         self.is_implicit_VR: bool = is_implicit_VR
         self.is_little_endian: bool = is_little_endian
 
@@ -2826,9 +2828,7 @@ class FileMetaDataset(Dataset):
         self.PrivateInformation: bytes  # OB, 1C
 
     @staticmethod
-    def validate(
-        init_value: Union[Dataset, MutableMapping[BaseTag, _DatasetValue]]
-    ) -> None:
+    def validate(init_value: _DatasetType) -> None:
         """Raise errors if initialization value is not acceptable for file_meta
 
         Parameters

--- a/pydicom/encoders/base.py
+++ b/pydicom/encoders/base.py
@@ -289,9 +289,7 @@ class Encoder:
         kwargs = {**self.kwargs_from_ds(ds), **kwargs}
         self._validate_encoding_profile(**kwargs)
 
-        file_meta = cast("FileDataset", ds).file_meta
-        file_meta = cast("FileMetaDataset", file_meta)
-        tsyntax = file_meta.TransferSyntaxUID
+        tsyntax = ds.file_meta.TransferSyntaxUID
         if not tsyntax.is_compressed:
             return self._encode_bytes(
                 ds.PixelData, idx, encoding_plugin, **kwargs

--- a/pydicom/multival.py
+++ b/pydicom/multival.py
@@ -83,10 +83,11 @@ class MultiValue(MutableSequence[_ItemType]):
         return self._list == other
 
     @overload
-    def __getitem__(self, index: int) -> _ItemType: pass
+    def __getitem__(self, index: int) -> _ItemType: pass  # pragma: no cover
 
     @overload
-    def __getitem__(self, index: slice) -> MutableSequence[_ItemType]: pass
+    def __getitem__(self, index: slice) -> MutableSequence[_ItemType]:
+        pass  # pragma: no cover
 
     def __getitem__(
         self, index: Union[slice, int]
@@ -106,10 +107,11 @@ class MultiValue(MutableSequence[_ItemType]):
         return self._list != other
 
     @overload
-    def __setitem__(self, idx: int, val: _T) -> None: pass
+    def __setitem__(self, idx: int, val: _T) -> None: pass  # pragma: no cover
 
     @overload
-    def __setitem__(self, idx: slice, val: Iterable[_T]) -> None: pass
+    def __setitem__(self, idx: slice, val: Iterable[_T]) -> None:
+        pass  # pragma: no cover
 
     def __setitem__(  # type: ignore[misc]
         self, idx: Union[int, slice], val: Union[_T, Iterable[_T]]

--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -155,9 +155,7 @@ def get_pixeldata(ds: "Dataset") -> "numpy.ndarray":
     NotImplementedError
         If the transfer syntax is not supported
     """
-    file_meta = cast("FileDataset", ds).file_meta
-    file_meta = cast("FileMetaDataset", file_meta)
-    transfer_syntax = file_meta.TransferSyntaxUID
+    transfer_syntax = ds.file_meta.TransferSyntaxUID
 
     if not HAVE_PIL:
         raise ImportError(

--- a/pydicom/pixel_data_handlers/pylibjpeg_handler.py
+++ b/pydicom/pixel_data_handlers/pylibjpeg_handler.py
@@ -223,8 +223,7 @@ def generate_frames(
     RuntimeError
         If the plugin required to decode the pixel data is not installed.
     """
-    file_meta: "FileMetaDataset" = ds.file_meta
-    tsyntax = file_meta.TransferSyntaxUID
+    tsyntax = ds.file_meta.TransferSyntaxUID
     # The check of transfer syntax must be first
     if tsyntax not in _DECODERS:
         if tsyntax in _OPENJPEG_SYNTAXES:

--- a/pydicom/pixel_data_handlers/rle_handler.py
+++ b/pydicom/pixel_data_handlers/rle_handler.py
@@ -127,8 +127,7 @@ def get_pixeldata(ds: "Dataset", rle_segment_order: str = '>') -> "np.ndarray":
         If the actual length of the pixel data doesn't match the expected
         length.
     """
-    file_meta = cast("FileMetaDataset", ds.file_meta)  # type: ignore[has-type]
-    transfer_syntax = file_meta.TransferSyntaxUID
+    transfer_syntax = ds.file_meta.TransferSyntaxUID
     # The check of transfer syntax must be first
     if transfer_syntax not in SUPPORTED_TRANSFER_SYNTAXES:
         raise NotImplementedError(

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -1146,9 +1146,7 @@ def pixel_dtype(ds: "Dataset", as_float: bool = False) -> "np.dtype":
         raise ImportError("Numpy is required to determine the dtype.")
 
     if ds.is_little_endian is None:
-        file_meta = cast("FileDataset", ds).file_meta
-        file_meta = cast("FileMetaDataset", file_meta)
-        ds.is_little_endian = file_meta.TransferSyntaxUID.is_little_endian
+        ds.is_little_endian = ds.file_meta.TransferSyntaxUID.is_little_endian
 
     if not as_float:
         # (0028,0103) Pixel Representation, US, 1
@@ -1302,9 +1300,7 @@ def reshape_pixel_array(ds: "Dataset", arr: "np.ndarray") -> "np.ndarray":
 
     # Valid values for Planar Configuration are dependent on transfer syntax
     if nr_samples > 1:
-        file_meta = cast("FileDataset", ds).file_meta
-        file_meta = cast("FileMetaDataset", file_meta)
-        transfer_syntax = file_meta.TransferSyntaxUID
+        transfer_syntax = ds.file_meta.TransferSyntaxUID
         if transfer_syntax in ['1.2.840.10008.1.2.4.50',
                                '1.2.840.10008.1.2.4.57',
                                '1.2.840.10008.1.2.4.70',

--- a/pydicom/sequence.py
+++ b/pydicom/sequence.py
@@ -121,10 +121,12 @@ class Sequence(MultiValue[Dataset]):
                 item.parent = self._parent
 
     @overload  # type: ignore[override]
-    def __setitem__(self, idx: int, val: Dataset) -> None: pass
+    def __setitem__(self, idx: int, val: Dataset) -> None:
+        pass  # pragma: no cover
 
     @overload
-    def __setitem__(self, idx: slice, val: Iterable[Dataset]) -> None: pass
+    def __setitem__(self, idx: slice, val: Iterable[Dataset]) -> None:
+        pass  # pragma: no cover
 
     def __setitem__(
         self, idx: Union[slice, int], val: Union[Iterable[Dataset], Dataset]

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1875,7 +1875,7 @@ class TestFileDataset:
         expected_diff = {'__class__', '__doc__', '__hash__', 'fromkeys'}
         if sys.version_info[:2] >= (3, 9):
             expected_diff = expected_diff.union({
-                '__ror__', '__ior__', '__or__','__reversed__',
+                '__ror__', '__ior__', '__or__', '__reversed__',
                 '__class_getitem__',
             })
 

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -5,6 +5,7 @@ import copy
 import io
 import math
 import pickle
+import sys
 import weakref
 
 import pytest
@@ -1871,10 +1872,13 @@ class TestFileDataset:
         """Ensure that we don't use inherited dict functionality"""
         ds = Dataset()
         di = dict()
-        expected_diff = {
-            '__class__', '__class_getitem__', '__doc__', '__hash__',
-            '__ior__', '__or__', '__reversed__', '__ror__', 'fromkeys'
-        }
+        expected_diff = {'__class__', '__doc__', '__hash__', 'fromkeys'}
+        if sys.version_info[:2] >= (3, 9):
+            expected_diff = expected_diff.union({
+                '__ror__', '__ior__', '__or__','__reversed__',
+                '__class_getitem__',
+            })
+
         assert expected_diff == set(dir(di)) - set(dir(ds))
 
     def test_copy_filedataset(self):

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1874,11 +1874,11 @@ class TestFileDataset:
         di = dict()
         expected_diff = {'__class__', '__doc__', '__hash__', 'fromkeys'}
         if sys.version_info[:2] >= (3, 8):
-            expected_diff = expected_diff.union({'__reversed__'})
+            expected_diff.add('__reversed__')
         if sys.version_info[:2] >= (3, 9):
-            expected_diff = expected_diff.union({
-                '__ror__', '__ior__', '__or__', '__class_getitem__',
-            })
+            expected_diff.update([
+                '__ror__', '__ior__', '__or__', '__class_getitem__'
+            ])
 
         assert expected_diff == set(dir(di)) - set(dir(ds))
 

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1873,10 +1873,11 @@ class TestFileDataset:
         ds = Dataset()
         di = dict()
         expected_diff = {'__class__', '__doc__', '__hash__', 'fromkeys'}
+        if sys.version_info[:2] >= (3, 8):
+            expected_diff = expected_diff.union({'__reversed__'})
         if sys.version_info[:2] >= (3, 9):
             expected_diff = expected_diff.union({
-                '__ror__', '__ior__', '__or__', '__reversed__',
-                '__class_getitem__',
+                '__ror__', '__ior__', '__or__', '__class_getitem__',
             })
 
         assert expected_diff == set(dir(di)) - set(dir(ds))


### PR DESCRIPTION
#### Describe the changes
* Change `Dataset` to no longer inherit from `dict`. Fixes a Liskov substitution issue and `__iter__` type hint problem
* Add `__array__` implementation so dataset access still works in a numpy array.
* Some minor type improvements
* Ensure `FileDataset.file_meta` exists and is not `None`

Missing `dict` methods:
* Python 3.6+: ``__class__,  __doc__, __hash__, fromkeys``
* Python 3.8+: ``__reversed__``
* Python 3.9+: ``__ior__, __or__, __ror__, __class_getitem__``

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
