### PR TITLE
[MRG] Fix setting VR OL, OD and OV values containing backslashes

### DIFF
--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -106,4 +106,4 @@ Fixes
   rather than YBR with the Pillow pixel data handler (:pr:`878`)
 * Allow to deepcopy a `~pydicom.dataset.FileDataset` object (:issue:`1147`)
 * Fixed elements with a VR of **OL**, **OD** and **OV** not being set correctly
-  when an encoded backslash was part of the element value (:issue:`1421`)
+  when an encoded backslash was part of the element value (:issue:`1412`)

--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -105,3 +105,5 @@ Fixes
 * Fixed handling of JPEG (10918-1) images compressed using RGB colourspace
   rather than YBR with the Pillow pixel data handler (:pr:`878`)
 * Allow to deepcopy a `~pydicom.dataset.FileDataset` object (:issue:`1147`)
+* Fixed elements with a VR of **OL**, **OD** and **OV** not being set correctly
+  when an encoded backslash was part of the element value (:issue:`1421`)

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -433,13 +433,21 @@ class DataElement:
     @value.setter
     def value(self, val: Any) -> None:
         """Convert (if necessary) and set the value of the element."""
+        # Ignore backslash characters in these str or byte VRs
+        #   Based on Part 5, Section 6.2 and
+        exclusions = [
+            'LT', 'OB', 'OD', 'OF', 'OL', 'OV', 'OW', 'ST', 'UN', 'UT',
+            'OB/OW', 'OW/OB', 'OB or OW', 'OW or OB',
+        ]
+
         # Check if is a string with multiple values separated by '\'
         # If so, turn them into a list of separate strings
         #  Last condition covers 'US or SS' etc
-        if isinstance(val, (str, bytes)) and self.VR not in \
-                ['UT', 'ST', 'LT', 'FL', 'FD', 'AT', 'OB', 'OW', 'OF', 'SL',
-                 'SQ', 'SS', 'UL', 'OB/OW', 'OW/OB', 'OB or OW',
-                 'OW or OB', 'UN'] and 'US' not in self.VR:
+        if (
+            isinstance(val, (str, bytes))
+            and self.VR not in exclusions
+            and 'US' not in self.VR
+        ):
             try:
                 if _backslash_str in val:
                     val = cast(str, val).split(_backslash_str)

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -433,8 +433,9 @@ class DataElement:
     @value.setter
     def value(self, val: Any) -> None:
         """Convert (if necessary) and set the value of the element."""
-        # Ignore backslash characters in these str or byte VRs
-        #   Based on Part 5, Section 6.2 and
+        # Ignore backslash characters in these VRs, based on:
+        # * Which str VRs can have backslashes in Part 5, Section 6.2
+        # * All byte VRs
         exclusions = [
             'LT', 'OB', 'OD', 'OF', 'OL', 'OV', 'OW', 'ST', 'UN', 'UT',
             'OB/OW', 'OW/OB', 'OB or OW', 'OW or OB',

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -439,6 +439,8 @@ class DataElement:
         exclusions = [
             'LT', 'OB', 'OD', 'OF', 'OL', 'OV', 'OW', 'ST', 'UN', 'UT',
             'OB/OW', 'OW/OB', 'OB or OW', 'OW or OB',
+            # Probably not needed
+            'AT', 'FD', 'FL', 'SQ', 'SS', 'SL', 'UL',
         ]
 
         # Check if is a string with multiple values separated by '\'

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -1546,3 +1546,16 @@ def test_set_value(vr, pytype, vm0, vmN, keyword):
     elem = ds[keyword]
     assert elem.value == list(vmN)
     assert list(vmN) == elem.value
+
+
+@pytest.mark.parametrize("vr, pytype, vm0, vmN, keyword", VALUE_REFERENCE)
+def test_assigning_bytes(vr, pytype, vm0, vmN, keyword):
+    """Test that byte VRs are excluded from the backslash check."""
+    if pytype == bytes:
+        ds = Dataset()
+        value = b"\x00\x01" + b"\\" + b"\x02\x03"
+        setattr(ds, keyword, value)
+        elem = ds[keyword]
+        assert elem.VR == vr
+        assert elem.value == value
+        assert elem.VM == 1


### PR DESCRIPTION
#### Describe the changes

Closes #1412

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
