### PR TITLE
[WIP] Allow float values to be cast into int for IS.

### DIFF
--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -143,6 +143,12 @@ Default: ``False``.
 .. versionadded:: 2.0
 """
 
+allow_IS_float = False
+"""Set to ``True`` to allow : class`~pydicom.valuerep.IS` instances to be
+created using :class:`floats<float`; otherwise, a TypeError will be raised when
+creating an IS VR value with a float.
+"""
+
 allow_DS_float = False
 """Set to ``True`` to allow :class:`~pydicom.valuerep.DSdecimal`
 instances to be created using :class:`floats<float>`; otherwise, they must be

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -758,7 +758,8 @@ class IS(int):
         # and will raise error. E.g. IS(Decimal('1')) is ok, but not IS(1.23)
         #   IS('1.23') will raise ValueError
         if isinstance(val, (float, Decimal, str)) and newval != float(val):
-            raise TypeError("Could not convert value to integer without loss")
+            if not config.allow_IS_float:
+                raise TypeError("Could not convert value to integer without loss")
 
         # Checks in case underlying int is >32 bits, DICOM does not allow this
         if not -2**31 <= newval < 2**31 and config.enforce_valid_values:


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
Allow float values to be cast to int for IS.

__Use case__: Recently ran into a dicom coming directly from a scanner that had a float falue with an IS VR.  I tried a number of workarounds, adding a `data_element_callback`, but I have other callbacks and it quickly became too complicated.  I'd like a way to simply allow this (ideally warn).

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [X] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
