### PR TITLE
[MRG] Ensure encoding is correct when using Dataset.compress()

### DIFF
--- a/doc/old/image_data_compression.rst
+++ b/doc/old/image_data_compression.rst
@@ -23,6 +23,7 @@ The requirements for compressed *Pixel Data* in the DICOM Standard are:
   of encoded data is too large for the basic offset table then the use of
   the :func:`extended offset table <pydicom.encaps.encapsulate_extended>` is
   recommended.
+* A dataset with encapsulated data must use explicit VR, little endian encoding
 
 See the :dcm:`relevant sections of the DICOM Standard<part05/sect_8.2.html>`
 for more information.
@@ -49,6 +50,12 @@ for more information.
 
     # Basic encapsulation
     ds.PixelData = encapsulate(frames)
+
+    # Set the dataset encoding
+    ds.is_little_endian = True
+    ds.is_implicit_VR = False
+
+    # Save!
     ds.save_as("CT_small_compressed_basic.dcm")
 
     # Extended encapsulation
@@ -111,6 +118,7 @@ A specific encoding plugin can be used by passing the plugin name via the
 
 .. code-block:: python
 
+    # Will set `ds.is_little_endian` an `ds.is_implicit_VR` automatically
     ds.compress(RLELossless, encoding_plugin='pylibjpeg')
     ds.save_as("CT_small_rle.dcm")
 

--- a/doc/old/image_data_compression.rst
+++ b/doc/old/image_data_compression.rst
@@ -119,7 +119,7 @@ A specific encoding plugin can be used by passing the plugin name via the
 
 .. code-block:: python
 
-    # Will set `ds.is_little_endian` an `ds.is_implicit_VR` automatically
+    # Will set `ds.is_little_endian` and `ds.is_implicit_VR` automatically
     ds.compress(RLELossless, encoding_plugin='pylibjpeg')
     ds.save_as("CT_small_rle.dcm")
 

--- a/doc/old/image_data_compression.rst
+++ b/doc/old/image_data_compression.rst
@@ -23,7 +23,8 @@ The requirements for compressed *Pixel Data* in the DICOM Standard are:
   of encoded data is too large for the basic offset table then the use of
   the :func:`extended offset table <pydicom.encaps.encapsulate_extended>` is
   recommended.
-* A dataset with encapsulated data must use explicit VR, little endian encoding
+* A dataset with encapsulated pixel data must use explicit VR little endian
+  encoding
 
 See the :dcm:`relevant sections of the DICOM Standard<part05/sect_8.2.html>`
 for more information.

--- a/doc/release_notes/v2.3.0.rst
+++ b/doc/release_notes/v2.3.0.rst
@@ -26,3 +26,5 @@ Fixes
 
 * Fixed odd-length **OB** values not being padded during write (:issue:`1511`)
 * Fixed Hologic private dictionary entry (0019xx43)
+* Fixed :meth:`~pydicom.dataset.Dataset.compress` not setting the correct
+  encoding for the rest of the dataset (:issue:`1565`)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1712,7 +1712,12 @@ class Dataset:
         else:
             self.PixelData = encapsulate(encoded)
 
+        # PS3.5 Annex A.4 - encapsulated pixel data uses undefined length
         self['PixelData'].is_undefined_length = True
