### PR TITLE
Make dependencies not use --pre

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -127,7 +127,7 @@ jobs:
 
     - name: Install pymedphys
       if: ${{ matrix.pymedphys-dep == 'pymedphys' }}
-      run: python -m pip install --pre pymedphys[user,tests]
+      run: python -m pip install --pre pymedphys && python -m pip install pymedphys[user,tests]
     - name: Get PyMedPhys cache directory
       if: ${{ matrix.pymedphys-dep == 'pymedphys' }}
       id: pymedphys-cache-location


### PR DESCRIPTION
By installing with --pre all dependencies bring along their development releases also. This is a recipe for weird problems (https://github.com/pydicom/pydicom/issues/1473#issuecomment-895622509) (thanks @scaramallion for getting to the bottom of that one, sorry I miss-attributed the cause).

So here's the fix.