### PR TITLE
[MRG] Better type hinting for UID in doc and uid.py

### DIFF
--- a/examples/input_output/plot_write_dicom.py
+++ b/examples/input_output/plot_write_dicom.py
@@ -12,12 +12,13 @@ have to change UIDs to valid values and add all required DICOM data elements.
 # authors : Guillaume Lemaitre <g.lemaitre58@gmail.com>
 # license : MIT
 
+import datetime
 import os
 import tempfile
-import datetime
 
 import pydicom
 from pydicom.dataset import FileDataset, FileMetaDataset
+from pydicom.uid import UID
 
 # Create some temporary filenames
 suffix = '.dcm'
@@ -27,9 +28,9 @@ filename_big_endian = tempfile.NamedTemporaryFile(suffix=suffix).name
 print("Setting file meta information...")
 # Populate required values for file meta information
 file_meta = FileMetaDataset()
-file_meta.MediaStorageSOPClassUID = '1.2.840.10008.5.1.4.1.1.2'
-file_meta.MediaStorageSOPInstanceUID = "1.2.3"
-file_meta.ImplementationClassUID = "1.2.3.4"
+file_meta.MediaStorageSOPClassUID = UID('1.2.840.10008.5.1.4.1.1.2')
+file_meta.MediaStorageSOPInstanceUID = UID("1.2.3")
+file_meta.ImplementationClassUID = UID("1.2.3.4")
 
 print("Setting dataset values...")
 # Create the FileDataset instance (initially no data elements, but file_meta

--- a/pydicom/uid.py
+++ b/pydicom/uid.py
@@ -1,19 +1,19 @@
 # Copyright 2008-2022 pydicom authors. See LICENSE file for details.
 """Functions for handling DICOM unique identifiers (UIDs)"""
 
-import os
-import uuid
-import random
 import hashlib
+import os
+import random
 import re
 import sys
-from typing import List, Optional, TypeVar, Type, Union, Any
+import uuid
 import warnings
+from typing import Any, List, Optional, Type, TypeVar, Union
 
 from pydicom import config
 from pydicom._uid_dict import UID_dictionary
 from pydicom.config import disable_value_validation
-from pydicom.valuerep import validate_value, STR_VR_REGEXES
+from pydicom.valuerep import STR_VR_REGEXES, validate_value
 
 _deprecations = {
     "JPEGBaseline": "JPEGBaseline8Bit",
@@ -45,23 +45,6 @@ def __getattr__(name: str) -> Any:
 
     raise AttributeError(f"module {__name__} has no attribute {name}")
 
-
-# Many thanks to the Medical Connections for offering free
-# valid UIDs (http://www.medicalconnections.co.uk/FreeUID.html)
-# Their service was used to obtain the following root UID for pydicom:
-PYDICOM_ROOT_UID = "1.2.826.0.1.3680043.8.498."
-"""pydicom's root UID ``'1.2.826.0.1.3680043.8.498.'``"""
-PYDICOM_IMPLEMENTATION_UID = PYDICOM_ROOT_UID + "1"
-"""
-pydicom's (0002,0012) *Implementation Class UID*
-``'1.2.826.0.1.3680043.8.498.1'``
-"""
-
-# Regexes for valid UIDs and valid UID prefixes
-RE_VALID_UID = STR_VR_REGEXES["UI"]
-"""Regex for a valid UID"""
-RE_VALID_UID_PREFIX = re.compile(r"^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*\.$")
-"""Regex for a valid UID prefix"""
 
 
 class UID(str):
@@ -249,6 +232,23 @@ class UID(str):
             return True
 
         return False
+
+# Many thanks to the Medical Connections for offering free
+# valid UIDs (http://www.medicalconnections.co.uk/FreeUID.html)
+# Their service was used to obtain the following root UID for pydicom:
+PYDICOM_ROOT_UID = "1.2.826.0.1.3680043.8.498."
+"""pydicom's root UID ``'1.2.826.0.1.3680043.8.498.'``"""
+PYDICOM_IMPLEMENTATION_UID = UID(f'{PYDICOM_ROOT_UID}1')
+"""
+pydicom's (0002,0012) *Implementation Class UID*
+``'1.2.826.0.1.3680043.8.498.1'``
+"""
+
+# Regexes for valid UIDs and valid UID prefixes
+RE_VALID_UID = STR_VR_REGEXES["UI"]
+"""Regex for a valid UID"""
+RE_VALID_UID_PREFIX = re.compile(r"^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*\.$")
+"""Regex for a valid UID prefix"""
 
 
 with disable_value_validation():

--- a/pydicom/uid.py
+++ b/pydicom/uid.py
@@ -233,6 +233,7 @@ class UID(str):
 
         return False
 
+
 # Many thanks to the Medical Connections for offering free
 # valid UIDs (http://www.medicalconnections.co.uk/FreeUID.html)
 # Their service was used to obtain the following root UID for pydicom:


### PR DESCRIPTION
in doc : use class UID instead of direct str to assign a UID
in uid.py : use class UID instead of str for PYDICOM_IMPLEMENTATION_UID (and move the code block after class UID definition so that it can use this class)

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better

Note : this seemed to me a very minor change that did not need specific testing.