### PR TITLE
[MRG+1] Fix length validation of DS values

### DIFF
--- a/doc/release_notes/v2.4.0.rst
+++ b/doc/release_notes/v2.4.0.rst
@@ -3,7 +3,9 @@ Version 2.4.0
 
 Enhancements
 ------------
-* Added :attr:`~pydicom.valuerep.PersonName.alphabetic` enum (:pr:`1634`)
+* Added attribute :attr:`~pydicom.valuerep.PersonName.alphabetic` (:pr:`1634`)
 
-
-
+Fixes
+-----
+* Fixed length validation of DS values with maximum length without a leading
+  zero (:issue:`1632`)

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -603,6 +603,13 @@ class TestDSfloat:
             valuerep.DSfloat('3.141592653589793',
                              validation_mode=config.RAISE)
 
+    def test_handle_missing_leading_zero(self):
+        """Test that no error is raised with maximum length DS string
+        without leading zero."""
+        # Regression test for #1632
+        valuerep.DSfloat(".002006091181818",
+                         validation_mode=config.RAISE)
+
     def test_DSfloat_auto_format(self):
         """Test creating a value using DSfloat copies auto_format"""
         x = DSfloat(math.pi, auto_format=True)

--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -874,7 +874,7 @@ class DSfloat(float):
 
         if (validation_mode == config.RAISE and
                 not self.auto_format):
-            if len(repr(self)[1:-1]) > 16:
+            if len(str(self)) > 16:
                 raise OverflowError(
                     "Values for elements with a VR of 'DS' must be <= 16 "
                     "characters long, but the float provided requires > 16 "
@@ -884,7 +884,7 @@ class DSfloat(float):
                     "explicitly construct a DS object with 'auto_format' "
                     "set to True"
                 )
-            if not is_valid_ds(repr(self)[1:-1]):
+            if not is_valid_ds(str(self)):
                 # This will catch nan and inf
                 raise ValueError(
                     f'Value "{str(self)}" is not valid for elements with a VR '


### PR DESCRIPTION
- use str() instead of repr() for validation -
  this uses the original string if available
- fixes #1632

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
