### PR TITLE
[MRG] add infer_sq_for_un_vr config option

### DIFF
--- a/doc/release_notes/v2.3.0.rst
+++ b/doc/release_notes/v2.3.0.rst
@@ -28,7 +28,9 @@ Enhancements
   :func:`~pydicom.pixel_data_handlers.utils.unpack_bits`(:pr:`1594`)
 * Added :func:`~pydicom.pixel_data_handlers.util.expand_ybr422` for expanding
   uncompressed ``YBR_FULL_422`` data to ``YBR_FULL`` (:pr:`1593`)
-
+* Replacement of ``UN`` VR with ``SQ`` VR for undefined length data elements
+  (introduced in 2.2.2), can now be configured via
+  :attr:`~pydicom.config.settings.infer_sq_for_un_vr`
 
 Fixes
 -----

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -301,6 +301,15 @@ displaying the file meta information data elements
 .. versionadded:: 2.0
 """
 
+infer_sq_for_un_vr = True
+"""
+If ``True``, and the VR of a known data element is encoded as **UN** in
+an explicit encoding, the VR is changed to SQ per PS 3.5, section 6.2.2
+Can be set to ``False`` where the content of the tag shown as **UN** is
+not DICOM conformant and would lead to a failure if accessing it.
+.. versionadded:: 2.3
+"""
+
 # Logging system and debug function to change logging level
 logger = logging.getLogger("pydicom")
 logger.addHandler(logging.NullHandler())

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -229,7 +229,7 @@ class Settings:
         self._writing_validation_mode = value
 
     @property
-    def infer_sq_for_un_vr(self) -> int:
+    def infer_sq_for_un_vr(self) -> bool:
         """If ``True``, and the VR of a known data element is encoded as
         **UN** in an explicit encoding for an undefined length data element,
         the VR is changed to SQ per PS 3.5, section 6.2.2. Can be set to

--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -194,6 +194,7 @@ class Settings:
         self._writing_validation_mode: Optional[int] = (
             RAISE if _use_future else None
         )
+        self._infer_sq_for_un_vr: bool = True
 
     @property
     def reading_validation_mode(self) -> int:
@@ -226,6 +227,20 @@ class Settings:
     @writing_validation_mode.setter
     def writing_validation_mode(self, value: int) -> None:
         self._writing_validation_mode = value
+
+    @property
+    def infer_sq_for_un_vr(self) -> int:
+        """If ``True``, and the VR of a known data element is encoded as
+        **UN** in an explicit encoding for an undefined length data element,
+        the VR is changed to SQ per PS 3.5, section 6.2.2. Can be set to
+        ``False`` where the content of the tag shown as **UN** is not DICOM
+        conformant and would lead to a failure if accessing it.
+        """
+        return self._infer_sq_for_un_vr
+
+    @infer_sq_for_un_vr.setter
+    def infer_sq_for_un_vr(self, value: bool) -> None:
+        self._infer_sq_for_un_vr = value
 
 
 settings = Settings()
@@ -299,15 +314,6 @@ of :class:`~pydicom.dataset.Dataset` begin with a separate section
 displaying the file meta information data elements
 
 .. versionadded:: 2.0
-"""
-
-infer_sq_for_un_vr = True
-"""
-If ``True``, and the VR of a known data element is encoded as **UN** in
-an explicit encoding, the VR is changed to SQ per PS 3.5, section 6.2.2
-Can be set to ``False`` where the content of the tag shown as **UN** is
-not DICOM conformant and would lead to a failure if accessing it.
-.. versionadded:: 2.3
 """
 
 # Logging system and debug function to change logging level

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -236,7 +236,7 @@ def data_element_generator(
         else:
             # VR UN with undefined length shall be handled as SQ
             # see PS 3.5, section 6.2.2
-            if vr == VR_.UN:
+            if vr == VR_.UN and config.infer_sq_for_un_vr:
                 vr = VR_.SQ
             # Try to look up type to see if is a SQ
             # if private tag, won't be able to look it up in dictionary,

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -236,7 +236,7 @@ def data_element_generator(
         else:
             # VR UN with undefined length shall be handled as SQ
             # see PS 3.5, section 6.2.2
-            if vr == VR_.UN and config.infer_sq_for_un_vr:
+            if vr == VR_.UN and config.settings.infer_sq_for_un_vr:
                 vr = VR_.SQ
             # Try to look up type to see if is a SQ
             # if private tag, won't be able to look it up in dictionary,

--- a/pydicom/sr/coding.py
+++ b/pydicom/sr/coding.py
@@ -61,4 +61,4 @@ class Code(NamedTuple):
         return not (self == other)
 
 
-Code.__new__.__defaults__ = (None,)  # type: ignore[attr-defined]
+Code.__new__.__defaults__ = (None,)

--- a/pydicom/tests/conftest.py
+++ b/pydicom/tests/conftest.py
@@ -66,6 +66,14 @@ def dont_replace_un_with_known_vr():
 
 
 @pytest.fixture
+def dont_replace_un_with_sq_vr():
+    old_value = config.infer_sq_for_un_vr
+    config.infer_sq_for_un_vr = False
+    yield
+    config.infer_sq_for_un_vr = old_value
+
+
+@pytest.fixture
 def dont_raise_on_writing_invalid_value():
     old_value = config.settings.writing_validation_mode
     config.settings.writing_validation_mode = config.WARN

--- a/pydicom/tests/conftest.py
+++ b/pydicom/tests/conftest.py
@@ -67,10 +67,10 @@ def dont_replace_un_with_known_vr():
 
 @pytest.fixture
 def dont_replace_un_with_sq_vr():
-    old_value = config.infer_sq_for_un_vr
-    config.infer_sq_for_un_vr = False
+    old_value = config.settings.infer_sq_for_un_vr
+    config.settings.infer_sq_for_un_vr = False
     yield
-    config.infer_sq_for_un_vr = old_value
+    config.settings.infer_sq_for_un_vr = old_value
 
 
 @pytest.fixture

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -460,6 +460,15 @@ class TestReader:
         assert len(seq_element.value) == 1
         assert len(seq_element.value[0].ReferencedSeriesSequence) == 1
 
+    def test_un_sequence_dont_infer(
+            self,
+            dont_replace_un_with_sq_vr,
+            dont_replace_un_with_known_vr
+    ):
+        ds = dcmread(get_testdata_file("UN_sequence.dcm"))
+        seq_element = ds[0x4453100c]
+        assert seq_element.VR == "UN"
+
     def test_no_meta_group_length(self, no_datetime_conversion):
         """Read file with no group length in file meta."""
         # Issue 108 -- iView example file with no group length (0002,0002)


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
 2.2.2 introduced a breaking change for where an IOError is raised for some files that contain spurious bytes with no sequence terminator (because they're not actually sequences). Since the error is raised in the data_element_generator, there is no way to circumvent this issue via fixers. Further the 2.2.2 logic change does not respect the `replace_un_with_known_vr` configuration parameter because it is now always set to SQ.  

This merge request introduces the `infer_sq_for_un_vr` which, when set to False, allows parsing of non-compliant DICOMs with data that would otherwise fail to parse as of 2.2.2.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
