### PR TITLE
[MRG] Handle adding a list with one value

### DIFF
--- a/doc/release_notes/v2.3.0.rst
+++ b/doc/release_notes/v2.3.0.rst
@@ -47,3 +47,6 @@ Fixes
 * Fixed bad DICOMDIR offsets when using :meth:`FileSet.write()
   <pydicom.fileset.FileSet.write>` with a *Directory Record Sequence* using
   undefined length items (:issue:`1596`)
+* Assigning a list of length one as tag value is now correctly handled as
+  assigning the single value (:issue:`1606`)
+

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -512,9 +512,10 @@ class DataElement:
             val.append
         except AttributeError:  # not a list
             return self._convert(val)
-        else:
-            return MultiValue(self._convert, val,
-                              validation_mode=self.validation_mode)
+        if len(val) == 1:
+            return self._convert(val[0])
+        return MultiValue(self._convert, val,
+                          validation_mode=self.validation_mode)
 
     def _convert(self, val: Any) -> Any:
         """Convert `val` to an appropriate type for the element's VR."""

--- a/pydicom/tests/test_json.py
+++ b/pydicom/tests/test_json.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2008-2019 pydicom authors. See LICENSE file for details.
 import json
+from unittest import mock
 
 import pytest
 
@@ -271,13 +272,14 @@ class TestDataSetToJson:
         assert ds_json.index('"00100020"') < ds_json.index('"00100030"')
         assert ds_json.index('"00100030"') < ds_json.index('"00100040"')
 
-    def test_suppress_invalid_tags(self):
+    @mock.patch("pydicom.DataElement.to_json_dict", side_effect=ValueError)
+    def test_suppress_invalid_tags(self, _):
         """Test tags that raise exceptions don't if suppress_invalid_tags True.
         """
         ds = Dataset()
-        ds.add_new(0x00100010, 'PN', ['Jane^Doe'])
+        ds.add_new(0x00100010, 'PN', 'Jane^Doe')
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             ds.to_json_dict()
 
         ds_json = ds.to_json_dict(suppress_invalid_tags=True)

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -1540,20 +1540,27 @@ def test_set_value(vr, pytype, vm0, vmN, keyword, disable_value_validation):
         assert value == elem.value
 
     # Test VM = 1
-    ds = Dataset()
-    value = vmN[0]
-    if vr == 'SQ':
-        setattr(ds, keyword, [value])
-        elem = ds[keyword]
-        assert elem.value[0] == value
-        assert value == elem.value[0]
-    else:
+    if vr != 'SQ':
+        ds = Dataset()
+        value = vmN[0]
         setattr(ds, keyword, value)
         elem = ds[keyword]
         assert elem.value == value
         assert value == elem.value
 
-    if vr[0] == 'O':
+    # Test VM = 1 as list
+    ds = Dataset()
+    value = vmN[0]
+    setattr(ds, keyword, [value])
+    elem = ds[keyword]
+    if vr == 'SQ':
+        assert elem.value[0] == value
+        assert value == elem.value[0]
+    else:
+        assert elem.value == value
+        assert value == elem.value
+
+    if vr[0] == 'O' or vr == 'UN':
         return
 
     # Test VM > 1


### PR DESCRIPTION
- is now handled like adding the single value in the list
- fixes #1606

#### Describe the changes
Only handles the case of a list with a single value. I'm unsure if we also have to handle assigning an empty list, but as this seems to make no problems, and may potentially change the behavior, I left it out.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
