### PR TITLE
[MRG] Ensure AT DataElements are encoded properly by code_dataelem

### DIFF
--- a/doc/release_notes/v2.4.0.rst
+++ b/doc/release_notes/v2.4.0.rst
@@ -38,6 +38,7 @@ Fixes
   (:issue:`1702`)
 * Fixed wrong waveform data calculation when as_raw=False and baseline!=0 (:issue:`1667`)
 * Fixed reading LUTData to expected size (:pr:`1747`)
+* Fixed handling of AT VRs when codifying data elements (:issue:`1738`)
 
 Pydicom Internals
 -----------------

--- a/pydicom/tests/test_util.py
+++ b/pydicom/tests/test_util.py
@@ -171,6 +171,12 @@ class TestCodify:
         out, err = capsys.readouterr()
         assert r"c:\temp\testout.dcm" in out
 
+    def test_code_dataelem_at(self):
+        """Test utils.codify.code_dataelem"""
+        elem = DataElement(0x00000901, 'AT', (0x1234, 0x5678))
+        out = 'ds.OffendingElement = (0x1234, 0x5678)'
+        assert out == code_dataelem(elem)
+
 
 class TestDump:
     """Test the utils.dump module"""

--- a/pydicom/util/codify.py
+++ b/pydicom/util/codify.py
@@ -121,7 +121,12 @@ def code_dataelem(
     except KeyError:
         have_keyword = False
 
-    valuerep = repr(dataelem.value)
+    # If the value representation of the data element is AT (Attribute Tag),
+    # then format it as a tag
+    if dataelem.VR == 'AT':
+        valuerep = tag_repr(dataelem.value)
+    else:
+        valuerep = repr(dataelem.value)
 
     if exclude_size:
         if (


### PR DESCRIPTION
#### Describe the changes
This PR is intended to address the issue highlighted in #1738. 

This is accomplished by checking the VR of the data element, and if it is AT (Attribute Tag), then it is a tag and should be formatted as such. Existing behavior was not modified for any other VRs.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
