### PR TITLE
Expose dataset in data_element_callback

### DIFF
--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -813,6 +813,7 @@ def DataElement_from_raw(
         raw = config.data_element_callback(
             raw_data_element,
             encoding=encoding,
+            dataset=dataset,
             **config.data_element_callback_kwargs
         )
 

--- a/pydicom/tests/test_util.py
+++ b/pydicom/tests/test_util.py
@@ -373,6 +373,17 @@ class TestDataElementCallbackTests:
         else:
             assert expected == got
 
+    def testDataElementCallback(self):
+        """Ensure data_element_callback has access to dataset."""
+        def callback(raw_elem, dataset, **_kwargs):
+            assert 'PatientName' in dataset.dir()
+            return raw_elem
+        config.data_element_callback = callback
+        ds = filereader.read_dataset(self.bytesio, is_little_endian=True,
+                                     is_implicit_VR=True)
+        assert ds.InstanceNumber is None
+        config.reset_data_element_callback()
+
 
 class TestLeanRead:
     def test_explicit_little(self):


### PR DESCRIPTION
#### Describe the changes

Revisit #1316

> Also, there was a proposal to use the dataset in the data_element_callback in DataElement_from_raw, as it is now available - what do you think?

And expose dataset.

I believe this would also give one the necessary tools to do what I was trying to in #1551 but only with callbacks.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [X] Fix or feature added
- [x] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
