### PR TITLE
[MRG] Fix DSfloat bug when enforce_valid_values is True 

### DIFF
--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -499,7 +499,7 @@ class TestDS:
 
 class TestDSfloat:
     """Unit tests for pickling DSfloat"""
-    def test_pickling(self):
+    def test_pickling(self, enforce_valid_both_fixture):
         # Check that a pickled DSFloat is read back properly
         x = DSfloat(9.0)
         x.original_string = "hello"
@@ -508,13 +508,13 @@ class TestDSfloat:
         assert x.real == x2.real
         assert x.original_string == x2.original_string
 
-    def test_new_empty(self):
+    def test_new_empty(self, enforce_valid_both_fixture):
         """Test passing an empty value."""
         assert isinstance(DSfloat(''), str)
         assert DSfloat('') == ''
         assert DSfloat(None) is None
 
-    def test_str_value(self):
+    def test_str_value(self, enforce_valid_both_fixture):
         """Test creating using str"""
         assert DSfloat('1.20') == 1.2
         assert DSfloat('1.20') == 1.20
@@ -524,7 +524,7 @@ class TestDSfloat:
         assert DSfloat('1.20') == '1.20'
         assert DSfloat('1.20 ') == '1.20'
 
-    def test_str(self):
+    def test_str(self, enforce_valid_both_fixture):
         """Test DSfloat.__str__()."""
         val = DSfloat(1.1)
         assert str(val) == '1.1'
@@ -532,7 +532,7 @@ class TestDSfloat:
         val = DSfloat("1.1")
         assert str(val) == '1.1'
 
-    def test_repr(self):
+    def test_repr(self, enforce_valid_both_fixture):
         """Test DSfloat.__repr__()."""
         val = DSfloat(1.1)
         assert repr(val) == "'1.1'"
@@ -542,7 +542,7 @@ class TestDSfloat:
         assert repr(val) == repr("1.1")
         assert repr(val) == repr('1.1')
 
-    def test_DSfloat(self):
+    def test_DSfloat(self, enforce_valid_both_fixture):
         """Test creating a value using DSfloat."""
         x = DSfloat('1.2345')
         y = DSfloat(x)
@@ -551,7 +551,7 @@ class TestDSfloat:
         assert 1.2345 == y
         assert "1.2345" == y.original_string
 
-    def test_DSdecimal(self):
+    def test_DSdecimal(self, enforce_valid_both_fixture):
         """Test creating a value using DSdecimal."""
         x = DSdecimal('1.2345')
         y = DSfloat(x)

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -529,7 +529,7 @@ class DSfloat(float):
                 self.original_string = format_number_as_ds(self)
 
         if config.enforce_valid_values and not self.auto_format:
-            if len(repr(self).strip('"')) > 16:
+            if len(repr(self).strip("'")) > 16:
                 raise OverflowError(
                     "Values for elements with a VR of 'DS' must be <= 16 "
                     "characters long, but the float provided requires > 16 "
@@ -538,7 +538,7 @@ class DSfloat(float):
                     "override the length check, or explicitly construct a DS "
                     "object with 'auto_format' set to True"
                 )
-            if not is_valid_ds(repr(self).strip('"')):
+            if not is_valid_ds(repr(self).strip("'")):
                 # This will catch nan and inf
                 raise ValueError(
                     f'Value "{str(self)}" is not valid for elements with a VR '

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -529,7 +529,7 @@ class DSfloat(float):
                 self.original_string = format_number_as_ds(self)
 
         if config.enforce_valid_values and not self.auto_format:
-            if len(repr(self).strip("'")) > 16:
+            if len(repr(self)[1:-1]) > 16:
                 raise OverflowError(
                     "Values for elements with a VR of 'DS' must be <= 16 "
                     "characters long, but the float provided requires > 16 "
@@ -538,7 +538,7 @@ class DSfloat(float):
                     "override the length check, or explicitly construct a DS "
                     "object with 'auto_format' set to True"
                 )
-            if not is_valid_ds(repr(self).strip("'")):
+            if not is_valid_ds(repr(self)[1:-1]):
                 # This will catch nan and inf
                 raise ValueError(
                     f'Value "{str(self)}" is not valid for elements with a VR '


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
It appears that a change in #1397 that changed the repr of DSfloat from being enclosed in double quotes to now being enclosed in single quotes. This change broke some checks on the representation of the `DSfloat` that are run in the `DSfloat` constructor when `pydicom.config.enforce_valid_values` is set to `True`. This has had some pretty severe consequences, for example the following snippet currently raises a `ValueError`:

```python
import pydicom

pydicom.config.enforce_valid_value = True

pydicom.valuerep.DSfloat(1.0)  # ValueError!
```

This pull request makes a simple tweak to fix this bug by stripping whatever outer characters surround the repr rather than stripping literal double quote characters. It also adds some regression tests simply by deploying the existing fixture to run tests both with and without the `enforce_valid_values` flag on more of the DSfloat-related (and, defensively, the DSdecimal-related) tests in `test_valuerep.py`

#### Tasks 
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
