### PR TITLE
[MRG] Pytest deprecations

### DIFF
--- a/.github/workflows/merge-typing.yml
+++ b/.github/workflows/merge-typing.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install typing dependencies
       run: |
         python -m pip install -U pip
-        python -m pip install -U mypy
+        python -m pip install mypy==0.971
         python -m pip install -U types-requests types-pkg_resources types-setuptools
     - name: Run typing check with mypy
       run: |

--- a/.github/workflows/pr-type-spell.yml
+++ b/.github/workflows/pr-type-spell.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install typing dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -U mypy
+        python -m pip install mypy==0.971
         python -m pip install -U types-requests types-pkg_resources types-setuptools
 
     - name: Run typing check with mypy

--- a/doc/release_notes/v2.4.0.rst
+++ b/doc/release_notes/v2.4.0.rst
@@ -4,6 +4,8 @@ Version 2.4.0
 Changes
 -------
 * Removed support for Python 3.6 (EOL since December 2021)
+* In test suite, renamed 'setup' and 'teardown' methods,
+  deprecated starting in pytest 7.2
 
 Enhancements
 ------------

--- a/doc/release_notes/v2.4.0.rst
+++ b/doc/release_notes/v2.4.0.rst
@@ -4,8 +4,7 @@ Version 2.4.0
 Changes
 -------
 * Removed support for Python 3.6 (EOL since December 2021)
-* In test suite, renamed 'setup' and 'teardown' methods,
-  deprecated starting in pytest 7.2
+
 
 Enhancements
 ------------
@@ -35,3 +34,8 @@ Fixes
   syntax using VR ``OW`` (:issue:`1680`)
 * Fixed crash if reading regular dataset that has the SOP Class of a DICOMDIR
   (:issue:`1702`)
+
+Pydicom Internals
+-----------------
+* In test suites, renamed 'setup' and 'teardown' methods, deprecated starting
+  in pytest 7.2

--- a/pydicom/tests/test_codes.py
+++ b/pydicom/tests/test_codes.py
@@ -19,7 +19,7 @@ def ambiguous_scheme():
 
 
 class TestCode:
-    def setup(self):
+    def setup_method(self):
         self._value = "373098007"
         self._meaning = "Mean Value of population"
         self._scheme_designator = "SCT"

--- a/pydicom/tests/test_config.py
+++ b/pydicom/tests/test_config.py
@@ -25,10 +25,10 @@ PYTEST = [int(x) for x in pytest.__version__.split(".")]
 class TestDebug:
     """Tests for config.debug()."""
 
-    def setup(self):
+    def setup_method(self):
         self.logger = logging.getLogger("pydicom")
 
-    def teardown(self):
+    def teardown_method(self):
         # Reset to just NullHandler
         self.logger.handlers = [self.logger.handlers[0]]
 

--- a/pydicom/tests/test_data_manager.py
+++ b/pydicom/tests/test_data_manager.py
@@ -117,14 +117,14 @@ class TestGetData:
 class TestExternalDataSource:
     """Tests for the external data sources."""
 
-    def setup(self):
+    def setup_method(self):
         self.dpath = external_data_sources()["pydicom-data"].data_path
 
         # Backup the 693_UNCI.dcm file
         p = self.dpath / "693_UNCI.dcm"
         shutil.copy(p, self.dpath / "PYTEST_BACKUP")
 
-    def teardown(self):
+    def teardown_method(self):
         # Restore the backed-up file
         p = self.dpath / "693_UNCI.dcm"
         shutil.copy(self.dpath / "PYTEST_BACKUP", p)

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -50,7 +50,7 @@ class BadRepr:
 class TestDataset:
     """Tests for dataset.Dataset."""
 
-    def setup(self):
+    def setup_method(self):
         self.ds = Dataset()
         self.ds.TreatmentMachineName = "unit001"
 
@@ -1700,7 +1700,7 @@ class TestDataset:
 class TestDatasetElements:
     """Test valid assignments of data elements"""
 
-    def setup(self):
+    def setup_method(self):
         self.ds = Dataset()
         self.sub_ds1 = Dataset()
         self.sub_ds2 = Dataset()
@@ -1810,7 +1810,7 @@ class TestDatasetElements:
 
 
 class TestFileDataset:
-    def setup(self):
+    def setup_method(self):
         self.test_file = get_testdata_file('CT_small.dcm')
 
     def test_pickle_raw_data(self):
