### PR TITLE
[MRG] Handle invalid DICOMDIR dataset

### DIFF
--- a/doc/release_notes/v2.4.0.rst
+++ b/doc/release_notes/v2.4.0.rst
@@ -24,3 +24,5 @@ Fixes
   set to `True` (:issue:`1693`)
 * Fixed reading of data with 8 bits allocated, encoded in Big Endian transfer
   syntax using VR ``OW`` (:issue:`1680`)
+* Fixed crash if reading regular dataset that has the SOP Class of a DICOMDIR
+  (:issue:`1702`)

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -875,7 +875,7 @@ def read_partial(
                 "not match the contents of the dataset - handling it"
                 "as a regular dataset instead of a DICOMDIR."
             )
-            ds_class = FileDataset
+            ds_class: Union[Type[FileDataset], Type[DicomDir]] = FileDataset
         else:
             warnings.warn(
                 "The 'DicomDir' class is deprecated and will be removed in"
@@ -884,7 +884,7 @@ def read_partial(
                 "SOP Instances.",
                 DeprecationWarning
             )
-            ds_class: Union[Type[FileDataset], Type[DicomDir]] = DicomDir
+            ds_class = DicomDir
     else:
         ds_class = FileDataset
 

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -869,13 +869,22 @@ def read_partial(
     elem = file_meta.get(0x00020002, None)
     sop_class = elem.value.name if (elem and elem.VM == 1) else ""
     if sop_class == "Media Storage Directory Storage":
-        warnings.warn(
-            "The 'DicomDir' class is deprecated and will be removed in v3.0, "
-            "after which 'dcmread()' will return a normal 'FileDataset' "
-            "instance for 'Media Storage Directory' SOP Instances.",
-            DeprecationWarning
-        )
-        ds_class: Union[Type[FileDataset], Type[DicomDir]] = DicomDir
+        if "DirectoryRecordSequence" not in dataset:
+            warnings.warn(
+                "The SOP Class 'Media Storage Directory Storage' does"
+                "not match the contents of the dataset - handling it"
+                "as a regular dataset instead of a DICOMDIR."
+            )
+            ds_class = FileDataset
+        else:
+            warnings.warn(
+                "The 'DicomDir' class is deprecated and will be removed in"
+                " v3.0, after which 'dcmread()' will return a normal "
+                "'FileDataset' instance for 'Media Storage Directory' "
+                "SOP Instances.",
+                DeprecationWarning
+            )
+            ds_class: Union[Type[FileDataset], Type[DicomDir]] = DicomDir
     else:
         ds_class = FileDataset
 


### PR DESCRIPTION
- a regular dataset with a Directory Storage SOP Class is now handled as a regular dataset
- see discussion in #1702

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
