### PR TITLE
[MRG] Typos found by codespell

### DIFF
--- a/doc/release_notes/v0.9.5.rst
+++ b/doc/release_notes/v0.9.5.rst
@@ -38,6 +38,6 @@ Other
 .....
 
 * switch to Distribute for packaging
-* preliminary work on Python 3 compatiblity
+* preliminary work on Python 3 compatibility
 * preliminary work on using sphinx for documentation
 * preliminary work on better writing of files from scratch

--- a/doc/release_notes/v1.2.0.rst
+++ b/doc/release_notes/v1.2.0.rst
@@ -63,7 +63,7 @@ Fixes
 * Fixed handling of private tags in repeater range (:issue:`689`)
 * Fixed Pillow pixel data handler for non-JPEG2k transfer syntax (:issue:`663`)
 * Fixed handling of elements with ambiguous VR (:pr:`700, 728`)
-* Adapted pixel handlers where endianess is explicitly adapted (:issue:`704`)
+* Adapted pixel handlers where endianness is explicitly adapted (:issue:`704`)
 * Improve performance of bit unpacking (:pr:`715`)
 * First character set no longer removed (:issue:`707`)
 * Fixed RLE decoded data having the wrong byte order (:pr:`729`)

--- a/doc/tutorials/filesets.rst
+++ b/doc/tutorials/filesets.rst
@@ -332,7 +332,7 @@ use the :meth:`~pydicom.fileset.FileSet.add_custom` method.
 The :meth:`~pydicom.fileset.FileSet.add` method uses *pydicom's* default
 directory record creation functions to create the necessary records based on
 the SOP instance's attributes, such as *SOP Class UID* and *Modality*.
-Occassionally they may fail when an element required by these functions
+Occasionally they may fail when an element required by these functions
 is empty or missing:
 
 .. code-block:: python

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -354,7 +354,7 @@ class Dataset:
     is_little_endian : bool
         Shall be set before writing with ``write_like_original=False``.
         The :class:`Dataset` (excluding the pixel data) will be written using
-        the given endianess.
+        the given endianness.
     is_implicit_VR : bool
         Shall be set before writing with ``write_like_original=False``.
         The :class:`Dataset` will be written using the transfer syntax with
@@ -382,7 +382,7 @@ class Dataset:
 
         # the following read_XXX attributes are used internally to store
         # the properties of the dataset after read from a file
-        # set depending on the endianess of the read dataset
+        # set depending on the endianness of the read dataset
         self.read_little_endian: Optional[bool] = None
         # set depending on the VR handling of the read dataset
         self.read_implicit_vr: Optional[bool] = None
@@ -1148,7 +1148,7 @@ class Dataset:
     def _dataset_slice(self, slce: slice) -> "Dataset":
         """Return a slice that has the same properties as the original dataset.
 
-        That includes properties related to endianess and VR handling,
+        That includes properties related to endianness and VR handling,
         and the specific character set. No element conversion is done, e.g.
         elements of type ``RawDataElement`` are kept.
         """
@@ -1168,7 +1168,7 @@ class Dataset:
 
         .. versionadded:: 1.1
 
-        This includes properties related to endianess, VR handling and the
+        This includes properties related to endianness, VR handling and the
         (0008,0005) *Specific Character Set*.
         """
         return (

--- a/pydicom/encoders/native.py
+++ b/pydicom/encoders/native.py
@@ -130,7 +130,7 @@ def _encode_row(src: bytes) -> bytes:
     Notes
     -----
     * 2-byte repeat runs are always encoded as Replicate Runs rather than
-      only when not preceeded by a Literal Run as suggested by the Standard.
+      only when not preceded by a Literal Run as suggested by the Standard.
     """
     out: List[int] = []
     out_append = out.append

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -830,7 +830,7 @@ def _write_dataset(
     if any, has been written.
     """
 
-    # if we want to write with the same endianess and VR handling as
+    # if we want to write with the same endianness and VR handling as
     # the read dataset we want to preserve raw data elements for
     # performance reasons (which is done by get_item);
     # otherwise we use the default converting item getter

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -774,10 +774,10 @@ def dtype_corrected_for_endianness(
     Parameters
     ----------
     is_little_endian : bool
-        The endianess of the affected :class:`~pydicom.dataset.Dataset`.
+        The endianness of the affected :class:`~pydicom.dataset.Dataset`.
     numpy_dtype : numpy.dtype
         The numpy data type used for the *Pixel Data* without considering
-        endianess.
+        endianness.
 
     Raises
     ------
@@ -788,7 +788,7 @@ def dtype_corrected_for_endianness(
     -------
     numpy.dtype
         The numpy data type used for the *Pixel Data* without considering
-        endianess.
+        endianness.
     """
     if is_little_endian is None:
         raise ValueError("Dataset attribute 'is_little_endian' "

--- a/pydicom/tests/test_handler_util.py
+++ b/pydicom/tests/test_handler_util.py
@@ -159,7 +159,7 @@ class TestNumpy_PixelDtype:
         assert ref_dtype == pixel_dtype(self.ds, as_float=as_float)
 
     def test_byte_swapping(self):
-        """Test that the endianess of the system is taken into account."""
+        """Test that the endianness of the system is taken into account."""
         # The main problem is that our testing environments are probably
         #   all little endian, but we'll try our best
         self.ds.BitsAllocated = 16
@@ -670,7 +670,7 @@ class TestNumpy_ConvertColourSpace:
 class TestNumpy_DtypeCorrectedForEndianness:
     """Tests for util.dtype_corrected_for_endianness."""
     def test_byte_swapping(self):
-        """Test that the endianess of the system is taken into account."""
+        """Test that the endianness of the system is taken into account."""
         # The main problem is that our testing environments are probably
         #   all little endian, but we'll try our best
         dtype = np.dtype('uint16')


### PR DESCRIPTION
#### Describe the changes

Fixes typos detected by [codespell](https://github.com/codespell-project/codespell).

I have very slightly modified a couple past release notes, I hope that's acceptable.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
