### PR TITLE
[MRG] Make codes hashable

### DIFF
--- a/pydicom/sr/coding.py
+++ b/pydicom/sr/coding.py
@@ -2,7 +2,6 @@
 
 from typing import NamedTuple, Any, Optional
 
-from pydicom.dataset import Dataset
 from pydicom.sr._snomed_dict import mapping as snomed_mapping
 
 
@@ -13,10 +12,13 @@ class Code(NamedTuple):
 
     ..versionadded: 1.4
     """
-    value: Any
+    value: str
     scheme_designator: str
     meaning: str
     scheme_version: Optional[str]
+
+    def __hash__(self) -> int:
+        return hash(self.scheme_designator + self.value)
 
     def __eq__(self, other: Any) -> bool:
         if self.scheme_designator == "SRT":

--- a/pydicom/tests/test_coding.py
+++ b/pydicom/tests/test_coding.py
@@ -1,7 +1,4 @@
-import pytest
-
 from pydicom.sr.coding import Code
-from pydicom.uid import UID
 
 
 class TestCode:
@@ -20,6 +17,15 @@ class TestCode:
         assert c.scheme_designator == self._scheme_designator
         assert c.meaning == self._meaning
         assert c.scheme_version is None
+
+    def test_use_as_dictionary_key(self):
+        c = Code(
+            value=self._value,
+            scheme_designator=self._scheme_designator,
+            meaning=self._meaning,
+        )
+        d = {c: 1}
+        assert c in d.keys()
 
     def test_construction_kwargs_optional(self):
         version = "v1.0"


### PR DESCRIPTION
This will allow using codes as dictionary keys!

<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
Adds a `__hash__` method to `pydicom.sr.coding.Code` to allow instances to be included into a `set` and used as `dict` keys.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [] Unit tests passing and overall coverage the same or better
