### PR TITLE
cut LUTData to expected size

### DIFF
--- a/doc/release_notes/v2.4.0.rst
+++ b/doc/release_notes/v2.4.0.rst
@@ -37,7 +37,7 @@ Fixes
 * Fixed crash if reading regular dataset that has the SOP Class of a DICOMDIR
   (:issue:`1702`)
 * Fixed wrong waveform data calculation when as_raw=False and baseline!=0 (:issue:`1667`)
-* Fixed reading LUTData to expected size
+* Fixed reading LUTData to expected size (:pr:`1747`)
 
 Pydicom Internals
 -----------------

--- a/doc/release_notes/v2.4.0.rst
+++ b/doc/release_notes/v2.4.0.rst
@@ -37,6 +37,7 @@ Fixes
 * Fixed crash if reading regular dataset that has the SOP Class of a DICOMDIR
   (:issue:`1702`)
 * Fixed wrong waveform data calculation when as_raw=False and baseline!=0 (:issue:`1667`)
+* Fixed reading LUTData to expected size
 
 Pydicom Internals
 -----------------

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -1,7 +1,7 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Utility functions used in the pixel data handlers."""
 
-from struct import unpack, calcsize
+from struct import unpack, unpack_from
 from sys import byteorder
 from typing import (
     Dict, Optional, Union, List, Tuple, TYPE_CHECKING, cast, Iterable,
@@ -447,8 +447,7 @@ def apply_voi(
     if item['LUTData'].VR == VR.OW:
         endianness = '<' if ds.is_little_endian else '>'
         unpack_fmt = f'{endianness}{nr_entries}H'
-        size = calcsize(unpack_fmt)
-        unc_data = unpack(unpack_fmt, cast(bytes, item.LUTData[:size]))
+        unc_data = unpack_from(unpack_fmt, cast(bytes, item.LUTData))
     else:
         unc_data = cast(List[int], item.LUTData)
 

--- a/pydicom/pixel_data_handlers/util.py
+++ b/pydicom/pixel_data_handlers/util.py
@@ -1,7 +1,7 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Utility functions used in the pixel data handlers."""
 
-from struct import unpack
+from struct import unpack, calcsize
 from sys import byteorder
 from typing import (
     Dict, Optional, Union, List, Tuple, TYPE_CHECKING, cast, Iterable,
@@ -447,7 +447,8 @@ def apply_voi(
     if item['LUTData'].VR == VR.OW:
         endianness = '<' if ds.is_little_endian else '>'
         unpack_fmt = f'{endianness}{nr_entries}H'
-        unc_data = unpack(unpack_fmt, cast(bytes, item.LUTData))
+        size = calcsize(unpack_fmt)
+        unc_data = unpack(unpack_fmt, cast(bytes, item.LUTData[:size]))
     else:
         unc_data = cast(List[int], item.LUTData)
 


### PR DESCRIPTION
#### Describe the changes
During work with some customer dicom i have found one which had strange length for attribute:
(0028,3006) OW 0000\0000\0000\0000\0000\0000\0000\0000\0000\0000\0000\0000\0000... # 131072, 1 LUTData
which was rising error:
struct.error: unpack requires a buffer of 131070 bytes
This change just calcucate size for unpack

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [X] Fix or feature added
- [X] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [X] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [X] Unit tests passing and overall coverage the same or better
