### PR TITLE
[MRG] Use wheel packages to install pyjpegls

### DIFF
--- a/.github/workflows/merge-pytest.yml
+++ b/.github/workflows/merge-pytest.yml
@@ -77,8 +77,7 @@ jobs:
 
     - name: Install and test jpeg_ls
       run: |
-        python -m pip install --upgrade cython
-        python -m pip install git+https://github.com/pydicom/pyjpegls
+        python -m pip install pyjpegls
         
         pytest ${{ matrix.pytest-args }} pydicom/tests/test_jpeg_ls_pixel_data.py pydicom/tests/test_JPEG_LS_transfer_syntax.py
         python -m pip uninstall -y pyjpegls
@@ -101,8 +100,7 @@ jobs:
 
     - name: Test all pixel handling
       run: |
-        python -m pip install pillow python-gdcm
-        python -m pip install git+https://github.com/pydicom/pyjpegls
+        python -m pip install pillow python-gdcm pyjpegls
         pytest ${{ matrix.pytest-args }}
 
     - name: Send coverage results

--- a/.github/workflows/pr-pytest.yml
+++ b/.github/workflows/pr-pytest.yml
@@ -154,8 +154,7 @@ jobs:
 
     - name: Install and test jpeg_ls
       run: |
-        python -m pip install --upgrade cython
-        python -m pip install git+https://github.com/pydicom/pyjpegls
+        python -m pip install pyjpegls
         pytest ${{ matrix.pytest-args }} pydicom/tests/test_JPEG_LS_transfer_syntax.py pydicom/tests/test_jpeg_ls_pixel_data.py
         python -m pip uninstall -y pyjpegls
 
@@ -177,8 +176,7 @@ jobs:
 
     - name: Test all pixel handling
       run: |
-        python -m pip install --upgrade pillow python-gdcm
-        python -m pip install git+https://github.com/pydicom/pyjpegls
+        python -m pip install --upgrade pillow python-gdcm pyjpegls
         pytest ${{ matrix.pytest-args }}
 
     - name: Send coverage results

--- a/doc/tutorials/installation.rst
+++ b/doc/tutorials/installation.rst
@@ -119,8 +119,7 @@ created to provide compatibility with the latest Python versions.
 
 Using pip::
 
-  pip install cython
-  pip install git+https://github.com/pydicom/pyjpegls
+  pip install pyjpegls
 
 Through conda::
 


### PR DESCRIPTION
- avoids having to build it using cython

The last `pyjpegls` related PR for now, I promise! 

#### Tasks
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [x] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