+
+        # PS3.5 Annex A.4 - encapsulated datasets use explicit VR little endian
+        self.is_implicit_VR = False
+        self.is_little_endian = True
 
         # Set the correct *Transfer Syntax UID*
         if not hasattr(self, 'file_meta'):

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -1034,16 +1034,16 @@ def dcmwrite(
 
     # Ensure is_little_endian and is_implicit_VR are set
     if None in encoding:
-        if tsyntax and not tsyntax.is_private:
-            dataset.is_little_endian = tsyntax.is_little_endian
-            dataset.is_implicit_VR = tsyntax.is_implicit_VR
-
         if tsyntax is None:
             raise AttributeError(
                 f"'{cls_name}.is_little_endian' and "
                 f"'{cls_name}.is_implicit_VR' must be set appropriately "
                 "before saving"
             )
+
+        if not tsyntax.is_private:
+            dataset.is_little_endian = tsyntax.is_little_endian
+            dataset.is_implicit_VR = tsyntax.is_implicit_VR
 
     if tsyntax and not tsyntax.is_private:
         # PS3.5 Annex A.4 - the length of encapsulated pixel data is undefined

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -1030,9 +1030,10 @@ def dcmwrite(
         tsyntax = None
 
     cls_name = dataset.__class__.__name__
+    encoding = (dataset.is_implicit_VR, dataset.is_little_endian)
 
     # Ensure is_little_endian and is_implicit_VR are set
-    if None in (dataset.is_little_endian, dataset.is_implicit_VR):
+    if None in encoding:
         if tsyntax and not tsyntax.is_private:
             dataset.is_little_endian = tsyntax.is_little_endian
             dataset.is_implicit_VR = tsyntax.is_implicit_VR
@@ -1044,7 +1045,7 @@ def dcmwrite(
                 "before saving"
             )
 
-    encoding = (dataset.is_implicit_VR, dataset.is_little_endian)
+
     if tsyntax and not tsyntax.is_private:
         # PS3.5 Annex A.4 - the length of encapsulated pixel data is undefined
         #   and native pixel data uses actual length

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -1024,33 +1024,41 @@ def dcmwrite(
         ``save_as()`` wraps ``dcmwrite()``.
     """
     tsyntax: Optional[UID]
+    try:
+        tsyntax = dataset.file_meta.TransferSyntaxUID
+    except AttributeError:
+        tsyntax = None
+
+    cls_name = dataset.__class__.__name__
 
     # Ensure is_little_endian and is_implicit_VR are set
     if None in (dataset.is_little_endian, dataset.is_implicit_VR):
-        has_tsyntax = False
-        try:
-            tsyntax = dataset.file_meta.TransferSyntaxUID
-            if not tsyntax.is_private:
-                dataset.is_little_endian = tsyntax.is_little_endian
-                dataset.is_implicit_VR = tsyntax.is_implicit_VR
-                has_tsyntax = True
-        except AttributeError:
-            pass
+        if tsyntax and not tsyntax.is_private:
+            dataset.is_little_endian = tsyntax.is_little_endian
+            dataset.is_implicit_VR = tsyntax.is_implicit_VR
 
-        if not has_tsyntax:
-            name = dataset.__class__.__name__
+        if tsyntax is None:
             raise AttributeError(
-                f"'{name}.is_little_endian' and '{name}.is_implicit_VR' must "
-                f"be set appropriately before saving"
+                f"'{cls_name}.is_little_endian' and "
+                f"'{cls_name}.is_implicit_VR' must be set appropriately "
+                "before saving"
             )
 
-    # Try and ensure that `is_undefined_length` is set correctly
-    try:
-        tsyntax = dataset.file_meta.TransferSyntaxUID
-        if not tsyntax.is_private:
+    encoding = (dataset.is_implicit_VR, dataset.is_little_endian)
+    if tsyntax and not tsyntax.is_private:
+        # PS3.5 Annex A.4 - the length of encapsulated pixel data is undefined
+        #   and native pixel data uses actual length
+        if "PixelData" in dataset:
             dataset['PixelData'].is_undefined_length = tsyntax.is_compressed
-    except (AttributeError, KeyError):
-        pass
+
+        # PS3.5 Annex A.4 - encapsulated datasets use Explicit VR Little
+        if tsyntax.is_compressed and encoding != (False, True):
+            warnings.warn(
+                "All encapsulated (compressed) transfer syntaxes must use "
+                "explicit VR little endian encoding for the dataset. Set "
+                f"'{cls_name}.is_little_endian = True' and '{cls_name}."
+                "is_implicit_VR = False' before saving"
+            )
 
     # Check that dataset's group 0x0002 elements are only present in the
     #   `dataset.file_meta` Dataset - user may have added them to the wrong

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -1045,7 +1045,6 @@ def dcmwrite(
                 "before saving"
             )
 
-
     if tsyntax and not tsyntax.is_private:
         # PS3.5 Annex A.4 - the length of encapsulated pixel data is undefined
         #   and native pixel data uses actual length

--- a/pydicom/tests/test_encoders.py
+++ b/pydicom/tests/test_encoders.py
@@ -1023,6 +1023,8 @@ class TestDatasetCompress:
         assert len(ds.PixelData) == 21370
         assert 'PlanarConfiguration' not in ds
         assert ds['PixelData'].is_undefined_length
+        assert not ds.is_implicit_VR
+        assert ds.is_little_endian
 
     @pytest.mark.skipif(not HAVE_NP, reason="Numpy is unavailable")
     def test_compress_arr(self):
@@ -1030,11 +1032,16 @@ class TestDatasetCompress:
         ds = get_testdata_file("CT_small.dcm", read=True)
         assert hasattr(ds, 'file_meta')
         arr = ds.pixel_array
+        ds.is_implicit_VR = True
+        assert ds.is_little_endian
         del ds.PixelData
         del ds.file_meta
+
         ds.compress(RLELossless, arr, encoding_plugin='pydicom')
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert len(ds.PixelData) == 21370
+        assert not ds.is_implicit_VR
+        assert ds.is_little_endian
 
     @pytest.mark.skipif(HAVE_NP, reason="Numpy is available")
     def test_encoder_unavailable(self, monkeypatch):


### PR DESCRIPTION
#### Describe the changes
* Closes #1565 
* Ensures dataset is encoded explicit VR little endian when using `Dataset.compress()`
* Adds a warning to `dcmwrite()` when the wrong encoding is used for encapsulated datasets

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] [Documentation](https://3191-14006067-gh.circle-artifacts.com/0/doc/_build/html/index.html) updated (if relevant) 
- [x] Unit tests passing and overall coverage the same or better
