### PR TITLE
[MRG] json_key method for BaseTag

### DIFF
--- a/doc/release_notes/v2.4.0.rst
+++ b/doc/release_notes/v2.4.0.rst
@@ -4,6 +4,7 @@ Version 2.4.0
 Enhancements
 ------------
 * Added attribute :attr:`~pydicom.valuerep.PersonName.alphabetic` (:pr:`1634`)
+* Added attribute :attr:`~pydicom.tag.BaseTag.json_key` (:pr:`1648`)
 * Added value validation for numerical VRs, add type validation for all
   validated VRs (:issue:`1414`)
 

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -201,6 +201,10 @@ class BaseTag(int):
 
     __repr__ = __str__
 
+    def json_key(self) -> str:
+        """Return the tag value as a JSON key string 'ggggeeee'."""
+        return "{0:04X}{1:04X}".format(self.group, self.element)
+
     @property
     def group(self) -> int:
         """Return the tag's group number as :class:`int`."""

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -201,8 +201,9 @@ class BaseTag(int):
 
     __repr__ = __str__
 
+    @property
     def json_key(self) -> str:
-        """Return the tag value as a JSON key string 'ggggeeee'."""
+        """Return the tag value as a JSON key string 'GGGGEEEE'."""
         return "{0:04X}{1:04X}".format(self.group, self.element)
 
     @property

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -204,7 +204,7 @@ class BaseTag(int):
     @property
     def json_key(self) -> str:
         """Return the tag value as a JSON key string 'GGGGEEEE'."""
-        return "{0:04X}{1:04X}".format(self.group, self.element)
+        return f"{self.group:04X}{self.element:04X}"
 
     @property
     def group(self) -> int:

--- a/pydicom/tests/test_tag.py
+++ b/pydicom/tests/test_tag.py
@@ -205,6 +205,13 @@ class TestBaseTag:
         assert '(1000, 2000)' == str(BaseTag(0x10002000))
         assert '(ffff, fffe)' == str(BaseTag(0xFFFFFFFE))
 
+    def test_json_key(self):
+        """Test BaseTag.json_key() produces correct value."""
+        assert '00000000' == BaseTag(0x00000000).json_key()
+        assert '00010002' == BaseTag(0x00010002).json_key()
+        assert '10002000' == BaseTag(0x10002000).json_key()
+        assert 'FFFFFFFE' == BaseTag(0xFFFFFFFE).json_key()
+
     def test_group(self):
         """Test BaseTag.group returns correct values."""
         assert 0x0000 == BaseTag(0x00000001).group

--- a/pydicom/tests/test_tag.py
+++ b/pydicom/tests/test_tag.py
@@ -207,10 +207,10 @@ class TestBaseTag:
 
     def test_json_key(self):
         """Test BaseTag.json_key() produces correct value."""
-        assert '00000000' == BaseTag(0x00000000).json_key()
-        assert '00010002' == BaseTag(0x00010002).json_key()
-        assert '10002000' == BaseTag(0x10002000).json_key()
-        assert 'FFFFFFFE' == BaseTag(0xFFFFFFFE).json_key()
+        assert '00000000' == BaseTag(0x00000000).json_key
+        assert '00010002' == BaseTag(0x00010002).json_key
+        assert '10002000' == BaseTag(0x10002000).json_key
+        assert 'FFFFFFFE' == BaseTag(0xFFFFFFFE).json_key
 
     def test_group(self):
         """Test BaseTag.group returns correct values."""


### PR DESCRIPTION
#### Describe the changes
Added a new 'json_key' method to BaseTag class that returns a string, used as key for JSON representation of DICOM data, as explained in Sec F.2.1.1.2 here: https://dicom.nema.org/dicom/2013/output/chtml/part18/sect_F.2.html.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
