### PR TITLE
[MRG] Get rid of trailing spaces and empty lines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,12 @@ filing issues. Please read it carefully to help make the code review
 process go as smoothly as possible and maximize the likelihood of your
 contribution being merged.
 
-_Note:_  
-If you want to contribute new functionality, you may first consider if this 
+_Note:_
+If you want to contribute new functionality, you may first consider if this
 functionality belongs to the pydicom core, or is better suited for
 [contrib-pydicom](https://github.com/pydicom/contrib-pydicom). contrib-pydicom
 collects some convenient functionality that uses pydicom, but doesn't
-belong to the pydicom core. If you're not sure where your contribution belongs, 
+belong to the pydicom core. If you're not sure where your contribution belongs,
 create an issue where you can discuss this before creating a pull request.
 
 
@@ -53,26 +53,26 @@ GitHub, clone, and develop on a branch. Steps:
 5. Add a meaningful commit message. Pull requests are "squash-merged", e.g.
    squashed into one commit with all commit messages combined. The commit
    messages can be edited during the merge, but it helps if they are clearly
-   and briefly showing what has been done in the commit. Check out the 
+   and briefly showing what has been done in the commit. Check out the
    [seven commonly accepted rules](https://www.theserverside.com/video/Follow-these-git-commit-message-guidelines)
    for commit messages. Here are some examples, taken from actual commits:
-   
+
    ```
    Add support for new VRs OV, SV, UV
-   
+
    -  closes #1016
    ```
    ```
-   Add warning when saving compressed without encapsulation  
-   ``` 
+   Add warning when saving compressed without encapsulation
+   ```
    ```
    Add optional handler argument to Dataset.decompress()
-   
+
    - also add it to Dataset.convert_pixel_data()
    - add separate error handling for given handle
    - see #537
    ```
-   
+
 6. To record your changes in Git, push the changes to your GitHub
    account with:
 
@@ -96,12 +96,12 @@ submit a pull request:
    follow [PEP-8 guidelines](https://www.python.org/dev/peps/pep-0008/) for
    the code, and the [Google style](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings)
    for documentation.
-   
+
 -  If your pull request addresses an issue, please use the pull request title to
    describe the issue and mention the issue number in the pull request
    description. This will make sure a link back to the original issue is
-   created. Use "closes #issue-number" or "fixes #issue-number" to let GitHub 
-   automatically close the related issue on commit. Use any other keyword 
+   created. Use "closes #issue-number" or "fixes #issue-number" to let GitHub
+   automatically close the related issue on commit. Use any other keyword
    (i.e. works on, related) to avoid GitHub to close the referenced issue.
 
 -  All public methods should have informative docstrings with sample
@@ -111,7 +111,7 @@ submit a pull request:
    if the contribution is complete and ready for a detailed review. Some of the
    core developers will review your code, make suggestions for changes, and
    approve it as soon as it is ready for merge. Pull requests are usually merged
-   after two approvals by core developers, or other developers asked to review the code. 
+   after two approvals by core developers, or other developers asked to review the code.
    An incomplete contribution -- where you expect to do more work before receiving a full
    review -- should be prefixed with `[WIP]` (to indicate a work in progress) and
    changed to `[MRG]` when it matures. WIPs may be useful to: indicate you are
@@ -128,10 +128,10 @@ submit a pull request:
    to other methods available in pydicom.
 
 -  Documentation and high-coverage tests are necessary for enhancements to be
-   accepted. Bug-fixes shall be provided with 
+   accepted. Bug-fixes shall be provided with
    [regression tests](https://en.wikipedia.org/wiki/regression_testing) that
    fail before the fix. For new features, the correct behavior shall be
-   verified by feature tests. A good practice to write sufficient tests is 
+   verified by feature tests. A good practice to write sufficient tests is
    [test-driven development](https://en.wikipedia.org/wiki/Test-driven_development).
 
 You can also check for common programming errors and style issues with the
@@ -155,7 +155,7 @@ following tools:
 -  No PEP8 warnings, check with:
 
   ```bash
-  $ pip install pycodestyle  # formerly called pep8 
+  $ pip install pycodestyle  # formerly called pep8
   $ pycodestyle path/to/module.py
   ```
 

--- a/doc/guides/encoding/index.rst
+++ b/doc/guides/encoding/index.rst
@@ -11,7 +11,7 @@ Pixel Data Encoding
    rle_lossless
 
 
-Encoding plugin information: 
+Encoding plugin information:
 
 .. toctree::
    :maxdepth: 1

--- a/doc/old/best_practices.rst
+++ b/doc/old/best_practices.rst
@@ -12,25 +12,25 @@ Introduction
 ------------
 
 There are some features of *pydicom* that allow you to help check your code
-for more strict DICOM practices, and to future-proof against major 
+for more strict DICOM practices, and to future-proof against major
 *pydicom* version changes.
 
-It is recommended that you turn on two features if you can: 
+It is recommended that you turn on two features if you can:
 enforcement of valid DICOM, and a flag to enable "future" pydicom changes.
 
 Enforcing Valid DICOM
 ---------------------
 
-*pydicom* has a configuration option to help enforce valid DICOM: 
+*pydicom* has a configuration option to help enforce valid DICOM:
 :attr:`~pydicom.config.enforce_valid_values`.
 
 If set to `True`, some non-standard DICOM will result in *pydicom* raising
 an error rather than assuming a default behavior or issuing a warning.
 
-This flag does not guarantee strict DICOM results, but is a help for 
+This flag does not guarantee strict DICOM results, but is a help for
 some specific situations that have been added to *pydicom* over time.
 
-In some cases, especially if you are dealing with files that do not 
+In some cases, especially if you are dealing with files that do not
 strictly adhere to the DICOM Standard, you may need to disable this flag.
 
 To turn on the flag in your code:
@@ -40,7 +40,7 @@ To turn on the flag in your code:
   from pydicom import config
   config.enforce_valid_values = True
 
-Note that you *must not* use 
+Note that you *must not* use
 :code:`from pydicom.config import enforce_valid_values`.
 That makes the `enforce_valid_values` variable local only to that module,
 so *pydicom* would not see your change to its value.
@@ -53,10 +53,10 @@ existing code using the library. Sometimes, major changes are necessary
 to make significant improvements to the library.
 
 To help you protect your code against future changes, *pydicom* allows you
-to flag that it should behave as it will for any known upcoming 
+to flag that it should behave as it will for any known upcoming
 major changes.
 
-Running your code with this turned on will help identify any parts of 
+Running your code with this turned on will help identify any parts of
 your code that are not compatible with the known changes in the next major
 version of *pydicom*.
 
@@ -65,7 +65,7 @@ The simplest way to set this behavior is to set an environment variable
 current terminal session:
 
 .. code-block::
-  
+
   SET PYDICOM_FUTURE=True           (Windows)
 
   export PYDICOM_FUTURE=True        (many linux environments)

--- a/doc/old/writing_files.rst
+++ b/doc/old/writing_files.rst
@@ -76,8 +76,8 @@ other individual items.
 
 For details on calling the codify command, see the :ref:`cli_codify` section.
 
-``codify`` could also be called from code, rather than from a command line; you 
-can look at the codify.py source and the ``code_file`` function for a 
+``codify`` could also be called from code, rather than from a command line; you
+can look at the codify.py source and the ``code_file`` function for a
 starting point for that.
 
 
@@ -90,7 +90,7 @@ can certainly write code from scratch to make a complete DICOM file using
 pydicom.
 
 It's not particularly difficult, but to produce a valid DICOM file requires
-specific items to be created.  A basic example of that is available in the 
+specific items to be created.  A basic example of that is available in the
 example file :ref:`sphx_glr_auto_examples_input_output_plot_write_dicom.py`.
 
 Just don't forget the warnings in the Introduction section above, and be sure

--- a/doc/release_notes/v1.3.0.rst
+++ b/doc/release_notes/v1.3.0.rst
@@ -66,7 +66,7 @@ Fixes
 * Correctly handle elements with ambiguous VR in sequence items (:issue:`804`)
 * Fix bug where new DicomDir objects always have is_implicit_VR
 * Fix dataset equality for mixed raw vs converted data elements (:issue:`835`)
-* Remove excess padding in Pixel Data 
+* Remove excess padding in Pixel Data
 * Fix wrong date format in anonymize example
 * Fix unknown VR exception message when VR isn't ASCII (:issue:`791`)
 * Fix jis-x-0201 characters encoding (:issue:`856`)

--- a/doc/release_notes/v1.3.0.rst
+++ b/doc/release_notes/v1.3.0.rst
@@ -70,4 +70,3 @@ Fixes
 * Fix wrong date format in anonymize example
 * Fix unknown VR exception message when VR isn't ASCII (:issue:`791`)
 * Fix jis-x-0201 characters encoding (:issue:`856`)
-

--- a/doc/release_notes/v1.4.0.rst
+++ b/doc/release_notes/v1.4.0.rst
@@ -75,7 +75,7 @@ Enhancements
 * Updated DICOM dictionary to 2019e edition (:issue:`1013`)
 * Added support for new VRs OV, SV, UV (:issue:`1016`)
 * Code dictionaries and ``Code`` class for structured reporting added
-  (alpha release only).  See the 
+  (alpha release only).  See the
   :doc:`Structured Reporting tutorial <../tutorials/sr_basics>` for more
   information
 

--- a/doc/tutorials/sr_basics.rst
+++ b/doc/tutorials/sr_basics.rst
@@ -5,11 +5,11 @@ Structured Reporting
 .. versionadded:: 1.4
 
 Starting in *pydicom* version 1.4, some support for DICOM Structured Reporting (SR) began to be added,
-as alpha code; the API for this is subject to change in future *pydicom* versions. At this point the 
-code is limited to code dictionaries and one class :class:`~pydicom.sr.coding.Code` 
+as alpha code; the API for this is subject to change in future *pydicom* versions. At this point the
+code is limited to code dictionaries and one class :class:`~pydicom.sr.coding.Code`
 as a foundational step for future work.
 
-Most access is through a ``codes`` class instance provided in ``pydicom.sr.codedict``. This can be used 
+Most access is through a ``codes`` class instance provided in ``pydicom.sr.codedict``. This can be used
 with a ``dir()`` method on a particular scheme designator ('DCM' here) or CID (see further below)::
 
     >>> from pydicom.sr.codedict import codes
@@ -39,7 +39,7 @@ If the CID number is unknown, it is possible to find it through a CID name dicti
     >>> [name for name in cid_for_name if 'Observ' in name]
     ['ObservationSubjectClass', 'ObserverType', 'EchoFindingObservationTypes']
     >>> cid_for_name['ObserverType']
-    270   
+    270
 
 
 The following Scheme Designators are available in ``codes``:

--- a/pydicom/data/test_files/dicomdirtests/README.txt
+++ b/pydicom/data/test_files/dicomdirtests/README.txt
@@ -1,12 +1,12 @@
 In this directory are different variant of a DICOMDIR file representing the 3 patient directories.
 
-DICOMDIR: 
+DICOMDIR:
 created using dcmmkdir from DCMTK
 
-DICOMDIR-bigEnd: 
+DICOMDIR-bigEnd:
 created from DICOMDIR using dcmodify by changing the transfer syntax to Explicit Big Endian
 
-DICOMDIR-implicit: 
+DICOMDIR-implicit:
 Created from DICOMDIR using pydicom's `FileSet.write(force_implicit=True)`
 
 DICOMDIR-nooffset:

--- a/pydicom/data/test_files/dicomdirtests/tiny_alpha/README
+++ b/pydicom/data/test_files/dicomdirtests/tiny_alpha/README
@@ -46,4 +46,3 @@ if use_alphanumeric:
     fs.write("tiny_alpha")
 else:
     fs.write("tiny")
-


### PR DESCRIPTION
#### Describe the changes

Remove a few trailing spaces and empty lines.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [X] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
