### PR TITLE
[MRG] Use a next-gen Docker convenience CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.8
+      - image: python:3.8
     steps:
       - checkout
       - run:

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -85,9 +85,9 @@ fi
 
 # Installing required system packages to support the rendering of math
 # notation in the HTML documentation
-sudo -E apt-get -yq update
-sudo -E apt-get -yq remove texlive-binaries --purge
-sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes \
+apt-get -yq update
+apt-get -yq remove texlive-binaries --purge
+apt-get -yq --no-install-suggests --no-install-recommends --force-yes \
     install dvipng texlive-latex-base texlive-latex-extra \
     texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended\
     latexmk


### PR DESCRIPTION
#### Describe the changes
- Use a next-gen Docker convenience CircleCI image. Context: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

#### Tasks
- [X] Documentation updated (if relevant)
  - [X] No warnings during build
  - [X] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
