### PR TITLE
[MRG] Prefer logger.warning to deprecated logger.warn

### DIFF
--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -245,7 +245,9 @@ def _DT_from_str(value: str) -> DT:
     value = value.rstrip()
     length = len(value)
     if length < 4 or length > 26:
-        logger.warning(f"Expected length between 4 and 26, got length {length}")
+        logger.warning(
+            f"Expected length between 4 and 26, got length {length}"
+        )
 
     return DT(value)
 
@@ -586,7 +588,9 @@ def _TM_from_str(value: str) -> TM:
     value = value.rstrip()
     length = len(value)
     if (length < 2 or length > 16) and length != 0:
-        logger.warning(f"Expected length between 2 and 16, got length {length}")
+        logger.warning(
+            f"Expected length between 2 and 16, got length {length}"
+        )
 
     return TM(value)
 

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -119,7 +119,7 @@ def convert_ATvalue(
 
     # length > 4
     if length % 4 != 0:
-        logger.warn(
+        logger.warning(
             "Expected length to be multiple of 4 for VR 'AT', "
             f"got length {length}"
         )
@@ -245,7 +245,7 @@ def _DT_from_str(value: str) -> DT:
     value = value.rstrip()
     length = len(value)
     if length < 4 or length > 26:
-        logger.warn(f"Expected length between 4 and 26, got length {length}")
+        logger.warning(f"Expected length between 4 and 26, got length {length}")
 
     return DT(value)
 
@@ -586,7 +586,7 @@ def _TM_from_str(value: str) -> TM:
     value = value.rstrip()
     length = len(value)
     if (length < 2 or length > 16) and length != 0:
-        logger.warn(f"Expected length between 2 and 16, got length {length}")
+        logger.warning(f"Expected length between 2 and 16, got length {length}")
 
     return TM(value)
 


### PR DESCRIPTION
Using `logger.warn` emits deprecation warnings in recent versions of Python.