### PR TITLE
[MRG] Improvements for bit packing and unpacking

### DIFF
--- a/pydicom/benchmarks/bench_handler_numpy.py
+++ b/pydicom/benchmarks/bench_handler_numpy.py
@@ -12,7 +12,9 @@ import numpy as np
 from pydicom import dcmread
 from pydicom.data import get_testdata_file
 from pydicom.dataset import Dataset, FileMetaDataset
-from pydicom.pixel_data_handlers.numpy_handler import get_pixeldata
+from pydicom.pixel_data_handlers.numpy_handler import (
+    get_pixeldata, unpack_bits, pack_bits
+)
 from pydicom.uid import ExplicitVRLittleEndian, generate_uid
 
 # 1/1, 1 sample/pixel, 1 frame
@@ -212,3 +214,21 @@ class TimeGetPixelData:
         """Time retrieval of YBR_FULL_422 data."""
         for ii in range(self.no_runs):
             get_pixeldata(self.ds_ybr_422)
+
+
+class TimePackUnpack:
+    def setup(self):
+        """Setup the tests."""
+        self.no_runs = 100
+        self.ds_1_1_1 = dcmread(EXPL_1_1_1F)
+        self.unpacked = unpack_bits(self.ds_1_1_1.PixelData)
+
+    def time_unpack(self):
+        """Time unpacking"""
+        for ii in range(self.no_runs):
+            unpack_bits(self.ds_1_1_1.PixelData)
+
+    def time_pack(self):
+        """Time packing."""
+        for ii in range(self.no_runs):
+            pack_bits(self.unpacked)

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -173,8 +173,7 @@ def pack_bits(arr: "np.ndarray", pad: bool = True) -> bytes:
     if arr.shape[0] % 8:
         arr = np.append(arr, np.zeros(8 - arr.shape[0] % 8))
 
-    # Reshape so each row is 8 bits
-    arr = np.packbits(arr.astype('uint8'), bitorder="little")
+    arr = np.packbits(arr.astype('u1'), bitorder="little")
 
     packed: bytes = arr.tobytes()
     if pad:
@@ -207,7 +206,6 @@ def unpack_bits(bytestream: bytes) -> "np.ndarray":
     :dcm:`Annex D<part05/chapter_D.html>`
     """
     arr = np.frombuffer(bytestream, dtype='u1')
-
     return cast("np.ndarray", np.unpackbits(arr, bitorder="little"))
 
 
@@ -367,6 +365,6 @@ def get_pixeldata(ds: "Dataset", read_only: bool = False) -> "np.ndarray":
         ds.PhotometricInterpretation = "RGB"
 
     if not read_only and ds.BitsAllocated > 1:
-        return cast("np.ndarray", arr.copy())
+        return arr.copy()
 
-    return cast("np.ndarray", arr)
+    return arr

--- a/pydicom/pixel_data_handlers/numpy_handler.py
+++ b/pydicom/pixel_data_handlers/numpy_handler.py
@@ -174,9 +174,7 @@ def pack_bits(arr: "np.ndarray", pad: bool = True) -> bytes:
         arr = np.append(arr, np.zeros(8 - arr.shape[0] % 8))
 
     # Reshape so each row is 8 bits
-    arr = np.reshape(arr, (-1, 8))
-    arr = np.fliplr(arr)
-    arr = np.packbits(arr.astype('uint8'))
+    arr = np.packbits(arr.astype('uint8'), bitorder="little")
 
     packed: bytes = arr.tobytes()
     if pad:
@@ -208,21 +206,9 @@ def unpack_bits(bytestream: bytes) -> "np.ndarray":
     :dcm:`Section 8.1.1<part05/chapter_8.html#sect_8.1.1>` and
     :dcm:`Annex D<part05/chapter_D.html>`
     """
-    # Thanks to @sbrodehl (#643)
-    # e.g. b'\xC0\x09' -> [192, 9]
-    arr = np.frombuffer(bytestream, dtype='uint8')
-    # -> [1 1 0 0 0 0 0 0 0 0 0 0 1 0 0 1]
-    arr = np.unpackbits(arr)
-    # -> [[1 1 0 0 0 0 0 0],
-    #     [0 0 0 0 1 0 0 1]]
-    arr = np.reshape(arr, (-1, 8))
-    # -> [[0 0 0 0 0 0 1 1],
-    #     [1 0 0 1 0 0 0 0]]
-    arr = np.fliplr(arr)
-    # -> [0 0 0 0 0 0 1 1 1 0 0 1 0 0 0 0]
-    arr = np.ravel(arr)
+    arr = np.frombuffer(bytestream, dtype='u1')
 
-    return cast("np.ndarray", arr)
+    return cast("np.ndarray", np.unpackbits(arr, bitorder="little"))
 
 
 def get_pixeldata(ds: "Dataset", read_only: bool = False) -> "np.ndarray":


### PR DESCRIPTION
#### Describe the changes
* Improve efficiency of bit packing and unpacking
* `unpack_bits()` (time per 100 runs): 55.0 ms -> 6.0 ms
* `pack_bits()` (time per 100 runs): 63.6 ms -> 22.0 ms

#### Tasks
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
