### PR TITLE
[WIP] Fix DICOMDIR offset calculation with undefined length items

### DIFF
--- a/doc/release_notes/v2.3.0.rst
+++ b/doc/release_notes/v2.3.0.rst
@@ -41,3 +41,6 @@ Fixes
   (:issue:`1581`)
 * Fixed crashes on Windows and MacOS when using the GDCM plugin to compress
   into *RLE Lossless* (:issue:`1581`)
+* Fixed bad DICOMDIR offsets when using :meth:`FileSet.write()
+  <pydicom.fileset.FileSet.write>` with a *Directory Record Sequence* using
+  undefined length items (:issue:`1596`)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -393,6 +393,9 @@ class Dataset:
         self.is_little_endian: Optional[bool] = None
         self.is_implicit_VR: Optional[bool] = None
 
+        # True if the dataset is a sequence item with undefined length
+        self.is_undefined_length_sequence_item = False
+
         # the parent data set, if this dataset is a sequence item
         self.parent: "Optional[weakref.ReferenceType[Dataset]]" = None
 

--- a/pydicom/fileset.py
+++ b/pydicom/fileset.py
@@ -1717,6 +1717,7 @@ class FileSet:
                     f"{cast(Path, self.path) / file_id}"
                 )
                 continue
+
             # If the instance's existing directory structure doesn't match
             #   the pydicom semantics then stage for movement
             if instance.for_moving:
@@ -2255,6 +2256,10 @@ class FileSet:
             offset += 8  # a sequence item's (tag + length)
             # Copy safe - only modifies RecordNode._offset
             offset += node._encode_record(force_implicit)
+            # If the sequence item has undefined length then it uses a
+            #   sequence item delimiter item
+            if node._record.is_undefined_length_sequence_item:
+                offset += 8
 
         # Step 2: Update the records and add to *Directory Record Sequence*
         ds.DirectoryRecordSequence = []

--- a/pydicom/tests/test_fileset.py
+++ b/pydicom/tests/test_fileset.py
@@ -2450,6 +2450,21 @@ class TestFileSet_Modify:
         with pytest.raises(ValueError, match=msg):
             fs.add(ds)
 
+    def test_write_undefined_length(self, dicomdir_copy):
+        """Test writing with undefined length items"""
+        t, ds = dicomdir_copy
+        elem = ds["DirectoryRecordSequence"]
+        ds["DirectoryRecordSequence"].is_undefined_length = True
+        for item in ds.DirectoryRecordSequence:
+            item.is_undefined_length_sequence_item = True
+
+        fs = FileSet(ds)
+        fs.write(use_existing=True)
+
+        ds = dcmread(Path(t.name) / "DICOMDIR")
+        item = ds.DirectoryRecordSequence[-1]
+        assert item.ReferencedFileID == ['98892003', 'MR700', '4648']
+
 
 @pytest.mark.filterwarnings("ignore:The 'DicomDir'")
 class TestFileSet_Copy:


### PR DESCRIPTION
#### Describe the changes
* Closes #1596 
* Fix DICOMDIR offset calculation when undefined length sequence items are used
* Add `Dataset.is_undefined_length_sequence_item` (previously dynamically assigned during read)

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
