### PR TITLE
[MRG] Exclude CharPyLS for Python 3.11

### DIFF
--- a/.github/workflows/merge-pytest.yml
+++ b/.github/workflows/merge-pytest.yml
@@ -76,7 +76,7 @@ jobs:
         python -m pip uninstall -y pillow
 
     - name: Install and test jpeg_ls
-      if: ${{ matrix.python-version != '3.12-dev' }}
+      if: ${{ matrix.python-version != '3.11' && matrix.python-version != '3.12-dev' }}
       run: |
         python -m pip install --upgrade cython
         python -m pip install git+https://github.com/Who8MyLunch/CharPyLS
@@ -101,7 +101,7 @@ jobs:
         pytest ${{ matrix.pytest-args }} pydicom/tests/test_pylibjpeg.py
 
     - name: Test all pixel handling
-      if: ${{ matrix.python-version != '3.12-dev' }}
+      if: ${{ matrix.python-version != '3.11' && matrix.python-version != '3.12-dev' }}
       run: |
         python -m pip install pillow python-gdcm
         python -m pip install git+https://github.com/Who8MyLunch/CharPyLS

--- a/doc/old/image_data_handlers.rst
+++ b/doc/old/image_data_handlers.rst
@@ -51,8 +51,8 @@ handled by the given packages:
 
 +-------------------------------------------------------------+-------+-------------+----------+-----------------+-----------------+
 | Transfer Syntax                                             | NumPy | | NumPy +   | | NumPy +| | NumPy +       | | NumPy +       |
-+------------------------------------+------------------------+       | | JPEG-LS   | | GDCM   | | Pillow        | | pylibjpeg     |
-| Name                               | UID                    |       |             |          |                 |                 |
++------------------------------------+------------------------+       | | JPEG-LS\  | | GDCM   | | Pillow        | | pylibjpeg     |
+| Name                               | UID                    |       |  :sup:`7`   |          |                 |                 |
 +====================================+========================+=======+=============+==========+=================+=================+
 | Explicit VR Little Endian          | 1.2.840.10008.1.2.1    | |chk| | |chk|       | |chk|    |     |chk|       | |chk|           |
 +------------------------------------+------------------------+-------+-------------+----------+-----------------+-----------------+
@@ -92,6 +92,7 @@ handled by the given packages:
 | :sup:`4` *with the pylibjpeg-rle plugin and using the* :meth:`~pydicom.dataset.Dataset.decompress` *method, 4-5x faster than default*
 | :sup:`5` *with the pylibjpeg-libjpeg plugin*
 | :sup:`6` *with the pylibjpeg-openjpeg plugin*
+| :sup:`7` *only up to Python 3.10*
 
 Usage
 .....

--- a/doc/release_notes/v2.4.0.rst
+++ b/doc/release_notes/v2.4.0.rst
@@ -44,3 +44,4 @@ Pydicom Internals
 -----------------
 * In test suites, renamed 'setup' and 'teardown' methods, deprecated starting
   in pytest 7.2
+* Do not try to use `CharPyLS` with Python > 3.10 (:issue:`1788`)


### PR DESCRIPTION
- does not compile, see #1788

For the time being, just exclude JPEG-LS builds for Python > 3.10 and add a note in the transfer syntax table.


#### Tasks
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
