### PR TITLE
[MRG ]Fix incorrect expansion of segmented LUTs…

### DIFF
--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -107,3 +107,5 @@ Fixes
 * Allow to deepcopy a `~pydicom.dataset.FileDataset` object (:issue:`1147`)
 * Fixed elements with a VR of **OL**, **OD** and **OV** not being set correctly
   when an encoded backslash was part of the element value (:issue:`1412`)
+* Fixed expansion of linear segments with floating point steps in
+  segmented LUTs (:issue:`1415`)

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -873,7 +873,7 @@ def _expand_segmented_lut(
                 lut.extend([y1] * length)
             else:
                 step = (y1 - y0) / length
-                vals = np.around(np.arange(y0 + step, y1 + step, step))
+                vals = np.around(np.linspace(y0 + step, y1, length))
                 lut.extend([int(vv) for vv in vals])
         elif opcode == 2:
             # C.7.9.2.3: Indirect segment

--- a/pydicom/tests/test_handler_util.py
+++ b/pydicom/tests/test_handler_util.py
@@ -1252,6 +1252,11 @@ class TestNumpy_ExpandSegmentedLUT:
         out = _expand_segmented_lut(data, 'H')
         assert [-400, -320, -240, -160, -80, 0] == out
 
+        # Positive slope, floating point steps
+        data = (0, 1, 163, 1, 48, 255)
+        out = _expand_segmented_lut(data, 'H')
+        assert (1 + 48) == len(out)
+
         # No slope
         data = (0, 2, 0, 28672, 1, 5, 28672)
         out = _expand_segmented_lut(data, 'H')


### PR DESCRIPTION
… by replacing np.arange with np.linspace

- closes #1415

#### Describe the changes
See #1415 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
