### PR TITLE
[MRG] Catch error in creating a dataelement in to_json_dict

### DIFF
--- a/doc/release_notes/v2.4.0.rst
+++ b/doc/release_notes/v2.4.0.rst
@@ -19,3 +19,6 @@ Fixes
 * Fixed extremely long BytesLengthException error messages (:pr:`1683`)
 * In codify, ensure unique variable names for DICOM keywords repeated
   in sequences, and handle unicode characters correctly (:issue:`1670`)
+* Fixed handling of some invalid values in
+  :meth:`~pydicom.dataset.Dataset.to_json_dict` if `suppress_invalid_tags` is
+  set to `True` (:issue:`1693`)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -2492,8 +2492,8 @@ class Dataset:
         json_dataset = {}
         for key in self.keys():
             json_key = '{:08X}'.format(key)
-            data_element = self[key]
             try:
+                data_element = self[key]
                 json_dataset[json_key] = data_element.to_json_dict(
                     bulk_data_element_handler=bulk_data_element_handler,
                     bulk_data_threshold=bulk_data_threshold

--- a/pydicom/tests/test_json.py
+++ b/pydicom/tests/test_json.py
@@ -7,7 +7,7 @@ import pytest
 
 from pydicom import dcmread
 from pydicom.data import get_testdata_file
-from pydicom.dataelem import DataElement
+from pydicom.dataelem import DataElement, RawDataElement
 from pydicom.dataset import Dataset
 from pydicom.tag import Tag, BaseTag
 from pydicom.valuerep import PersonName
@@ -284,7 +284,23 @@ class TestDataSetToJson:
 
         ds_json = ds.to_json_dict(suppress_invalid_tags=True)
 
-        assert ds_json.get("00100010") is None
+        assert "00100010" not in ds_json
+
+    def test_suppress_invalid_tags_with_failed_dataelement(self):
+        """Test tags that raise exceptions don't if suppress_invalid_tags True.
+        """
+        ds = Dataset()
+        # we have to add a RawDataElement as creating a DataElement would
+        # already raise an exception
+        ds[0x00082128] = RawDataElement(
+            Tag(0x00082128), 'IS', 4, b'5.25', 0, True, True)
+
+        with pytest.raises(TypeError):
+            ds.to_json_dict()
+
+        ds_json = ds.to_json_dict(suppress_invalid_tags=True)
+
+        assert "00082128" not in ds_json
 
 
 class TestSequence:


### PR DESCRIPTION
- allows to ignore this case if suppress_invalid_tags is set
- fixes #1693

The problem occurred because an exception was raised during the creation of an `IS` dataelement with a float number.

This is somewhat related to #1661, which is about the fact that this exception cannot be suppressed if just reading the tags normally, which I still find unsatisfying, and we may have to find a solution there...

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
