### PR TITLE
[MRG] Make workflow install --pre pymedphys release

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -127,7 +127,7 @@ jobs:
 
     - name: Install pymedphys
       if: ${{ matrix.pymedphys-dep == 'pymedphys' }}
-      run: python -m pip install pymedphys[user,tests]>=0.31.0
+      run: python -m pip install --pre pymedphys[user,tests]
     - name: Get PyMedPhys cache directory
       if: ${{ matrix.pymedphys-dep == 'pymedphys' }}
       id: pymedphys-cache-location


### PR DESCRIPTION
PyMedPhys released a development version ([0.38.0.dev0](https://pypi.org/project/pymedphys/0.38.0.dev0/)) containing a fix for https://github.com/pydicom/pydicom/pull/1458#issuecomment-893891181.

By making pydicom pull a development release this allows me to fix pydicom's CI promptly without needing to craft a production pymedphys release.
