### PR TITLE
[MRG] ability to handle truncated files through Pillow

### DIFF
--- a/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/pydicom/pixel_data_handlers/pillow_handler.py
@@ -18,7 +18,8 @@ except ImportError:
     HAVE_NP = False
 
 try:
-    from PIL import Image, features
+    from PIL import Image, features, ImageFile
+    ImageFile.LOAD_TRUNCATED_IMAGES = True
     HAVE_PIL = True
     HAVE_JPEG = features.check_codec("jpg")
     HAVE_JPEG2K = features.check_codec("jpg_2000")


### PR DESCRIPTION
The existing Pillow handler (in pixel_array) throws an error when faced with truncated image files. Proposed changes through ImageFile module now explicitly instruct Pillow to read truncated files, so that pixel_array always works even if the image is corrupt.
