### PR TITLE
[WIP] Extend Dataset.walk() to optionally provide a trace

### DIFF
--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1645,8 +1645,8 @@ class TestDataset:
         def test_callback(dataset, elem, trace):
             if elem.keyword == 'PatientID':
                 if trace:
-                    beam, item = trace[0]
-                    dataset.PatientID = f'{beam:08x}^{item}'
+                    _, beam, item = trace[0]
+                    dataset.PatientID = f'{beam.tag:08x}^{item}'
                 else:
                     dataset.PatientID = 'BASE'
 
@@ -1659,7 +1659,7 @@ class TestDataset:
         ds.BeamSequence[1].PatientID = 'JAN^Citizen^Jr'
         ds.BeamSequence[1].PatientName = 'Other^Name'
 
-        ds.tracewalk(test_callback, recursive=True)
+        ds.walk(test_callback, recursive=True, trace=True)
 
         assert 'CITIZEN^Jan' == ds.PatientName
         assert 'BASE' == ds.PatientID

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1639,6 +1639,35 @@ class TestDataset:
         assert 'FIXED' == ds.BeamSequence[1].PatientID
         assert 'Other^Name' == ds.BeamSequence[1].PatientName
 
+    def test_tracewalk(self):
+        """Test Dataset.walk iterates through sequences with stack"""
+
+        def test_callback(dataset, elem, trace):
+            if elem.keyword == 'PatientID':
+                if trace:
+                    beam, item = trace[0]
+                    dataset.PatientID = f'{beam:08x}^{item}'
+                else:
+                    dataset.PatientID = 'BASE'
+
+        ds = Dataset()
+        ds.PatientName = 'CITIZEN^Jan'
+        ds.PatientID = 'JAN^Citizen^III'
+        ds.BeamSequence = [Dataset(), Dataset()]
+        ds.BeamSequence[0].PatientID = 'JAN^Citizen^Snr'
+        ds.BeamSequence[0].PatientName = 'Some^Name'
+        ds.BeamSequence[1].PatientID = 'JAN^Citizen^Jr'
+        ds.BeamSequence[1].PatientName = 'Other^Name'
+
+        ds.tracewalk(test_callback, recursive=True)
+
+        assert 'CITIZEN^Jan' == ds.PatientName
+        assert 'BASE' == ds.PatientID
+        assert '300a00b0^0' == ds.BeamSequence[0].PatientID
+        assert 'Some^Name' == ds.BeamSequence[0].PatientName
+        assert '300a00b0^1' == ds.BeamSequence[1].PatientID
+        assert 'Other^Name' == ds.BeamSequence[1].PatientName
+
     def test_update_with_dataset(self):
         """Regression test for #779"""
         ds = Dataset()


### PR DESCRIPTION
#### Describe the changes

This is one prototype to extend Dataset.walk() provide a trace to the callback() when running recursively. In this version:

* A new `_tracewalk()` is added
* The original `walk()` implementation is moved to `_walk()`
* A new `walk()` dispatches to either `_walk()` or `_tracewalk()` on the first call.
* The trace is provided as a tuple to prevent modifications in the callback
*  The structure of the trace is:
```
(
   (dataset of SQ element, SQ element, item number),
   (dataset of SQ element, SQ element, item number),
   ...
   etc
)
```

Some "arbitrary" decisions:

* Whether or not to return the dataset that contains the SQ... I think it might be useful when dealing with private sequences/tags. But there are also workarounds that a callback could implement if it was not provided in the trace. (easiest if the SQ DataElement is returned)
*  I'm not sure the SQ DataElement provides much info beyond the tag. But it does contain the VM which might be useful in a callback. Also can be implemented with logic in the callback().
* Separating the implementations... I wrote a few versions that combined the two, but separation keeps the logic cleaner and removes branching
* Whether or not the trace comes to `callback()` as a positional or keyword parameter. Maybe it should be a keyword-only parameter so that it forces people writing callbacks to expect them?
* What exactly to include in the trace? I think the minimal trace to be useful would be:
```
(
   (tag, item number),
   (tag, item number),
   ...
   etc
)
```

But I think private tags/sequences might become more complex. Ultimately, I decided to just put the whole dataset, dataelement in the trace because it takes no effort and the `callback()` can see all of those objects anyway if someone is determined (see this gist https://gist.github.com/jstorrs/4d8e22b53cbb6412e5355e0c7754efee) that does all of this as a decorator around the existing `walk`), so whatever potential damage a `callback()` can do is already entirely possible.

See further explanation at #1695.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
