### PR TITLE
[MRG] allow multiple deferred reads with file-like objects

### DIFF
--- a/doc/release_notes/v2.3.0.rst
+++ b/doc/release_notes/v2.3.0.rst
@@ -49,4 +49,6 @@ Fixes
   undefined length items (:issue:`1596`)
 * Assigning a list of length one as tag value is now correctly handled as
   assigning the single value (:issue:`1606`)
+* Fixed an exception with multiple deferred reads with file-like objects
+  (:issue:`1609`)
 

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -1190,7 +1190,8 @@ def read_deferred_data_element(
     # The first element out of the iterator should be the same type as the
     #   the deferred element == RawDataElement
     elem = cast(RawDataElement, next(elem_gen))
-    fp.close()
+    if is_filename:
+        fp.close()
     if elem.VR != raw_data_elem.VR:
         raise ValueError(
             f"Deferred read VR {elem.VR} does not match original "

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -1522,6 +1522,10 @@ class TestDeferredRead:
         filelike = io.BytesIO(data)
         dataset = pydicom.dcmread(filelike, defer_size=1024)
         assert 32768 == len(dataset.PixelData)
+        # The 'Histogram tables' private data element is also > 1024 bytes so
+        # pluck this out to confirm multiple deferred reads work (#1609).
+        private_block = dataset.private_block(0x43, 'GEMS_PARM_01')
+        assert 2068 == len(private_block[0x29].value)
 
 
 class TestReadTruncatedFile:


### PR DESCRIPTION
#### Describe the changes

Allow multiple deferred reads with file-like objects by ensuring that any file-like object is not unnecessarily closed. 
Closes #1609

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
