### PR TITLE
[MRG] small bugfix in example pydicomtree.py

### DIFF
--- a/examples/dicomtree.py
+++ b/examples/dicomtree.py
@@ -48,7 +48,7 @@ def RunTree(w, filename):
 
 def show_file(filename, tree):
     tree.hlist.add("root", text=filename)
-    ds = pydicom.dcmread(sys.argv[1])
+    ds = pydicom.dcmread(filename)
     ds.decode()  # change strings to unicode
     recurse_tree(tree, ds, "root", False)
     tree.autosetmode()


### PR DESCRIPTION
#### Describe the changes
In the example pydicomtree.py the function show_file() did use a global variable (sys.argv access) instead of the parameter of the function. This is okay in this example but prevents reuse of the function and was probably not intended.

#### Tasks
Most of the tasks are not applicable since it's a minor change in a non-core component.
- [x] Fix added

