### PR TITLE
[MRG] Fix AttributeError on deep copy of FileDataset

### DIFF
--- a/doc/release_notes/v2.3.0.rst
+++ b/doc/release_notes/v2.3.0.rst
@@ -23,8 +23,9 @@ Enhancements
 
 Fixes
 -----
-
 * Fixed odd-length **OB** values not being padded during write (:issue:`1511`)
 * Fixed Hologic private dictionary entry (0019xx43)
 * Fixed :meth:`~pydicom.dataset.Dataset.compress` not setting the correct
   encoding for the rest of the dataset (:issue:`1565`)
+* Fixed `AttributeError` on deep copy of :class:`~pydicom.dataset.FileDataset`
+  (:issue:`1571`)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -33,6 +33,8 @@ from typing import (
 import warnings
 import weakref
 
+from pydicom.filebase import DicomFileLike
+
 try:
     import numpy
 except ImportError:
@@ -48,7 +50,7 @@ from pydicom.datadict import (
 )
 from pydicom.dataelem import DataElement, DataElement_from_raw, RawDataElement
 from pydicom.encaps import encapsulate, encapsulate_extended
-from pydicom.fileutil import path_from_pathlike
+from pydicom.fileutil import path_from_pathlike, PathType
 from pydicom.pixel_data_handlers.util import (
     convert_color_space, reshape_pixel_array, get_image_pixel_ids
 )
@@ -2616,7 +2618,7 @@ class FileDataset(Dataset):
 
     def __init__(
         self,
-        filename_or_obj: Union[str, os.PathLike, BinaryIO],
+        filename_or_obj: Union[PathType, BinaryIO, DicomFileLike],
         dataset: _DatasetType,
         preamble: Optional[bytes] = None,
         file_meta: Optional["FileMetaDataset"] = None,
@@ -2657,8 +2659,8 @@ class FileDataset(Dataset):
 
         filename: Optional[str] = None
         filename_or_obj = path_from_pathlike(filename_or_obj)
-        self.fileobj_type: Any
-        self.filename: Union[str, BinaryIO]
+        self.fileobj_type: Any = None
+        self.filename: Union[PathType, BinaryIO] = ""
 
         if isinstance(filename_or_obj, str):
             filename = filename_or_obj

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1925,6 +1925,15 @@ class TestFileDataset:
         ds.preamble = None
         assert ds == ds2
 
+    def test_deepcopy_without_filename(self):
+        """Regression test for #1571."""
+        file_meta = FileMetaDataset()
+        ds = FileDataset(filename_or_obj="", dataset={}, file_meta=file_meta,
+                         preamble=b"\0" * 128)
+
+        ds2 = copy.deepcopy(ds)
+        assert ds2.filename == ""
+
 
 class TestDatasetOverlayArray:
     """Tests for Dataset.overlay_array()."""


### PR DESCRIPTION
- always set filename and fileobj_type instance vars
- fixes #1571

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
