### PR TITLE
[MRG] Use sensible chunk size for test data download

### DIFF
--- a/doc/release_notes/v2.4.0.rst
+++ b/doc/release_notes/v2.4.0.rst
@@ -3,7 +3,5 @@ Version 2.4.0
 
 Enhancements
 ------------
-* Added :attr:`~pydicom.valuerep.PersonName.alphabetic` enum (:pr:`1634`)
-
-
-
+* Added attribute :attr:`~pydicom.valuerep.PersonName.alphabetic` (:pr:`1634`)
+* Increased download speed with progress bar for test data (:issue:`1611`)

--- a/pydicom/data/download.py
+++ b/pydicom/data/download.py
@@ -101,7 +101,7 @@ def download_with_progress(url: str, fpath: pathlib.Path) -> None:
             total_size_in_bytes = int(r.headers.get("content-length", 0))
             with open(fpath, "wb") as file:
                 for data in tqdm.tqdm(
-                    r.iter_content(), total=total_size_in_bytes,
+                    r.iter_content(chunk_size=4096), total=total_size_in_bytes,
                     unit="B", unit_scale=True, miniters=1,
                     desc=url.split("/")[-1]
                 ):


### PR DESCRIPTION
- default chunk size with progress bar was 1 byte
- fixes #1611

This is a trivial change, and I did not write a test case (which would have to be a performance test) for this. We don't have (and probably don't need) tests for download.

#### Tasks
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
