### PR TITLE
[MRG] Skip jpeg-ls tests for Python 3.11

### DIFF
--- a/.github/workflows/merge-pytest.yml
+++ b/.github/workflows/merge-pytest.yml
@@ -76,6 +76,7 @@ jobs:
         python -m pip uninstall -y pillow
 
     - name: Install and test jpeg_ls
+      if: ${{ matrix.python-version != '3.11-dev' || matrix.os == 'windows-latest' }}
       run: |
         python -m pip install -U cython
         python -m pip install git+https://github.com/Who8MyLunch/CharPyLS

--- a/.github/workflows/merge-pytest.yml
+++ b/.github/workflows/merge-pytest.yml
@@ -76,7 +76,7 @@ jobs:
         python -m pip uninstall -y pillow
 
     - name: Install and test jpeg_ls
-      if: ${{ matrix.python-version != '3.11-dev' || matrix.os == 'windows-latest' }}
+      if: ${{ matrix.python-version != '3.11-dev' }}
       run: |
         python -m pip install -U cython
         python -m pip install git+https://github.com/Who8MyLunch/CharPyLS
@@ -92,6 +92,7 @@ jobs:
         python -m pip uninstall -y python-gdcm
 
     - name: Install and test pylibjpeg
+      if: ${{ matrix.python-version != '3.11-dev' }}
       run: |
         python -m pip install pylibjpeg
         python -m pip uninstall -y pylibjpeg-openjpeg pylibjpeg-rle
@@ -100,6 +101,7 @@ jobs:
         pytest ${{ matrix.pytest-args }} pydicom/tests/test_pylibjpeg.py
 
     - name: Test all pixel handling
+      if: ${{ matrix.python-version != '3.11-dev' }}
       run: |
         python -m pip install pillow python-gdcm
         python -m pip install git+https://github.com/Who8MyLunch/CharPyLS

--- a/.github/workflows/pr-pytest.yml
+++ b/.github/workflows/pr-pytest.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
         include:
           - os: 'ubuntu-latest'
             pytest-args: --cov=pydicom --cov-append
@@ -90,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11-dev']
         include:
           - os: 'ubuntu-latest'
             send-coverage: true
@@ -153,6 +153,7 @@ jobs:
         python -m pip uninstall -y pillow
 
     - name: Install and test jpeg_ls
+      if: ${{ matrix.python-version != '3.11-dev' || matrix.os == 'windows-latest' }}
       run: |
         python -m pip install -U cython
         python -m pip install git+https://github.com/Who8MyLunch/CharPyLS

--- a/.github/workflows/pr-pytest.yml
+++ b/.github/workflows/pr-pytest.yml
@@ -153,7 +153,7 @@ jobs:
         python -m pip uninstall -y pillow
 
     - name: Install and test jpeg_ls
-      if: ${{ matrix.python-version != '3.11-dev' || matrix.os == 'windows-latest' }}
+      if: ${{ matrix.python-version != '3.11-dev' }}
       run: |
         python -m pip install -U cython
         python -m pip install git+https://github.com/Who8MyLunch/CharPyLS
@@ -169,6 +169,7 @@ jobs:
         python -m pip uninstall -y python-gdcm
 
     - name: Install and test pylibjpeg
+      if: ${{ matrix.python-version != '3.11-dev' }}
       run: |
         python -m pip install -U pylibjpeg
         python -m pip uninstall -y pylibjpeg-openjpeg pylibjpeg-rle
@@ -177,6 +178,7 @@ jobs:
         pytest ${{ matrix.pytest-args }} pydicom/tests/test_pylibjpeg.py
 
     - name: Test all pixel handling
+      if: ${{ matrix.python-version != '3.11-dev' }}
       run: |
         python -m pip install -U pillow python-gdcm
         python -m pip install git+https://github.com/Who8MyLunch/CharPyLS

--- a/.github/workflows/pr-pytest.yml
+++ b/.github/workflows/pr-pytest.yml
@@ -90,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11-dev']
+        python-version: ['3.10']
         include:
           - os: 'ubuntu-latest'
             send-coverage: true
@@ -153,7 +153,6 @@ jobs:
         python -m pip uninstall -y pillow
 
     - name: Install and test jpeg_ls
-      if: ${{ matrix.python-version != '3.11-dev' }}
       run: |
         python -m pip install -U cython
         python -m pip install git+https://github.com/Who8MyLunch/CharPyLS
@@ -169,7 +168,6 @@ jobs:
         python -m pip uninstall -y python-gdcm
 
     - name: Install and test pylibjpeg
-      if: ${{ matrix.python-version != '3.11-dev' }}
       run: |
         python -m pip install -U pylibjpeg
         python -m pip uninstall -y pylibjpeg-openjpeg pylibjpeg-rle
@@ -178,7 +176,6 @@ jobs:
         pytest ${{ matrix.pytest-args }} pydicom/tests/test_pylibjpeg.py
 
     - name: Test all pixel handling
-      if: ${{ matrix.python-version != '3.11-dev' }}
       run: |
         python -m pip install -U pillow python-gdcm
         python -m pip install git+https://github.com/Who8MyLunch/CharPyLS


### PR DESCRIPTION
- CharPyLS does not compile under Linux/MacOS
- also add 3.11 builds for PR builds

I seems to have forgotten to add 3.11 builds to the PR builds, so this was not visible there.

#### Tasks
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
