### PR TITLE
[MRG] Typos found by codespell

### DIFF
--- a/build_tools/circle/push_doc.sh
+++ b/build_tools/circle/push_doc.sh
@@ -3,7 +3,7 @@
 # This script is meant to be called in the "deploy" step defined
 # in .circleci/config.yml. See https://circleci.com/docs/2.0 for more details.
 
-# We have three possibily workflows:
+# We have three possible workflows:
 #   If the git branch is 'master' then we want to commit and merge the dev/
 #       docs on gh-pages
 #   If the git branch is [0-9].[0.9].X (i.e. 0.9.X, 1.0.X, 1.2.X, 41.21.X) then

--- a/doc/old/ref_guide.rst
+++ b/doc/old/ref_guide.rst
@@ -32,7 +32,7 @@ File Writing
 DICOM files can also be written using *pydicom*. There are two ways to do this.
 
 * The first is to use
-  :func:`~filewriter.dcmwrite` with a prexisting :class:`~dataset.FileDataset`
+  :func:`~filewriter.dcmwrite` with a preexisting :class:`~dataset.FileDataset`
   (derived from :class:`~dataset.Dataset`) instance.
 * The second is to use the :meth:`Dataset.save_as()<dataset.Dataset.save_as>`
   method on a ``FileDataset`` or ``Dataset`` instance.

--- a/pydicom/data/download.py
+++ b/pydicom/data/download.py
@@ -185,7 +185,7 @@ def data_path_with_download(
     filename : str
         The filename of the file to return the path to.
     check_hash : bool, optional
-        ``True`` to perform a SHA256 checkum on the file, ``False`` otherwise.
+        ``True`` to perform a SHA256 checksum on the file, ``False`` otherwise.
     redownload_on_hash_mismatch : bool, optional
         ``True`` to redownload the file on checksum failure, ``False``
         otherwise.

--- a/pydicom/datadict.py
+++ b/pydicom/datadict.py
@@ -602,7 +602,7 @@ def private_dictionary_VM(tag: TagType, private_creator: str) -> str:
         The tag for the element whose value multiplicity (VM) is being
         retrieved.
     private_creator : str
-        The name of the private creater.
+        The name of the private creator.
 
     Returns
     -------

--- a/pydicom/fileset.py
+++ b/pydicom/fileset.py
@@ -90,7 +90,7 @@ def generate_filename(
         The starting index to use for the suffixes, (default ``0``).
         i.e. if you want to start at ``'00010'`` then `start` should be ``10``.
     alphanumeric : bool, optional
-        If ``False`` (defalt) then only generate suffixes using the characters
+        If ``False`` (default) then only generate suffixes using the characters
         [0-9], otherwise use [0-9][A-Z].
 
     Yields

--- a/pydicom/tests/test_codes.py
+++ b/pydicom/tests/test_codes.py
@@ -220,7 +220,7 @@ class TestCodesDict:
         assert codes.cid3001.NegativeLowRightScapulaLead == Code(
             value="2:124",
             scheme_designator="MDC",
-            meaning="negativ: low right scapula Lead",
+            meaning="negative: low right scapula Lead",
         )
 
     def test_cid3107(self):

--- a/pydicom/tests/test_handler_util.py
+++ b/pydicom/tests/test_handler_util.py
@@ -1891,7 +1891,7 @@ class TestNumpy_ApplyVOI:
         assert 8 == ds.BitsStored
         assert 0 == ds.PixelRepresentation
         item0 = ds.VOILUTSequence[0]
-        # Add another view thats the inverse
+        # Add another view that's the inverse
         ds.VOILUTSequence.append(Dataset())
         item1 = ds.VOILUTSequence[1]
         item1.LUTDescriptor = [256, 0, 16]

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -1208,7 +1208,7 @@ class TestPersonName:
         assert next(pn3_itr) == "m"
         assert next(pn3_itr) == "e"
 
-        # Attempting to get next characeter should stop the iteration
+        # Attempting to get next character should stop the iteration
         # I.e. next can only start once
         with pytest.raises(StopIteration):
             next(pn3_itr)
@@ -1220,7 +1220,7 @@ class TestPersonName:
             next(pn4)
 
     def test_iterator(self):
-        """Test that iterators can be corretly constructed"""
+        """Test that iterators can be correctly constructed"""
         name_str = "John^Doe^^Dr"
         pn1 = PersonName(name_str)
 


### PR DESCRIPTION
#### Describe the changes

More typos found by [copdespell](https://github.com/codespell-project/codespell). Not sure why I missed them in the first pull request.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
