### PR TITLE
Avoid multi-megabyte error message

### DIFF
--- a/doc/release_notes/v2.4.0.rst
+++ b/doc/release_notes/v2.4.0.rst
@@ -14,3 +14,4 @@ Fixes
   zero (:issue:`1632`)
 * Increased download speed with progress bar for test data (:issue:`1611`)
 * Fixed crash due to invalid private creator (:issue:`1638`)
+* Fixed extremely long BytesLengthException error messages (:pr:`1683`)

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -389,7 +389,8 @@ def convert_numbers(
     if length % bytes_per_value != 0:
         raise BytesLengthException(
             "Expected total bytes to be an even multiple of bytes per value. "
-            f"Instead received {shorten(repr(byte_string), width=10_000)} with length {length} and "
+            f"Instead received {shorten(repr(byte_string), width=10_000)} "
+            f"with length {length} and "
             f"struct format '{struct_format}' which corresponds to bytes per "
             f"value of {bytes_per_value}."
         )

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -6,7 +6,6 @@
 import re
 from io import BytesIO
 from struct import (unpack, calcsize)
-from textwrap import shorten
 from typing import (
     Optional, Union, List, Tuple, cast, MutableSequence, Any
 )
@@ -389,7 +388,8 @@ def convert_numbers(
     if length % bytes_per_value != 0:
         raise BytesLengthException(
             "Expected total bytes to be an even multiple of bytes per value. "
-            f"Instead received {shorten(repr(byte_string), width=10_000)} "
+            f"Instead received "
+            f"{repr(byte_string) if len(byte_string) <= 256 else 'bytes'} "
             f"with length {length} and "
             f"struct format '{struct_format}' which corresponds to bytes per "
             f"value of {bytes_per_value}."

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -6,6 +6,7 @@
 import re
 from io import BytesIO
 from struct import (unpack, calcsize)
+from textwrap import shorten
 from typing import (
     Optional, Union, List, Tuple, cast, MutableSequence, Any
 )
@@ -388,7 +389,7 @@ def convert_numbers(
     if length % bytes_per_value != 0:
         raise BytesLengthException(
             "Expected total bytes to be an even multiple of bytes per value. "
-            f"Instead received {byte_string!r} with length {length} and "
+            f"Instead received {shorten(repr(byte_string), width=10_000)} with length {length} and "
             f"struct format '{struct_format}' which corresponds to bytes per "
             f"value of {bytes_per_value}."
         )


### PR DESCRIPTION

<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes

If the incorrect data was large, this error message was very large. Ended up with a 300MB error log output because of this on a single real dicom.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [X] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
