### PR TITLE
[MRG] Do not use pytest.warns(None)

### DIFF
--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -9,6 +9,7 @@ import sys
 import weakref
 
 import pytest
+from pydicom.tests.test_helpers import assert_no_warning
 
 try:
     import numpy
@@ -247,9 +248,8 @@ class TestDataset:
 
     def test_contains_ignore(self, contains_ignore):
         """Test ignoring invalid keys."""
-        with pytest.warns(None) as record:
+        with assert_no_warning():
             assert 'invalid' not in self.ds
-            assert len(record) == 0
 
     def test_clear(self):
         assert 1 == len(self.ds)
@@ -2210,15 +2210,13 @@ def setattr_warn():
 
 def test_setattr_warns(setattr_warn):
     """"Test warnings for Dataset.__setattr__() for close matches."""
-    with pytest.warns(None) as record:
+    with assert_no_warning():
         ds = Dataset()
-        assert len(record) == 0
 
     for s in CAMEL_CASE[0]:
-        with pytest.warns(None) as record:
+        with assert_no_warning():
             val = getattr(ds, s, None)
             setattr(ds, s, val)
-            assert len(record) == 0
 
     for s in CAMEL_CASE[1]:
         msg = (
@@ -2232,15 +2230,13 @@ def test_setattr_warns(setattr_warn):
 
 def test_setattr_raises(setattr_raise):
     """"Test exceptions for Dataset.__setattr__() for close matches."""
-    with pytest.warns(None) as record:
+    with assert_no_warning():
         ds = Dataset()
-        assert len(record) == 0
 
     for s in CAMEL_CASE[0]:
-        with pytest.warns(None) as record:
+        with assert_no_warning():
             val = getattr(ds, s, None)
             setattr(ds, s, val)
-            assert len(record) == 0
 
     for s in CAMEL_CASE[1]:
         msg = (
@@ -2254,19 +2250,16 @@ def test_setattr_raises(setattr_raise):
 
 def test_setattr_ignore(setattr_ignore):
     """Test config.INVALID_KEYWORD_BEHAVIOR = 'IGNORE'"""
-    with pytest.warns(None) as record:
+    with assert_no_warning():
         ds = Dataset()
-        assert len(record) == 0
 
     for s in CAMEL_CASE[0]:
-        with pytest.warns(None) as record:
+        with assert_no_warning():
             val = getattr(ds, s, None)
             setattr(ds, s, val)
-            assert len(record) == 0
 
     ds = Dataset()
     for s in CAMEL_CASE[1]:
-        with pytest.warns(None) as record:
-            val = getattr(ds, s, None)
+        with assert_no_warning():
+            getattr(ds, s, None)
             setattr(ds, s, None)
-            assert len(record) == 0

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -28,6 +28,7 @@ from pydicom.filewriter import (
 )
 from pydicom.multival import MultiValue
 from pydicom.sequence import Sequence
+from pydicom.tests.test_helpers import assert_no_warning
 from pydicom.uid import (
     ImplicitVRLittleEndian,
     ExplicitVRBigEndian,
@@ -2435,9 +2436,8 @@ class TestWritePN:
         # PersonName value has not saved the default encoding
         fp = DicomBytesIO()
         fp.is_little_endian = True
-        with pytest.warns(None) as warnings:
+        with assert_no_warning():
             write_PN(fp, elem, encodings)
-        assert not warnings
         assert encoded == fp.getvalue()
 
         fp = DicomBytesIO()

--- a/pydicom/tests/test_handler_util.py
+++ b/pydicom/tests/test_handler_util.py
@@ -7,6 +7,7 @@ from struct import unpack, pack
 from sys import byteorder
 
 import pytest
+from pydicom.tests.test_helpers import assert_no_warning
 
 try:
     import numpy as np
@@ -2234,17 +2235,15 @@ class TestGetNrFrames:
         """Test return value when (0028,0008) 'Number of Frames' does not
             exist"""
         ds = Dataset()
-        with pytest.warns(None) as w:
+        with assert_no_warning():
             assert 1 == get_nr_frames(ds)
-            assert not w
 
     def test_existing(self):
         """Test return value when (0028,0008) 'Number of Frames' exists."""
         ds = Dataset()
         ds.NumberOfFrames = random.randint(1, 10)
-        with pytest.warns(None) as w:
+        with assert_no_warning():
             assert ds.NumberOfFrames == get_nr_frames(ds)
-            assert not w
 
 
 REFERENCE_PACK_UNPACK = [

--- a/pydicom/tests/test_helpers.py
+++ b/pydicom/tests/test_helpers.py
@@ -1,0 +1,16 @@
+# Copyright 2008-2018 pydicom authors. See LICENSE file for details.
+"""Helper functions for tests."""
+
+import warnings
+from contextlib import contextmanager
+from typing import Generator
+
+
+@contextmanager
+def assert_no_warning() -> Generator:
+    """Assert that no warning is issued.
+    Any warning will be handled as an error.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        yield


### PR DESCRIPTION
- avoids deprecation warnings from pytest
- fixes #1621

I did not add release notes, I think they are not needed for this.

#### Tasks
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
