### PR TITLE
[MRG] Pad odd-length OB values during write

### DIFF
--- a/doc/release_notes/index.rst
+++ b/doc/release_notes/index.rst
@@ -2,6 +2,7 @@
 Release notes
 =============
 
+.. include:: v2.3.0.rst
 .. include:: v2.2.0.rst
 .. include:: v2.1.1.rst
 .. include:: v2.1.0.rst

--- a/doc/release_notes/v2.3.0.rst
+++ b/doc/release_notes/v2.3.0.rst
@@ -1,0 +1,13 @@
+Version 2.3.0
+=================================
+
+Changes
+-------
+
+Enhancements
+------------
+
+Fixes
+-----
+
+* Fixed odd-length **OB** values not being padded during write (:issue:`1511`)

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -272,7 +272,12 @@ def write_numbers(fp: DicomIO, elem: DataElement, struct_format: str) -> None:
 
 def write_OBvalue(fp: DicomIO, elem: DataElement) -> None:
     """Write a data_element with VR of 'other byte' (OB)."""
-    fp.write(cast(bytes, elem.value))
+    if len(elem.value) % 2:
+        # Pad odd length values
+        fp.write(cast(bytes, elem.value))
+        fp.write(b'\x00')
+    else:
+        fp.write(cast(bytes, elem.value))
 
 
 def write_OWvalue(fp: DicomIO, elem: DataElement) -> None:

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -474,6 +474,20 @@ class TestWriteDataElement:
         data_elem = DataElement(0x00080060, 'CS', b'REG')
         self.check_data_element(data_elem, expected)
 
+    def test_write_OB_odd(self):
+        """Test an odd-length OB element is padded during write"""
+        value = b'\x00\x01\x02'
+        elem = DataElement(0x7FE00010, 'OB', value)
+        encoded_elem = self.encode_element(elem)
+        ref_bytes = b'\xe0\x7f\x10\x00\x04\x00\x00\x00' + value + b"\x00"
+        assert ref_bytes == encoded_elem
+
+        # Empty data
+        elem.value = b''
+        encoded_elem = self.encode_element(elem)
+        ref_bytes = b'\xe0\x7f\x10\x00\x00\x00\x00\x00'
+        assert ref_bytes == encoded_elem
+
     def test_write_OD_implicit_little(self):
         """Test writing elements with VR of OD works correctly."""
         # VolumetricCurvePoints


### PR DESCRIPTION
#### Describe the changes
Closes #1511 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
