### PR TITLE
[MRG] Improve post-read robustness for non-conformant datasets

### DIFF
--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -865,8 +865,6 @@ def read_partial(
     # Add the command set elements to the dataset (if any)
     dataset.update(command_set)
 
-    #ds_class: Union[FileDataset, DicomDir]
-
     # (0002, 0002) Media Storage SOP Class UID
     elem = file_meta.get(0x00020002, None)
     sop_class = elem.value.name if (elem and elem.VM == 1) else ""

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -9,7 +9,7 @@ from struct import (Struct, unpack)
 import sys
 from typing import (
     BinaryIO, Union, Optional, List, Any, Callable, cast, MutableSequence,
-    Iterator, Dict
+    Iterator, Dict, Type
 )
 import warnings
 import zlib
@@ -777,7 +777,7 @@ def read_partial(
     # Read preamble (if present)
     preamble = read_preamble(fileobj, force)
     # Read any File Meta Information group (0002,eeee) elements (if present)
-    file_meta_dataset = _read_file_meta_info(fileobj)
+    file_meta = _read_file_meta_info(fileobj)
 
     # Read Dataset
 
@@ -795,7 +795,7 @@ def read_partial(
     # transfer syntax of implicit VR little endian and correct it as necessary
     is_implicit_VR = True
     is_little_endian = True
-    transfer_syntax = file_meta_dataset.get("TransferSyntaxUID")
+    transfer_syntax = file_meta.get("TransferSyntaxUID")
     if peek == b'':  # EOF
         pass
     elif transfer_syntax is None:  # issue 258
@@ -865,34 +865,30 @@ def read_partial(
     # Add the command set elements to the dataset (if any)
     dataset.update(command_set)
 
-    class_uid = cast(
-        pydicom.uid.UID, file_meta_dataset.get("MediaStorageSOPClassUID", None)
-    )
-    ds: Union[DicomDir, FileDataset]
-    if class_uid and class_uid.name == "Media Storage Directory Storage":
+    #ds_class: Union[FileDataset, DicomDir]
+
+    # (0002, 0002) Media Storage SOP Class UID
+    elem = file_meta.get(0x00020002, None)
+    sop_class = elem.value.name if (elem and elem.VM == 1) else ""
+    if sop_class == "Media Storage Directory Storage":
         warnings.warn(
             "The 'DicomDir' class is deprecated and will be removed in v3.0, "
             "after which 'dcmread()' will return a normal 'FileDataset' "
             "instance for 'Media Storage Directory' SOP Instances.",
             DeprecationWarning
         )
-        ds = DicomDir(
-            fileobj,
-            dataset,
-            preamble,
-            file_meta_dataset,
-            is_implicit_VR,
-            is_little_endian,
-        )
+        ds_class: Union[Type[FileDataset], Type[DicomDir]] = DicomDir
     else:
-        ds = FileDataset(
-            fileobj,
-            dataset,
-            preamble,
-            file_meta_dataset,
-            is_implicit_VR,
-            is_little_endian,
-        )
+        ds_class = FileDataset
+
+    ds = ds_class(
+        fileobj,
+        dataset,
+        preamble,
+        file_meta,
+        is_implicit_VR,
+        is_little_endian,
+    )
     # save the originally read transfer syntax properties in the dataset
     ds.set_original_encoding(
         is_implicit_VR, is_little_endian, dataset._character_set

--- a/pydicom/sr/coding.py
+++ b/pydicom/sr/coding.py
@@ -61,4 +61,4 @@ class Code(NamedTuple):
         return not (self == other)
 
 
-Code.__new__.__defaults__ = (None,)  # type: ignore[attr-defined]
+Code.__new__.__defaults__ = (None,)


### PR DESCRIPTION
#### Describe the changes
I had a non-conformant dataset with multi-valued Media Storage SOP Class UID value but was otherwise perfectly parseable. 

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