@@ -1975,7 +1975,7 @@ class TestFileDataset:
 class TestDatasetOverlayArray:
     """Tests for Dataset.overlay_array()."""
 
-    def setup(self):
+    def setup_method(self):
         """Setup the test datasets and the environment."""
         self.original_handlers = pydicom.config.overlay_data_handlers
         pydicom.config.overlay_data_handlers = [NP_HANDLER]
@@ -2007,7 +2007,7 @@ class TestDatasetOverlayArray:
 
         self.dummy = DummyHandler()
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.overlay_data_handlers = self.original_handlers
 

--- a/pydicom/tests/test_encoders.py
+++ b/pydicom/tests/test_encoders.py
@@ -33,7 +33,7 @@ from pydicom.uid import (
 
 class TestEncoder:
     """Non-encoding tests for encoders.Encoder"""
-    def setup(self):
+    def setup_method(self):
         self.enc = Encoder(UID('1.2.3'))
 
     def test_init(self):
@@ -273,7 +273,7 @@ class TestEncoder:
 @pytest.mark.skipif(not HAVE_NP, reason="Numpy not available")
 class TestEncoder_Encode:
     """Tests for Encoder.encode() and related methods."""
-    def setup(self):
+    def setup_method(self):
         self.enc = RLELosslessEncoder
         self.ds = get_testdata_file("CT_small.dcm", read=True)
         self.ds_enc = get_testdata_file("MR_small_RLE.dcm", read=True)
@@ -524,7 +524,7 @@ class TestEncoder_Encode:
 @pytest.mark.skipif(not HAVE_NP, reason="Numpy not available")
 class TestEncoder_Preprocess:
     """Tests for Encoder._preprocess()."""
-    def setup(self):
+    def setup_method(self):
         self.e = Encoder(JPEG2000Lossless)
         self.ds = ds = Dataset()
         ds.Rows = 1

--- a/pydicom/tests/test_encoders_pydicom.py
+++ b/pydicom/tests/test_encoders_pydicom.py
@@ -110,7 +110,7 @@ class TestEncodeRow:
 @pytest.mark.skipif(not HAVE_NP, reason="Numpy not available")
 class TestEncodeFrame:
     """Tests for rle_handler._encode_frame."""
-    def setup(self):
+    def setup_method(self):
         """Setup the tests."""
         # Create a dataset skeleton for use in the cycle tests
         ds = Dataset()

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -922,7 +922,7 @@ class TestReader:
 
 
 class TestIncorrectVR:
-    def setup(self):
+    def setup_method(self):
         self.ds_explicit = BytesIO(
             b"\x08\x00\x05\x00CS\x0a\x00ISO_IR 100"  # SpecificCharacterSet
             b"\x08\x00\x20\x00DA\x08\x0020000101"  # StudyDate
@@ -1075,7 +1075,7 @@ class TestUnknownVR:
 
 
 class TestReadDataElement:
-    def setup(self):
+    def setup_method(self):
         ds = Dataset()
         ds.DoubleFloatPixelData = (
             b"\x00\x01\x02\x03\x04\x05\x06\x07"
@@ -1474,11 +1474,11 @@ class TestDeferredRead:
     """
 
     # Copy one of test files and use temporarily, then later remove.
-    def setup(self):
+    def setup_method(self):
         self.testfile_name = ct_name + ".tmp"
         shutil.copyfile(ct_name, self.testfile_name)
 
-    def teardown(self):
+    def teardown_method(self):
         if os.path.exists(self.testfile_name):
             os.remove(self.testfile_name)
 

--- a/pydicom/tests/test_fileset.py
+++ b/pydicom/tests/test_fileset.py
@@ -2153,10 +2153,10 @@ class TestFileSet_Load:
 @pytest.mark.filterwarnings("ignore:The 'DicomDir'")
 class TestFileSet_Modify:
     """Tests for a modified File-set."""
-    def setup(self):
+    def setup_method(self):
         self.fn = FileSet.__len__
 
-    def teardown(self):
+    def teardown_method(self):
         FileSet.__len__ = self.fn
 
     def test_write_dicomdir_fs_changes(self, dicomdir_copy):
@@ -2472,10 +2472,10 @@ class TestFileSet_Modify:
 @pytest.mark.filterwarnings("ignore:The 'DicomDir'")
 class TestFileSet_Copy:
     """Tests for copying a File-set."""
-    def setup(self):
+    def setup_method(self):
         self.orig = FileSet.__len__
 
-    def teardown(self):
+    def teardown_method(self):
         FileSet.__len__ = self.orig
 
     def test_copy(self, dicomdir, tdir):

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -97,10 +97,10 @@ def as_assertable(dataset):
 
 
 class TestWriteFile:
-    def setup(self):
+    def setup_method(self):
         self.file_out = TemporaryFile('w+b')
 
-    def teardown(self):
+    def teardown_method(self):
         self.file_out.close()
 
     def compare(self, in_filename):
@@ -308,11 +308,11 @@ class TestWriteFile:
 class TestScratchWriteDateTime(TestWriteFile):
     """Write and reread simple or multi-value DA/DT/TM data elements"""
 
-    def setup(self):
+    def setup_method(self):
         config.datetime_conversion = True
         self.file_out = TemporaryFile('w+b')
 
-    def teardown(self):
+    def teardown_method(self):
         config.datetime_conversion = False
         self.file_out.close()
 
@@ -349,7 +349,7 @@ class TestScratchWriteDateTime(TestWriteFile):
 class TestWriteDataElement:
     """Attempt to write data elements has the expected behaviour"""
 
-    def setup(self):
+    def setup_method(self):
         # Create a dummy (in memory) file to write to
         self.f1 = DicomBytesIO()
         self.f1.is_little_endian = True
@@ -1147,7 +1147,7 @@ class TestCorrectAmbiguousVRElement:
 class TestWriteAmbiguousVR:
     """Attempt to write data elements with ambiguous VR."""
 
-    def setup(self):
+    def setup_method(self):
         # Create a dummy (in memory) file to write to
         self.fp = DicomBytesIO()
         self.fp.is_implicit_VR = False
@@ -1207,7 +1207,7 @@ class TestWriteAmbiguousVR:
 class TestScratchWrite:
     """Simple dataset from scratch, written in all endian/VR combinations"""
 
-    def setup(self):
+    def setup_method(self):
         # Create simple dataset for all tests
         ds = Dataset()
         ds.PatientName = "Name^Patient"
@@ -1866,7 +1866,7 @@ class TestWriteFileMetaInfoToStandard:
 class TestWriteNonStandard:
     """Unit tests for writing datasets not to the DICOM standard."""
 
-    def setup(self):
+    def setup_method(self):
         """Create an empty file-like for use in testing."""
         self.fp = DicomBytesIO()
         self.fp.is_little_endian = True
@@ -2206,7 +2206,7 @@ class TestWriteNonStandard:
 class TestWriteFileMetaInfoNonStandard:
     """Unit tests for writing File Meta Info not to the DICOM standard."""
 
-    def setup(self):
+    def setup_method(self):
         """Create an empty file-like for use in testing."""
         self.fp = DicomBytesIO()
 
@@ -2626,7 +2626,7 @@ class TestWriteDT:
 class TestWriteUndefinedLengthPixelData:
     """Test write_data_element() for pixel data with undefined length."""
 
-    def setup(self):
+    def setup_method(self):
         self.fp = DicomBytesIO()
 
     def test_little_endian_correct_data(self):

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -97,7 +97,7 @@ save_dir = os.getcwd()
 
 
 class TestGDCM_JPEG_LS_no_gdcm:
-    def setup(self):
+    def setup_method(self):
         self.unicode_filename = os.path.join(
             tempfile.gettempdir(), "ДИКОМ.dcm")
         shutil.copyfile(jpeg_ls_lossless_name, self.unicode_filename)
@@ -108,7 +108,7 @@ class TestGDCM_JPEG_LS_no_gdcm:
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = []
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
         os.remove(self.unicode_filename)
 
@@ -122,7 +122,7 @@ class TestGDCM_JPEG_LS_no_gdcm:
 
 
 class TestGDCM_JPEG2000_no_gdcm:
-    def setup(self):
+    def setup_method(self):
         self.jpeg_2k = dcmread(jpeg2000_name)
         self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
         self.mr_small = dcmread(mr_name)
@@ -132,7 +132,7 @@ class TestGDCM_JPEG2000_no_gdcm:
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = []
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEG2000(self):
@@ -160,13 +160,13 @@ class TestGDCM_JPEG2000_no_gdcm:
 
 
 class TestGDCM_JPEGlossy_no_gdcm:
-    def setup(self):
+    def setup_method(self):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = []
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEGlossy(self):
@@ -185,12 +185,12 @@ class TestGDCM_JPEGlossy_no_gdcm:
 
 
 class TestGDCM_JPEGlossless_no_gdcm:
-    def setup(self):
+    def setup_method(self):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = []
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossless(self):

--- a/pydicom/tests/test_handler_util.py
+++ b/pydicom/tests/test_handler_util.py
@@ -106,7 +106,7 @@ REFERENCE_DTYPE = [
 @pytest.mark.skipif(not HAVE_NP, reason="Numpy is not available")
 class TestNumpy_PixelDtype:
     """Tests for util.pixel_dtype."""
-    def setup(self):
+    def setup_method(self):
         """Setup the test dataset."""
         self.ds = Dataset()
         self.ds.file_meta = FileMetaDataset()
@@ -294,7 +294,7 @@ if HAVE_NP:
 @pytest.mark.skipif(not HAVE_NP, reason="Numpy is not available")
 class TestNumpy_ReshapePixelArray:
     """Tests for util.reshape_pixel_array."""
-    def setup(self):
+    def setup_method(self):
         """Setup the test dataset."""
         self.ds = Dataset()
         self.ds.file_meta = FileMetaDataset()
@@ -940,12 +940,12 @@ class TestNumpy_ModalityLUT:
 @pytest.mark.skipif(not HAVE_NP, reason="Numpy is not available")
 class TestNumpy_PaletteColor:
     """Tests for util.apply_color_lut()."""
-    def setup(self):
+    def setup_method(self):
         """Setup the tests"""
         self.o_palette = get_palette_files('pet.dcm')[0]
         self.n_palette = get_palette_files('pet.dcm')[0][:-3] + 'tmp'
 
-    def teardown(self):
+    def teardown_method(self):
         """Teardown the tests"""
         if os.path.exists(self.n_palette):
             os.rename(self.n_palette, self.o_palette)

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -68,7 +68,7 @@ SUPPORTED_HANDLER_NAMES = (
 )
 
 class TestJPEGLS_no_jpeg_ls:
-    def setup(self):
+    def setup_method(self):
         self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
@@ -76,7 +76,7 @@ class TestJPEGLS_no_jpeg_ls:
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [numpy_handler]
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEG_LS_PixelArray(self):
@@ -85,7 +85,7 @@ class TestJPEGLS_no_jpeg_ls:
 
 
 class TestJPEGLS_JPEG2000_no_jpeg_ls:
-    def setup(self):
+    def setup_method(self):
         self.jpeg_2k = dcmread(jpeg2000_name)
         self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
         self.mr_small = dcmread(mr_name)
@@ -94,7 +94,7 @@ class TestJPEGLS_JPEG2000_no_jpeg_ls:
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [numpy_handler]
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEG2000PixelArray(self):
@@ -109,13 +109,13 @@ class TestJPEGLS_JPEG2000_no_jpeg_ls:
 
 
 class TestJPEGLS_JPEGlossy_no_jpeg_ls:
-    def setup(self):
+    def setup_method(self):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [numpy_handler]
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossy(self):
@@ -134,12 +134,12 @@ class TestJPEGLS_JPEGlossy_no_jpeg_ls:
 
 
 class TestJPEGLS_JPEGlossless_no_jpeg_ls:
-    def setup(self):
+    def setup_method(self):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [numpy_handler]
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossless(self):
@@ -158,7 +158,7 @@ class TestJPEGLS_JPEGlossless_no_jpeg_ls:
 
 @pytest.mark.skipif(not test_jpeg_ls_decoder, reason=jpeg_ls_missing_message)
 class TestJPEGLS_JPEG_LS_with_jpeg_ls:
-    def setup(self):
+    def setup_method(self):
         self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
         self.mr_small = dcmread(mr_name)
         self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
@@ -166,7 +166,7 @@ class TestJPEGLS_JPEG_LS_with_jpeg_ls:
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [jpeg_ls_handler, numpy_handler]
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEG_LS_PixelArray(self):
@@ -191,7 +191,7 @@ class TestJPEGLS_JPEG_LS_with_jpeg_ls:
 
 @pytest.mark.skipif(not test_jpeg_ls_decoder, reason=jpeg_ls_missing_message)
 class TestJPEGLS_JPEG2000_with_jpeg_ls:
-    def setup(self):
+    def setup_method(self):
         self.jpeg_2k = dcmread(jpeg2000_name)
         self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
         self.mr_small = dcmread(mr_name)
@@ -200,7 +200,7 @@ class TestJPEGLS_JPEG2000_with_jpeg_ls:
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [jpeg_ls_handler, numpy_handler]
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
     def test_JPEG2000PixelArray(self):
@@ -214,13 +214,13 @@ class TestJPEGLS_JPEG2000_with_jpeg_ls:
 
 @pytest.mark.skipif(not test_jpeg_ls_decoder, reason=jpeg_ls_missing_message)
 class TestJPEGLS_JPEGlossy_with_jpeg_ls:
-    def setup(self):
+    def setup_method(self):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
         self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [jpeg_ls_handler, numpy_handler]
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossy(self):
@@ -239,12 +239,12 @@ class TestJPEGLS_JPEGlossy_with_jpeg_ls:
 
 @pytest.mark.skipif(not test_jpeg_ls_decoder, reason=jpeg_ls_missing_message)
 class TestJPEGLS_JPEGlossless_with_jpeg_ls:
-    def setup(self):
+    def setup_method(self):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [jpeg_ls_handler, numpy_handler]
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.config.pixel_data_handlers = self.original_handlers
 
     def testJPEGlossless(self):

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -187,12 +187,12 @@ SUPPORTED_HANDLER_NAMES = (
 class TestNoNumpy_NoNumpyHandler:
     """Tests for handling datasets without numpy and the handler."""
 
-    def setup(self):
+    def setup_method(self):
         """Setup the environment."""
         self.original_handlers = config.pixel_data_handlers
         config.pixel_data_handlers = []
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         config.pixel_data_handlers = self.original_handlers
 
@@ -252,12 +252,12 @@ class TestNoNumpy_NoNumpyHandler:
 class TestNoNumpy_NumpyHandler:
     """Tests for handling datasets without numpy and the handler."""
 
-    def setup(self):
+    def setup_method(self):
         """Setup the environment."""
         self.original_handlers = config.pixel_data_handlers
         config.pixel_data_handlers = [NP_HANDLER]
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         config.pixel_data_handlers = self.original_handlers
 
@@ -323,12 +323,12 @@ class TestNoNumpy_NumpyHandler:
 class TestNumpy_NoNumpyHandler:
     """Tests for handling datasets without the handler."""
 
-    def setup(self):
+    def setup_method(self):
         """Setup the environment."""
         self.original_handlers = config.pixel_data_handlers
         config.pixel_data_handlers = []
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         config.pixel_data_handlers = self.original_handlers
 
@@ -421,12 +421,12 @@ REFERENCE_DATA_LITTLE = [
 class TestNumpy_NumpyHandler:
     """Tests for handling Pixel Data with the handler."""
 
-    def setup(self):
+    def setup_method(self):
         """Setup the test datasets and the environment."""
         self.original_handlers = config.pixel_data_handlers
         config.pixel_data_handlers = [NP_HANDLER]
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         config.pixel_data_handlers = self.original_handlers
 

--- a/pydicom/tests/test_overlay_np.py
+++ b/pydicom/tests/test_overlay_np.py
@@ -68,12 +68,12 @@ EXPL_16_1_1F = get_testdata_file("MR_small.dcm")
 @pytest.mark.skipif(HAVE_NP, reason='Numpy is available')
 class TestNoNumpy_NumpyHandler:
     """Tests for handling datasets without numpy and the handler."""
-    def setup(self):
+    def setup_method(self):
         """Setup the environment."""
         self.original_handlers = pydicom.config.overlay_data_handlers
         pydicom.config.overlay_data_handlers = [NP_HANDLER]
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.overlay_data_handlers = self.original_handlers
 
@@ -118,12 +118,12 @@ REFERENCE_DATA_LITTLE = [
 @pytest.mark.skipif(not HAVE_NP, reason='Numpy is not available')
 class TestNumpy_NumpyHandler:
     """Tests for handling Overlay Data with the handler."""
-    def setup(self):
+    def setup_method(self):
         """Setup the test datasets and the environment."""
         self.original_handlers = pydicom.config.overlay_data_handlers
         pydicom.config.overlay_data_handlers = [NP_HANDLER]
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.overlay_data_handlers = self.original_handlers
 
@@ -325,7 +325,7 @@ if HAVE_NP:
 @pytest.mark.skipif(not HAVE_NP, reason="Numpy is not available")
 class TestNumpy_ReshapeOverlayArray:
     """Tests for numpy_handler.reshape_overlay_array."""
-    def setup(self):
+    def setup_method(self):
         """Setup the test dataset."""
         self.elem = {
             'OverlayRows': 4,

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -139,12 +139,12 @@ REFERENCE_DATA_UNSUPPORTED = [
 class TestNoNumpy_NoPillowHandler:
     """Tests for handling datasets without numpy and the handler."""
 
-    def setup(self):
+    def setup_method(self):
         """Setup the environment."""
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = []
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.pixel_data_handlers = self.original_handlers
 
@@ -381,13 +381,13 @@ JPEG2K_MATCHING_DATASETS = [
 @pytest.mark.skipif(not HAVE_JPEG2K, reason='Pillow or JPEG2K not available')
 class TestPillowHandler_JPEG2K:
     """Tests for handling Pixel Data with the handler."""
-    def setup(self):
+    def setup_method(self):
         """Setup the test datasets and the environment."""
         self.original_handlers = pydicom.config.pixel_data_handlers
         self.original_j2k = pydicom.config.APPLY_J2K_CORRECTIONS
         pydicom.config.pixel_data_handlers = [NP_HANDLER, PIL_HANDLER]
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.pixel_data_handlers = self.original_handlers
         pydicom.config.APPLY_J2K_CORRECTIONS = self.original_j2k
@@ -514,12 +514,12 @@ class TestPillowHandler_JPEG2K:
 @pytest.mark.skipif(not HAVE_JPEG, reason='Pillow or JPEG not available')
 class TestPillowHandler_JPEG:
     """Tests for handling Pixel Data with the handler."""
-    def setup(self):
+    def setup_method(self):
         """Setup the test datasets and the environment."""
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [NP_HANDLER, PIL_HANDLER]
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.pixel_data_handlers = self.original_handlers
 

--- a/pydicom/tests/test_pylibjpeg.py
+++ b/pydicom/tests/test_pylibjpeg.py
@@ -336,12 +336,12 @@ print(not HAVE_PYLIBJPEG, (HAVE_LJ or HAVE_OJ or HAVE_RLE))
 @pytest.mark.skipif(not HAVE_PYLIBJPEG, reason='pylibjpeg not available')
 class TestHandler:
     """Tests for handling Pixel Data with the handler."""
-    def setup(self):
+    def setup_method(self):
         """Setup the test datasets and the environment."""
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [NP_HANDLER, LJ_HANDLER]
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.pixel_data_handlers = self.original_handlers
 
@@ -400,12 +400,12 @@ class TestHandler:
 
 @pytest.mark.skipif(not TEST_JPEG, reason="no -libjpeg plugin")
 class TestJPEG:
-    def setup(self):
+    def setup_method(self):
         """Setup the test datasets and the environment."""
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [NP_HANDLER, LJ_HANDLER]
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.pixel_data_handlers = self.original_handlers
 
@@ -498,12 +498,12 @@ class TestJPEG:
 
 @pytest.mark.skipif(not TEST_JPEGLS, reason="no -libjpeg plugin")
 class TestJPEGLS:
-    def setup(self):
+    def setup_method(self):
         """Setup the test datasets and the environment."""
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [NP_HANDLER, LJ_HANDLER]
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.pixel_data_handlers = self.original_handlers
 
@@ -537,12 +537,12 @@ class TestJPEGLS:
 
 @pytest.mark.skipif(not TEST_JPEG2K, reason="no -openjpeg plugin")
 class TestJPEG2K:
-    def setup(self):
+    def setup_method(self):
         """Setup the test datasets and the environment."""
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [NP_HANDLER, LJ_HANDLER]
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.pixel_data_handlers = self.original_handlers
 

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -184,12 +184,12 @@ REFERENCE_DATA_UNSUPPORTED = [
 @pytest.mark.skipif(HAVE_NP, reason='Numpy is available')
 class TestNoNumpy_NoRLEHandler:
     """Tests for handling datasets without numpy and the handler."""
-    def setup(self):
+    def setup_method(self):
         """Setup the environment."""
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = []
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.pixel_data_handlers = self.original_handlers
 
@@ -229,12 +229,12 @@ class TestNoNumpy_NoRLEHandler:
 @pytest.mark.skipif(HAVE_NP, reason='Numpy is available')
 class TestNoNumpy_RLEHandler:
     """Tests for handling datasets without numpy and the handler."""
-    def setup(self):
+    def setup_method(self):
         """Setup the environment."""
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [RLE_HANDLER]
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.pixel_data_handlers = self.original_handlers
 
@@ -287,12 +287,12 @@ class TestNoNumpy_RLEHandler:
 @pytest.mark.skipif(not HAVE_NP, reason='Numpy is not available')
 class TestNumpy_NoRLEHandler:
     """Tests for handling datasets with no handler."""
-    def setup(self):
+    def setup_method(self):
         """Setup the environment."""
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = []
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.pixel_data_handlers = self.original_handlers
 
@@ -332,12 +332,12 @@ class TestNumpy_NoRLEHandler:
 @pytest.mark.skipif(not HAVE_NP, reason='Numpy is not available')
 class TestNumpy_RLEHandler:
     """Tests for handling datasets with the handler."""
-    def setup(self):
+    def setup_method(self):
         """Setup the environment."""
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [RLE_HANDLER]
 
-    def teardown(self):
+    def teardown_method(self):
         """Restore the environment."""
         pydicom.config.pixel_data_handlers = self.original_handlers
 

--- a/pydicom/tests/test_uid.py
+++ b/pydicom/tests/test_uid.py
@@ -132,7 +132,7 @@ class TestGenerateUID:
 
 class TestUID:
     """Test DICOM UIDs"""
-    def setup(self):
+    def setup_method(self):
         """Set default UID"""
         self.uid = UID('1.2.840.10008.1.2')
 
@@ -348,7 +348,7 @@ class TestUID:
 
 class TestUIDPrivate:
     """Test private UIDs"""
-    def setup(self):
+    def setup_method(self):
         """Set default UID"""
         self.uid = UID('9.9.999.90009.1.2')
 

--- a/pydicom/tests/test_util.py
+++ b/pydicom/tests/test_util.py
@@ -357,7 +357,7 @@ class TestHexUtil:
 
 
 class TestDataElementCallbackTests:
-    def setup(self):
+    def setup_method(self):
         # Set up a dataset with commas in one item instead of backslash
         namespace = {}
         exec(raw_hex_code, {}, namespace)
@@ -369,7 +369,7 @@ class TestDataElementCallbackTests:
 
         self.bytesio = BytesIO(ds_bytes)
 
-    def teardown(self):
+    def teardown_method(self):
         config.reset_data_element_callback()
 
     def test_bad_separator(self, enforce_valid_values):

--- a/pydicom/tests/test_valuerep.py
+++ b/pydicom/tests/test_valuerep.py
@@ -1013,7 +1013,7 @@ class TestIS:
 class TestBadValueRead:
     """Unit tests for handling a bad value for a VR
        (a string in a number VR here)"""
-    def setup(self):
+    def setup_method(self):
         class TagLike:
             pass
 
@@ -1025,7 +1025,7 @@ class TestBadValueRead:
         self.tag.length = 2
         self.default_retry_order = pydicom.values.convert_retry_VR_order
 
-    def teardown(self):
+    def teardown_method(self):
         pydicom.values.convert_retry_VR_order = self.default_retry_order
 
     def test_read_bad_value_in_VR_default(self, disable_value_validation):
@@ -1425,10 +1425,10 @@ class TestPersonName:
 
 class TestDateTime:
     """Unit tests for DA, DT, TM conversion to datetime objects"""
-    def setup(self):
+    def setup_method(self):
         config.datetime_conversion = True
 
-    def teardown(self):
+    def teardown_method(self):
         config.datetime_conversion = False
 
     def test_date(self):


### PR DESCRIPTION
pytest 7.2 is now giving a large number of warnings about deprecated `setup` and `teardown` methods (which they say are `nose` tests and they will stop support for `nose` in future).

[Their recommendation](https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose) is to simply search/replace those names to `setup_method` and `teardown_method`, which is what this PR does.


- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
