### PR TITLE
[MRG] Fix incorrect component delimiter constant

### DIFF
--- a/doc/release_notes/v2.2.0.rst
+++ b/doc/release_notes/v2.2.0.rst
@@ -110,3 +110,5 @@ Fixes
   when an encoded backslash was part of the element value (:issue:`1412`)
 * Fixed expansion of linear segments with floating point steps in
   segmented LUTs (:issue:`1415`)
+* Fixed handling of code extensions with person name component delimiter
+  (:pr:`1449`)

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -41,7 +41,7 @@ TEXT_VR_DELIMS = {0x0d, 0x0a, 0x09, 0x0c}
 
 # Character/Character code for PN delimiter: name part separator '^'
 # (the component separator '=' is handled separately)
-PN_DELIMS = {0xe5}
+PN_DELIMS = {0x5e}
 
 
 class _DateTimeBase:


### PR DESCRIPTION
- typo in constant used for PN component delimiter while handling
  code extensions

<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
The related issue or a description of the bug or feature that this PR addresses.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better

This is a bit embarassing - used `0xe5` instead of `0x5e` for `^`, and the single-byte encoding tests have not been made with PN, so they passed even though the byte data was incorrect. Noticed this while trying to port some of the tests to fo-dicom.