### PR TITLE
[WIP] Add possibility to switch off use of external data in tests

### DIFF
--- a/benchmarks/bench_encaps.py
+++ b/benchmarks/bench_encaps.py
@@ -1,8 +1,8 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Benchmarks for the encaps module."""
+import pytest
 
 from pydicom import dcmread
-from pydicom.data import get_testdata_file
 from pydicom.encaps import (
     fragment_frame,
     itemise_frame,
@@ -11,14 +11,12 @@ from pydicom.encaps import (
 )
 
 
-JP2K_10FRAME = get_testdata_file('emri_small_jpeg_2k_lossless.dcm')
-
-
 class TimeFragmentFrame:
     """Time tests for the encaps.fragment_frame function."""
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, emri_jpeg_2k_lossless_name):
         """Setup the test"""
-        ds = dcmread(JP2K_10FRAME)
+        ds = dcmread(emri_jpeg_2k_lossless_name)
         self.test_data = decode_data_sequence(ds.PixelData)
         assert len(self.test_data) == 10
         self.no_runs = 1000
@@ -38,9 +36,10 @@ class TimeFragmentFrame:
 
 class TimeItemiseFrame:
     """Time tests for the encaps.itemise_frame function."""
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, emri_jpeg_2k_lossless_name):
         """Setup the test"""
-        ds = dcmread(JP2K_10FRAME)
+        ds = dcmread(emri_jpeg_2k_lossless_name)
         self.test_data = decode_data_sequence(ds.PixelData)
         assert len(self.test_data) == 10
         self.no_runs = 1000
@@ -60,9 +59,10 @@ class TimeItemiseFrame:
 
 class TimeEncapsulate:
     """Time tests for the encaps.encapsulate function."""
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, emri_jpeg_2k_lossless_name):
         """Setup the test"""
-        ds = dcmread(JP2K_10FRAME)
+        ds = dcmread(emri_jpeg_2k_lossless_name)
         self.test_data = decode_data_sequence(ds.PixelData)
         assert len(self.test_data) == 10
         self.no_runs = 1000

--- a/benchmarks/bench_handler_numpy.py
+++ b/benchmarks/bench_handler_numpy.py
@@ -8,6 +8,7 @@ from platform import python_implementation
 from tempfile import TemporaryFile
 
 import numpy as np
+import pytest
 
 from pydicom import dcmread
 from pydicom.data import get_testdata_file
@@ -18,35 +19,33 @@ from pydicom.pixel_data_handlers.numpy_handler import (
 from pydicom.uid import ExplicitVRLittleEndian, generate_uid
 
 # 1/1, 1 sample/pixel, 1 frame
-EXPL_1_1_1F = get_testdata_file("liver_1frame.dcm")
+EXPL_1_1_1F = "liver_1frame.dcm"
 # 1/1, 1 sample/pixel, 3 frame
-EXPL_1_1_3F = get_testdata_file("liver.dcm")
+EXPL_1_1_3F = "liver.dcm"
 # 8/8, 1 sample/pixel, 1 frame
-EXPL_8_1_1F = get_testdata_file("OBXXXX1A.dcm")
+EXPL_8_1_1F = "OBXXXX1A.dcm"
 # 8/8, 1 sample/pixel, 2 frame
-EXPL_8_1_2F = get_testdata_file("OBXXXX1A_2frame.dcm")
+EXPL_8_1_2F = "OBXXXX1A_2frame.dcm"
 # 8/8, 3 sample/pixel, 1 frame
-EXPL_8_3_1F = get_testdata_file("SC_rgb.dcm")
+EXPL_8_3_1F = "SC_rgb.dcm"
 # 8/8, 3 sample/pixel, 1 frame, YBR_FULL_422
-EXPL_8_3_1F_YBR422 = get_testdata_file('SC_ybr_full_422_uncompressed.dcm')
-# 8/8, 3 sample/pixel, 2 frame
-EXPL_8_3_2F = get_testdata_file("SC_rgb_2frame.dcm")
+EXPL_8_3_1F_YBR422 = 'SC_ybr_full_422_uncompressed.dcm'
 # 16/16, 1 sample/pixel, 1 frame
-EXPL_16_1_1F = get_testdata_file("MR_small.dcm")
+EXPL_16_1_1F = "MR_small.dcm"
 # 16/12, 1 sample/pixel, 10 frame
-EXPL_16_1_10F = get_testdata_file("emri_small.dcm")
+EXPL_16_1_10F = "emri_small.dcm"
 # 16/16, 3 sample/pixel, 1 frame
-EXPL_16_3_1F = get_testdata_file("SC_rgb_16bit.dcm")
+EXPL_16_3_1F = "SC_rgb_16bit.dcm"
 # 16/16, 3 sample/pixel, 2 frame
-EXPL_16_3_2F = get_testdata_file("SC_rgb_16bit_2frame.dcm")
+EXPL_16_3_2F = "SC_rgb_16bit_2frame.dcm"
 # 32/32, 1 sample/pixel, 1 frame
-IMPL_32_1_1F = get_testdata_file("rtdose_1frame.dcm")
+IMPL_32_1_1F = "rtdose_1frame.dcm"
 # 32/32, 1 sample/pixel, 15 frame
-IMPL_32_1_15F = get_testdata_file("rtdose.dcm")
+IMPL_32_1_15F = "rtdose.dcm"
 # 32/32, 3 sample/pixel, 1 frame
-EXPL_32_3_1F = get_testdata_file("SC_rgb_32bit.dcm")
+EXPL_32_3_1F = "SC_rgb_32bit.dcm"
 # 32/32, 3 sample/pixel, 2 frame
-EXPL_32_3_2F = get_testdata_file("SC_rgb_32bit_2frame.dcm")
+EXPL_32_3_2F = "SC_rgb_32bit_2frame.dcm"
 
 
 def _create_temporary_dataset(shape=(100, 1024, 1024, 3), bit_depth=16):
@@ -98,6 +97,7 @@ def _create_temporary_dataset(shape=(100, 1024, 1024, 3), bit_depth=16):
 
 class TimeGetPixelData_LargeDataset:
     """Time tests for numpy_handler.get_pixeldata with large datasets."""
+    @pytest.fixture(autouse=True)
     def setup(self):
         """Setup the tests."""
         self.no_runs = 100
@@ -112,25 +112,26 @@ class TimeGetPixelData_LargeDataset:
 
 class TimeGetPixelData:
     """Time tests for numpy_handler.get_pixeldata."""
-    def setup(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, rgb_8bit_2frames_name):
         """Setup the tests."""
         self.no_runs = 100
 
-        self.ds_1_1_1 = dcmread(EXPL_1_1_1F)
-        self.ds_1_1_3 = dcmread(EXPL_1_1_3F)
-        self.ds_8_1_1 = dcmread(EXPL_8_1_1F)
-        self.ds_8_1_2 = dcmread(EXPL_8_1_2F)
-        self.ds_8_3_1 = dcmread(EXPL_8_3_1F)
-        self.ds_8_3_2 = dcmread(EXPL_8_3_2F)
-        self.ds_16_1_1 = dcmread(EXPL_16_1_1F)
-        self.ds_16_1_10 = dcmread(EXPL_16_1_10F)
-        self.ds_16_3_1 = dcmread(EXPL_16_3_1F)
-        self.ds_16_3_2 = dcmread(EXPL_16_3_2F)
-        self.ds_32_1_1 = dcmread(IMPL_32_1_1F)
-        self.ds_32_1_15 = dcmread(IMPL_32_1_15F)
-        self.ds_32_3_1 = dcmread(EXPL_32_3_1F)
-        self.ds_32_3_2 = dcmread(EXPL_32_3_2F)
-        self.ds_ybr_422 = dcmread(EXPL_8_3_1F_YBR422)
+        self.ds_1_1_1 = dcmread(get_testdata_file(EXPL_1_1_1F))
+        self.ds_1_1_3 = dcmread(get_testdata_file(EXPL_1_1_3F))
+        self.ds_8_1_1 = dcmread(get_testdata_file(EXPL_8_1_1F))
+        self.ds_8_1_2 = dcmread(get_testdata_file(EXPL_8_1_2F))
+        self.ds_8_3_1 = dcmread(get_testdata_file(EXPL_8_3_1F))
+        self.ds_8_3_2 = dcmread(rgb_8bit_2frames_name)
+        self.ds_16_1_1 = dcmread(get_testdata_file(EXPL_16_1_1F))
+        self.ds_16_1_10 = dcmread(get_testdata_file(EXPL_16_1_10F))
+        self.ds_16_3_1 = dcmread(get_testdata_file(EXPL_16_3_1F))
+        self.ds_16_3_2 = dcmread(get_testdata_file(EXPL_16_3_2F))
+        self.ds_32_1_1 = dcmread(get_testdata_file(IMPL_32_1_1F))
+        self.ds_32_1_15 = dcmread(get_testdata_file(IMPL_32_1_15F))
+        self.ds_32_3_1 = dcmread(get_testdata_file(EXPL_32_3_1F))
+        self.ds_32_3_2 = dcmread(get_testdata_file(EXPL_32_3_2F))
+        self.ds_ybr_422 = dcmread(get_testdata_file(EXPL_8_3_1F_YBR422))
 
     def time_1bit_1sample_1frame(self):
         """Time retrieval of 1-bit, 1 sample/pixel, 1 frame."""
@@ -217,10 +218,11 @@ class TimeGetPixelData:
 
 
 class TimePackUnpack:
+    @pytest.fixture(autouse=True)
     def setup(self):
         """Setup the tests."""
         self.no_runs = 100
-        self.ds_1_1_1 = dcmread(EXPL_1_1_1F)
+        self.ds_1_1_1 = dcmread(get_testdata_file(EXPL_1_1_1F))
         self.unpacked = unpack_bits(self.ds_1_1_1.PixelData)
 
     def time_unpack(self):

--- a/benchmarks/bench_nested_seq.py
+++ b/benchmarks/bench_nested_seq.py
@@ -47,9 +47,6 @@ class TimeNestedSeqAccess:
     len_top_sequence = 2000
     dataset = create_nested_test_seq(len_top_sequence)
 
-    def setup(self):
-        pass
-
     def time_iterate_nested_elems(self):
         for func_gp in self.dataset.PerFrameFunctionalGroupsSequence:
             pps_item = func_gp.PlanePositionSequence[0]

--- a/benchmarks/bench_pixel_util.py
+++ b/benchmarks/bench_pixel_util.py
@@ -2,18 +2,16 @@
 """Benchmarks for the pixel data utilities."""
 
 import numpy as np
+import pytest
 
 from pydicom import dcmread
 from pydicom.data import get_testdata_file
 from pydicom.pixel_data_handlers.util import convert_color_space
 
 
-# 32/32, 3 sample/pixel, 2 frame
-EXPL_32_3_2F = get_testdata_file("SC_rgb_32bit_2frame.dcm")
-
-
 class TimeConvertColorSpace:
     """Benchmarks for utils.convert_color_space()."""
+    @pytest.fixture(autouse=True)
     def setup(self):
         """Setup the benchmark."""
         self.no_runs = 1000
@@ -24,7 +22,7 @@ class TimeConvertColorSpace:
         self.ybr_full = ds.pixel_array
 
         self.arr_large = np.ones((10, 1024, 1024, 3), dtype=np.uint8)
-        self.arr_32_3_2f = dcmread(EXPL_32_3_2F).pixel_array
+        self.arr_32_3_2f = dcmread(get_testdata_file("SC_rgb_32bit_2frame.dcm")).pixel_array
 
     def time_rgb_ybr(self):
         """Time converting from RGB to YBR color space."""

--- a/benchmarks/bench_rle_decode.py
+++ b/benchmarks/bench_rle_decode.py
@@ -1,5 +1,6 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Decoding benchmarks for the rle_handler module."""
+import pytest
 
 from pydicom import dcmread
 from pydicom.data import get_testdata_file
@@ -11,36 +12,37 @@ from pydicom.pixel_data_handlers.rle_handler import (
 
 
 # 8/8-bit, 1 sample/pixel, 1 frame
-OB_RLE_1F = get_testdata_file("OBXXXX1A_rle.dcm")
+OB_RLE_1F = "OBXXXX1A_rle.dcm"
 # 8/8-bit, 1 sample/pixel, 2 frame
-OB_RLE_2F = get_testdata_file("OBXXXX1A_rle_2frame.dcm")
+OB_RLE_2F = "OBXXXX1A_rle_2frame.dcm"
 # 8/8-bit, 3 sample/pixel, 1 frame
-SC_RLE_1F = get_testdata_file("SC_rgb_rle.dcm")
+SC_RLE_1F = "SC_rgb_rle.dcm"
 # 8/8-bit, 3 sample/pixel, 2 frame
-SC_RLE_2F = get_testdata_file("SC_rgb_rle_2frame.dcm")
+SC_RLE_2F = "SC_rgb_rle_2frame.dcm"
 # 16/16-bit, 1 sample/pixel, 1 frame
-MR_RLE_1F = get_testdata_file("MR_small_RLE.dcm")
+MR_RLE_1F = "MR_small_RLE.dcm"
 # 16/16-bit, 3 sample/pixel, 1 frame
-SC_RLE_16_1F = get_testdata_file("SC_rgb_rle_16bit.dcm")
+SC_RLE_16_1F = "SC_rgb_rle_16bit.dcm"
 # 16/16-bit, 3 sample/pixel, 2 frame
-SC_RLE_16_2F = get_testdata_file("SC_rgb_rle_16bit_2frame.dcm")
+SC_RLE_16_2F = "SC_rgb_rle_16bit_2frame.dcm"
 # 16/12-bit, 1 sample/pixel, 10 frame
-EMRI_RLE_10F = get_testdata_file("emri_small_RLE.dcm")
+EMRI_RLE_10F = "emri_small_RLE.dcm"
 # 32/32-bit, 1 sample/pixel, 1 frame
-RTDOSE_RLE_1F = get_testdata_file("rtdose_rle_1frame.dcm")
+RTDOSE_RLE_1F = "rtdose_rle_1frame.dcm"
 # 32/32-bit, 3 sample/pixel, 1 frame
-SC_RLE_32_1F = get_testdata_file("SC_rgb_rle_32bit.dcm")
+SC_RLE_32_1F = "SC_rgb_rle_32bit.dcm"
 # 32/32-bit, 3 sample/pixel, 2 frame
-SC_RLE_32_2F = get_testdata_file("SC_rgb_rle_32bit_2frame.dcm")
+SC_RLE_32_2F = "SC_rgb_rle_32bit_2frame.dcm"
 # 32/32-bit, 1 sample/pixel, 15 frame
-RTDOSE_RLE_15F = get_testdata_file("rtdose_rle.dcm")
+RTDOSE_RLE_15F = "rtdose_rle.dcm"
 
 
 class TimeRLEDecodeFrame:
     """Time tests for rle_handler._rle_decode_frame."""
+    @pytest.fixture(autouse=True)
     def setup(self):
         # MONOCHROME2, 64x64, 1 sample/pixel, 16 bits allocated, 12 bits stored
-        self.ds = dcmread(EMRI_RLE_10F)
+        self.ds = dcmread(get_testdata_file(EMRI_RLE_10F))
         self.frames = decode_data_sequence(self.ds.PixelData)
         assert len(self.frames) == 10
 
@@ -68,14 +70,15 @@ class TimeRLEDecodeFrame:
 
 class TimeGetPixelData:
     """Time tests for rle_handler.get_pixeldata."""
+    @pytest.fixture(autouse=True)
     def setup(self):
         """Setup the test"""
-        self.ds_8_1_1 = dcmread(OB_RLE_1F)
-        self.ds_8_3_1 = dcmread(SC_RLE_1F)
-        self.ds_16_1_1 = dcmread(MR_RLE_1F)
-        self.ds_16_3_1 = dcmread(SC_RLE_16_1F)
-        self.ds_32_1_1 = dcmread(RTDOSE_RLE_1F)
-        self.ds_32_3_1 = dcmread(SC_RLE_32_1F)
+        self.ds_8_1_1 = dcmread(get_testdata_file(OB_RLE_1F))
+        self.ds_8_3_1 = dcmread(get_testdata_file(SC_RLE_1F))
+        self.ds_16_1_1 = dcmread(get_testdata_file(MR_RLE_1F))
+        self.ds_16_3_1 = dcmread(get_testdata_file(SC_RLE_16_1F))
+        self.ds_32_1_1 = dcmread(get_testdata_file(RTDOSE_RLE_1F))
+        self.ds_32_3_1 = dcmread(get_testdata_file(SC_RLE_32_1F))
 
         self.no_runs = 100
 

--- a/benchmarks/bench_rle_encode.py
+++ b/benchmarks/bench_rle_encode.py
@@ -1,5 +1,6 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Encoding benchmarks for the rle_handler module."""
+import pytest
 
 from pydicom import dcmread
 from pydicom.data import get_testdata_file
@@ -8,33 +9,34 @@ from pydicom.uid import RLELossless
 
 
 # 8/8-bit, 1 sample/pixel, 1 frame
-EXPL_8_1_1F = get_testdata_file("OBXXXX1A.dcm")
+EXPL_8_1_1F = "OBXXXX1A.dcm"
 # 8/8-bit, 3 sample/pixel, 1 frame
-EXPL_8_3_1F = get_testdata_file("SC_rgb.dcm")
+EXPL_8_3_1F = "SC_rgb.dcm"
 # 16/16-bit, 1 sample/pixel, 1 frame
-EXPL_16_1_1F = get_testdata_file("MR_small.dcm")
+EXPL_16_1_1F = "MR_small.dcm"
 # 16/16-bit, 3 sample/pixel, 1 frame
-EXPL_16_3_1F = get_testdata_file("SC_rgb_16bit.dcm")
+EXPL_16_3_1F = "SC_rgb_16bit.dcm"
 # 32/32-bit, 1 sample/pixel, 1 frame
-EXPL_32_1_1F = get_testdata_file("rtdose_1frame.dcm")
+EXPL_32_1_1F = "rtdose_1frame.dcm"
 # 32/32-bit, 3 sample/pixel, 1 frame
-EXPL_32_3_1F = get_testdata_file("SC_rgb_32bit.dcm")
+EXPL_32_3_1F = "SC_rgb_32bit.dcm"
 
 
 class TimeRLEEncodeFrame:
     """Time tests for rle_handler.rle_encode_frame."""
+    @pytest.fixture(autouse=True)
     def setup(self):
-        ds = dcmread(EXPL_8_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_8_1_1F))
         self.arr8_1 = ds.pixel_array
-        ds = dcmread(EXPL_8_3_1F)
+        ds = dcmread(get_testdata_file(EXPL_8_3_1F))
         self.arr8_3 = ds.pixel_array
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         self.arr16_1 = ds.pixel_array
-        ds = dcmread(EXPL_16_3_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_3_1F))
         self.arr16_3 = ds.pixel_array
-        ds = dcmread(EXPL_32_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_32_1_1F))
         self.arr32_1 = ds.pixel_array
-        ds = dcmread(EXPL_32_3_1F)
+        ds = dcmread(get_testdata_file(EXPL_32_3_1F))
         self.arr32_3 = ds.pixel_array
 
         self.no_runs = 100
@@ -73,9 +75,10 @@ class TimeRLEEncodeFrame:
 # Requires numpy, pylibjpeg, pylibjpeg-rle and python-gdcm
 class TimeDatasetCompress:
     """Test Dataset.compress()."""
+    @pytest.fixture(autouse=True)
     def setup(self):
         # More real-world like dataset
-        self.ds = dcmread(EXPL_8_1_1F)
+        self.ds = dcmread(get_testdata_file(EXPL_8_1_1F))
         self.arr8_1 = self.ds.pixel_array
 
         self.no_runs = 1000

--- a/pydicom/data/data_manager.py
+++ b/pydicom/data/data_manager.py
@@ -44,7 +44,6 @@ And lastly, `pattern` is a str used to filter files against when searching.
 For a real-life example of an external data source you can look at the
 `pydicom-data <https://github.com/pydicom/pydicom-data>`_ repository.
 """
-
 from enum import IntEnum
 import fnmatch
 import os
@@ -338,6 +337,14 @@ def _get_testdata_file(name: str, download: bool = True) -> Optional[str]:
     matches = [m for m in data_path.rglob(name)]
     if matches:
         return os.fspath(matches[0])
+
+    if os.getenv("NO_EXTERNAL_DATA") == "1":
+        try:
+            import pytest
+            pytest.skip("Not testing external data files")
+        except ImportError:
+            # ignore if not in test context
+            pass
 
     # Check external data sources
     fpath: Optional[str]

--- a/pydicom/tests/conftest.py
+++ b/pydicom/tests/conftest.py
@@ -4,6 +4,7 @@
 
 import pytest
 from pydicom import config
+from pydicom.data import get_testdata_file
 
 
 @pytest.fixture
@@ -93,3 +94,120 @@ def raise_on_writing_invalid_value():
 def disable_value_validation():
     with config.disable_value_validation():
         yield
+
+
+# fixtures for often used testdata file names
+
+@pytest.fixture(scope="session")
+def ct_name():
+    yield get_testdata_file("CT_small.dcm")
+
+
+@pytest.fixture(scope="session")
+def mr_name():
+    yield get_testdata_file("MR_small.dcm")
+
+
+@pytest.fixture(scope="module")
+def mr_implicit_name():
+    yield get_testdata_file("MR_small_implicit.dcm")
+
+
+@pytest.fixture(scope="session")
+def rle_mr_name():
+    yield get_testdata_file("MR_small_RLE.dcm")
+
+
+@pytest.fixture(scope="session")
+def rtplan_name():
+    yield get_testdata_file("rtplan.dcm")
+
+
+@pytest.fixture(scope="session")
+def rtdose_name():
+    yield get_testdata_file("rtdose.dcm")
+
+
+@pytest.fixture(scope="session")
+def rtstruct_name():
+    yield get_testdata_file("rtstruct.dcm")
+
+
+@pytest.fixture(scope="session")
+def truncated_mr_name():
+    yield get_testdata_file("MR_truncated.dcm")
+
+
+@pytest.fixture(scope="session")
+def jpeg2000_name():
+    yield get_testdata_file("JPEG2000.dcm")
+
+
+@pytest.fixture(scope="session")
+def jpeg2000_lossless_name():
+    yield get_testdata_file("MR_small_jp2klossless.dcm")
+
+
+@pytest.fixture(scope="session")
+def jpeg_ls_lossless_name():
+    yield get_testdata_file("MR_small_jpeg_ls_lossless.dcm")
+
+
+@pytest.fixture(scope="session")
+def jpeg_lossy_name():
+    yield get_testdata_file("JPEG-lossy.dcm")
+
+
+@pytest.fixture(scope="session")
+def jpeg_lossless_name():
+    yield get_testdata_file("JPEG-LL.dcm")
+
+
+@pytest.fixture(scope="session")
+def emri_jpeg_ls_lossless_name():
+    yield get_testdata_file("emri_small_jpeg_ls_lossless.dcm")
+
+
+@pytest.fixture(scope="session")
+def emri_jpeg_2k_lossless_name():
+    yield get_testdata_file("emri_small_jpeg_2k_lossless.dcm")
+
+
+@pytest.fixture(scope="session")
+def color_3d_jpeg_baseline_name():
+    yield get_testdata_file("color3d_jpeg_baseline.dcm")
+
+
+@pytest.fixture(scope="session")
+def deflate_name():
+    yield get_testdata_file("image_dfl.dcm")
+
+
+@pytest.fixture(scope="session")
+def color_pl_name():
+    yield get_testdata_file("color-pl.dcm")
+
+
+@pytest.fixture(scope="session")
+def emri_name():
+    yield get_testdata_file("emri_small.dcm")
+
+
+@pytest.fixture(scope="session")
+def sc_rgb_name():
+    yield get_testdata_file("SC_rgb.dcm")
+
+
+@pytest.fixture(scope="session")
+def mono_8bit_1frame_name():
+    yield get_testdata_file("OBXXXX1A.dcm")
+
+
+@pytest.fixture(scope="session")
+def rgb_32bit_expl_name():
+    yield get_testdata_file("SC_rgb_32bit.dcm")
+
+
+@pytest.fixture(scope="session")
+def rgb_8bit_2frames_name():
+    yield get_testdata_file("SC_rgb_2frame.dcm")

--- a/pydicom/tests/test_JPEG_LS_transfer_syntax.py
+++ b/pydicom/tests/test_JPEG_LS_transfer_syntax.py
@@ -49,25 +49,24 @@ except ImportError:
     gdcm_handler = None
     HAVE_GDCM = False
 
-mr_name = get_testdata_file("MR_small.dcm")
-jpeg_ls_lossless_name = get_testdata_file("MR_small_jpeg_ls_lossless.dcm")
-emri_name = get_testdata_file("emri_small.dcm")
-emri_jpeg_ls_lossless = get_testdata_file(
-    "emri_small_jpeg_ls_lossless.dcm")
+
 dir_name = os.path.dirname(sys.argv[0])
 save_dir = os.getcwd()
 
 
-class Test_JPEG_LS_Lossless_transfer_syntax():
-    def setup_method(self, method):
-        self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
-        self.mr_small = dcmread(mr_name)
-        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
-        self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.pixel_data_handlers
+class Test_JPEG_LS_Lossless_transfer_syntax:
 
-    def teardown_method(self, method):
-        pydicom.config.pixel_data_handlers = self.original_handlers
+    @pytest.fixture(autouse=True)
+    def setup(self, mr_name, emri_jpeg_ls_lossless_name):
+        self.jpeg_ls_lossless = dcmread(get_testdata_file(
+            "MR_small_jpeg_ls_lossless.dcm")
+        )
+        self.mr_small = dcmread(mr_name)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless_name)
+        self.emri_small = dcmread(get_testdata_file("emri_small.dcm"))
+        original_handlers = pydicom.config.pixel_data_handlers
+        yield
+        pydicom.config.pixel_data_handlers = original_handlers
 
     @pytest.mark.skipif(not HAVE_NP, reason=numpy_missing_message)
     def test_read_mr_with_numpy(self):

--- a/pydicom/tests/test_dataset.py
+++ b/pydicom/tests/test_dataset.py
@@ -1883,9 +1883,9 @@ class TestFileDataset:
         assert '/some/path/to/test' == fds.filename
 
     @pytest.mark.skipif(not HAVE_NP, reason="Numpy not available")
-    def test_with_array(self):
+    def test_with_array(self, ct_name):
         """Test Dataset within a numpy array"""
-        ds = get_testdata_file("CT_small.dcm", read=True)
+        ds = dcmread(ct_name)
         arr = numpy.array([ds])
         assert arr[0].PatientName == ds.PatientName
         assert arr.dtype == object

--- a/pydicom/tests/test_encaps.py
+++ b/pydicom/tests/test_encaps.py
@@ -24,7 +24,9 @@ from pydicom.encaps import (
 from pydicom.filebase import DicomBytesIO
 
 
-JP2K_10FRAME_NOBOT = get_testdata_file('emri_small_jpeg_2k_lossless.dcm')
+@pytest.fixture
+def jp2k_10frame_nobot_name():
+    return get_testdata_file('emri_small_jpeg_2k_lossless.dcm')
 
 
 class TestGetFrameOffsets:
@@ -472,10 +474,10 @@ class TestGeneratePixelDataFrames:
         assert next(frames) == b'\x03\x00\x00\x00\x02\x04'
         pytest.raises(StopIteration, next, frames)
 
-    def test_empty_bot_multi_fragments_per_frame(self):
+    def test_empty_bot_multi_fragments_per_frame(self, jp2k_10frame_nobot_name):
         """Test multi-frame where multiple frags per frame and no BOT."""
         # Regression test for #685
-        ds = dcmread(JP2K_10FRAME_NOBOT)
+        ds = dcmread(jp2k_10frame_nobot_name)
         assert 10 == ds.NumberOfFrames
         frame_gen = generate_pixel_data_frame(ds.PixelData, ds.NumberOfFrames)
         for ii in range(10):
@@ -541,9 +543,9 @@ class TestGeneratePixelData:
         with pytest.raises(ValueError, match=msg):
             next(generate_pixel_data(bytestream))
 
-    def test_empty_bot_too_few_fragments(self):
+    def test_empty_bot_too_few_fragments(self, jp2k_10frame_nobot_name):
         """Test parsing with too few fragments."""
-        ds = dcmread(JP2K_10FRAME_NOBOT)
+        ds = dcmread(jp2k_10frame_nobot_name)
         assert 10 == ds.NumberOfFrames
 
         msg = (
@@ -1137,9 +1139,10 @@ class TestEncapsulateFrame:
 
 class TestEncapsulate:
     """Test encaps.encapsulate."""
-    def test_encapsulate_single_fragment_per_frame_no_bot(self):
+    def test_encapsulate_single_fragment_per_frame_no_bot(
+            self, jp2k_10frame_nobot_name):
         """Test encapsulating single fragment per frame with no BOT values."""
-        ds = dcmread(JP2K_10FRAME_NOBOT)
+        ds = dcmread(jp2k_10frame_nobot_name)
         frames = decode_data_sequence(ds.PixelData)
         assert len(frames) == 10
 
@@ -1151,9 +1154,9 @@ class TestEncapsulate:
         # Original data has no BOT values
         assert data == ds.PixelData
 
-    def test_encapsulate_single_fragment_per_frame_bot(self):
+    def test_encapsulate_single_fragment_per_frame_bot(self, jp2k_10frame_nobot_name):
         """Test encapsulating single fragment per frame with BOT values."""
-        ds = dcmread(JP2K_10FRAME_NOBOT)
+        ds = dcmread(jp2k_10frame_nobot_name)
         frames = decode_data_sequence(ds.PixelData)
         assert len(frames) == 10
 
@@ -1178,9 +1181,9 @@ class TestEncapsulate:
             0x8594  # 34196
         ]
 
-    def test_encapsulate_bot(self):
+    def test_encapsulate_bot(self, jp2k_10frame_nobot_name):
         """Test the Basic Offset Table is correct."""
-        ds = dcmread(JP2K_10FRAME_NOBOT)
+        ds = dcmread(jp2k_10frame_nobot_name)
         frames = decode_data_sequence(ds.PixelData)
         assert len(frames) == 10
 
@@ -1231,8 +1234,8 @@ class TestEncapsulate:
 
 class TestEncapsulateExtended:
     """Tests for encaps.encapsulate_extended."""
-    def test_encapsulate(self):
-        ds = dcmread(JP2K_10FRAME_NOBOT)
+    def test_encapsulate(self, jp2k_10frame_nobot_name):
+        ds = dcmread(jp2k_10frame_nobot_name)
         frames = decode_data_sequence(ds.PixelData)
         assert len(frames) == 10
 

--- a/pydicom/tests/test_encoders_gdcm.py
+++ b/pydicom/tests/test_encoders_gdcm.py
@@ -21,21 +21,13 @@ except ImportError:
     HAVE_GDCM = False
     GDCM_VERSION = [0, 0, 0]
 
-# EXPL: Explicit VR Little Endian
-EXPL_8_1_1F = get_testdata_file("OBXXXX1A.dcm")
-EXPL_8_3_1F = get_testdata_file("SC_rgb.dcm")
-EXPL_16_1_1F = get_testdata_file("MR_small.dcm")
-EXPL_16_3_1F = get_testdata_file("SC_rgb_16bit.dcm")
-EXPL_32_1_1F = get_testdata_file("rtdose_1frame.dcm")
-EXPL_32_3_1F = get_testdata_file("SC_rgb_32bit.dcm")
-
 
 @pytest.mark.skipif(not HAVE_GDCM, reason='GDCM plugin is not available')
 class TestRLELossless:
     """Tests for encoding RLE Lossless."""
-    def test_cycle_u8_1s_1f(self):
+    def test_cycle_u8_1s_1f(self, mono_8bit_1frame_name):
         """Test an encode/decode cycle for 8-bit 1 sample/pixel."""
-        ds = dcmread(EXPL_8_1_1F)
+        ds = dcmread(mono_8bit_1frame_name)
         ref = ds.pixel_array
         assert ds.BitsAllocated == 8
         assert ds.SamplesPerPixel == 1
@@ -53,7 +45,7 @@ class TestRLELossless:
 
     def test_cycle_u8_3s_1f(self):
         """Test an encode/decode cycle for 8-bit 3 sample/pixel."""
-        ds = dcmread(EXPL_8_3_1F)
+        ds = dcmread(get_testdata_file("SC_rgb.dcm"))
         ref = ds.pixel_array
         assert ds.BitsAllocated == 8
         assert ds.SamplesPerPixel == 3
@@ -75,7 +67,7 @@ class TestRLELossless:
 
     def test_cycle_i16_1s_1f(self):
         """Test an encode/decode cycle for 16-bit 1 sample/pixel."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file("MR_small.dcm"))
         ref = ds.pixel_array
         assert ds.BitsAllocated == 16
         assert ds.SamplesPerPixel == 1
@@ -95,7 +87,7 @@ class TestRLELossless:
 
     def test_cycle_u16_3s_1f(self):
         """Test an encode/decode cycle for 16-bit 3 sample/pixel."""
-        ds = dcmread(EXPL_16_3_1F)
+        ds = dcmread(get_testdata_file("SC_rgb_16bit.dcm"))
         ref = ds.pixel_array
         assert ds.BitsAllocated == 16
         assert ds.SamplesPerPixel == 3
@@ -117,7 +109,7 @@ class TestRLELossless:
 
     def test_cycle_u32_1s_1f(self):
         """Test an encode/decode cycle for 32-bit 1 sample/pixel."""
-        ds = dcmread(EXPL_32_1_1F)
+        ds = dcmread(get_testdata_file("rtdose_1frame.dcm"))
         ref = ds.pixel_array
         assert ds.BitsAllocated == 32
         assert ds.SamplesPerPixel == 1
@@ -136,9 +128,9 @@ class TestRLELossless:
         assert np.array_equal(ref, arr)
 
     @pytest.mark.skipif(GDCM_VERSION < [3, 0, 10], reason="GDCM bug")
-    def test_cycle_u32_3s_1f(self):
+    def test_cycle_u32_3s_1f(self, rgb_32bit_expl_name):
         """Test an encode/decode cycle for 32-bit 3 sample/pixel."""
-        ds = dcmread(EXPL_32_3_1F)
+        ds = dcmread(rgb_32bit_expl_name)
         ref = ds.pixel_array
         assert ds.BitsAllocated == 32
         assert ds.SamplesPerPixel == 3
@@ -160,9 +152,9 @@ class TestRLELossless:
         assert np.array_equal(ref, arr)
 
     @pytest.mark.skipif(GDCM_VERSION >= [3, 0, 10], reason="GDCM bug fixed")
-    def test_cycle_u32_3s_1f_raises(self):
+    def test_cycle_u32_3s_1f_raises(self, rgb_32bit_expl_name):
         """Test that 32-bit, 3 sample/px data raises exception."""
-        ds = dcmread(EXPL_32_3_1F)
+        ds = dcmread(rgb_32bit_expl_name)
         ref = ds.pixel_array
         assert ds.BitsAllocated == 32
         assert ds.SamplesPerPixel == 3
@@ -176,9 +168,9 @@ class TestRLELossless:
         with pytest.raises(RuntimeError, match=msg):
             gdcm_rle_encode(ds.PixelData, **kwargs)
 
-    def test_invalid_byteorder_raises(self):
+    def test_invalid_byteorder_raises(self, mono_8bit_1frame_name):
         """Test that big endian source raises exception."""
-        ds = dcmread(EXPL_8_1_1F)
+        ds = dcmread(mono_8bit_1frame_name)
         enc = RLELosslessEncoder
         kwargs = enc.kwargs_from_ds(ds)
 
@@ -191,9 +183,9 @@ class TestRLELossless:
                 ds.PixelData, encoding_plugin='gdcm', byteorder='>', **kwargs
             )
 
-    def test_above_32bit_raises(self):
+    def test_above_32bit_raises(self, mono_8bit_1frame_name):
         """Test that > 32-bit Bits Allocated raises exception."""
-        ds = dcmread(EXPL_8_1_1F)
+        ds = dcmread(mono_8bit_1frame_name)
         enc = RLELosslessEncoder
         kwargs = enc.kwargs_from_ds(ds)
         kwargs['bits_allocated'] = 64

--- a/pydicom/tests/test_fileset.py
+++ b/pydicom/tests/test_fileset.py
@@ -2394,9 +2394,9 @@ class TestFileSet_Modify:
         assert "RT DOSE" == seq[3].DirectoryRecordType
         assert Dataset(ds) == dcmread(paths[0])
 
-    def test_add_rt_structure_set(self, tdir):
+    def test_add_rt_structure_set(self, tdir, rtstruct_name):
         """Test adding an RT Structure Set instance."""
-        ds = dcmread(get_testdata_file("rtstruct.dcm"), force=True)
+        ds = dcmread(rtstruct_name, force=True)
         ds.file_meta = FileMetaDataset()
         ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         ds.StudyDate = "20201001"

--- a/pydicom/tests/test_gdcm_pixel_data.py
+++ b/pydicom/tests/test_gdcm_pixel_data.py
@@ -43,72 +43,29 @@ gdcm_im_missing_message = (
 )
 
 
-empty_number_tags_name = get_testdata_file(
-    "reportsi_with_empty_number_tags.dcm")
-rtplan_name = get_testdata_file("rtplan.dcm")
-rtdose_name = get_testdata_file("rtdose.dcm")
-ct_name = get_testdata_file("CT_small.dcm")
-mr_name = get_testdata_file("MR_small.dcm")
-truncated_mr_name = get_testdata_file("MR_truncated.dcm")
-jpeg2000_name = get_testdata_file("JPEG2000.dcm")
-jpeg2000_lossless_name = get_testdata_file("MR_small_jp2klossless.dcm")
-jpeg_ls_lossless_name = get_testdata_file("MR_small_jpeg_ls_lossless.dcm")
-jpeg_lossy_name = get_testdata_file("JPEG-lossy.dcm")
-jpeg_lossless_name = get_testdata_file("JPEG-LL.dcm")
-jpeg_lossless_odd_data_size_name = get_testdata_file(
-    'SC_rgb_small_odd_jpeg.dcm')
-deflate_name = get_testdata_file("image_dfl.dcm")
-rtstruct_name = get_testdata_file("rtstruct.dcm")
-priv_SQ_name = get_testdata_file("priv_SQ.dcm")
-nested_priv_SQ_name = get_testdata_file("nested_priv_SQ.dcm")
-meta_missing_tsyntax_name = get_testdata_file("meta_missing_tsyntax.dcm")
-no_meta_group_length = get_testdata_file("no_meta_group_length.dcm")
-gzip_name = get_testdata_file("zipMR.gz")
-color_px_name = get_testdata_file("color-px.dcm")
-color_pl_name = get_testdata_file("color-pl.dcm")
-explicit_vr_le_no_meta = get_testdata_file("ExplVR_LitEndNoMeta.dcm")
-explicit_vr_be_no_meta = get_testdata_file("ExplVR_BigEndNoMeta.dcm")
-emri_name = get_testdata_file("emri_small.dcm")
-emri_big_endian_name = get_testdata_file("emri_small_big_endian.dcm")
-emri_jpeg_ls_lossless = get_testdata_file(
-    "emri_small_jpeg_ls_lossless.dcm")
-emri_jpeg_2k_lossless = get_testdata_file(
-    "emri_small_jpeg_2k_lossless.dcm")
-color_3d_jpeg_baseline = get_testdata_file("color3d_jpeg_baseline.dcm")
-sc_rgb_jpeg_dcmtk_411_YBR_FULL_422 = get_testdata_file(
-    "SC_rgb_dcmtk_+eb+cy+np.dcm")
-sc_rgb_jpeg_dcmtk_411_YBR_FULL = get_testdata_file(
-    "SC_rgb_dcmtk_+eb+cy+n1.dcm")
-sc_rgb_jpeg_dcmtk_422_YBR_FULL = get_testdata_file(
-    "SC_rgb_dcmtk_+eb+cy+n2.dcm")
-sc_rgb_jpeg_dcmtk_444_YBR_FULL = get_testdata_file(
-    "SC_rgb_dcmtk_+eb+cy+s4.dcm")
-sc_rgb_jpeg_dcmtk_422_YBR_FULL_422 = get_testdata_file(
-    "SC_rgb_dcmtk_+eb+cy+s2.dcm")
-sc_rgb_jpeg_dcmtk_RGB = get_testdata_file("SC_rgb_dcmtk_+eb+cr.dcm")
-sc_rgb_jpeg2k_gdcm_KY = get_testdata_file("SC_rgb_gdcm_KY.dcm")
-ground_truth_sc_rgb_jpeg2k_gdcm_KY_gdcm = get_testdata_file(
-    "SC_rgb_gdcm2k_uncompressed.dcm"
-)
-J2KR_16_13_1_1_1F_M2_MISMATCH = get_testdata_file("J2K_pixelrep_mismatch.dcm")
-
 dir_name = os.path.dirname(sys.argv[0])
 save_dir = os.getcwd()
 
 
+@pytest.fixture(scope="module")
+def sc_rgb_jpeg2k_gdcm_ky_name():
+    return get_testdata_file("SC_rgb_gdcm_KY.dcm")
+
+
 class TestGDCM_JPEG_LS_no_gdcm:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, mr_name, jpeg_ls_lossless_name, emri_name,
+              emri_jpeg_ls_lossless_name):
         self.unicode_filename = os.path.join(
             tempfile.gettempdir(), "ДИКОМ.dcm")
         shutil.copyfile(jpeg_ls_lossless_name, self.unicode_filename)
         self.jpeg_ls_lossless = dcmread(self.unicode_filename)
         self.mr_small = dcmread(mr_name)
-        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless_name)
         self.emri_small = dcmread(emri_name)
         self.original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = []
-
-    def teardown_method(self):
+        yield
         pydicom.config.pixel_data_handlers = self.original_handlers
         os.remove(self.unicode_filename)
 
@@ -122,18 +79,19 @@ class TestGDCM_JPEG_LS_no_gdcm:
 
 
 class TestGDCM_JPEG2000_no_gdcm:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, mr_name, jpeg2000_name, jpeg2000_lossless_name,
+              emri_name, emri_jpeg_2k_lossless_name, sc_rgb_jpeg2k_gdcm_ky_name):
         self.jpeg_2k = dcmread(jpeg2000_name)
         self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
         self.mr_small = dcmread(mr_name)
-        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
+        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless_name)
         self.emri_small = dcmread(emri_name)
-        self.sc_rgb_jpeg2k_gdcm_KY = dcmread(sc_rgb_jpeg2k_gdcm_KY)
-        self.original_handlers = pydicom.config.pixel_data_handlers
+        self.sc_rgb_jpeg2k_gdcm_KY = dcmread(sc_rgb_jpeg2k_gdcm_ky_name)
+        original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = []
-
-    def teardown_method(self):
-        pydicom.config.pixel_data_handlers = self.original_handlers
+        yield
+        pydicom.config.pixel_data_handlers = original_handlers
 
     def test_JPEG2000(self):
         """JPEG2000: Returns correct values for sample data elements"""
@@ -160,14 +118,14 @@ class TestGDCM_JPEG2000_no_gdcm:
 
 
 class TestGDCM_JPEGlossy_no_gdcm:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, jpeg_lossy_name, color_3d_jpeg_baseline_name):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
-        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.pixel_data_handlers
+        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline_name)
+        original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = []
-
-    def teardown_method(self):
-        pydicom.config.pixel_data_handlers = self.original_handlers
+        yield
+        pydicom.config.pixel_data_handlers = original_handlers
 
     def test_JPEGlossy(self):
         """JPEG-lossy: Returns correct values for sample data elements"""
@@ -185,13 +143,13 @@ class TestGDCM_JPEGlossy_no_gdcm:
 
 
 class TestGDCM_JPEGlossless_no_gdcm:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, jpeg_lossless_name):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.pixel_data_handlers
+        original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = []
-
-    def teardown_method(self):
-        pydicom.config.pixel_data_handlers = self.original_handlers
+        yield
+        pydicom.config.pixel_data_handlers = original_handlers
 
     def testJPEGlossless(self):
         """JPEGlossless: Returns correct values for sample data elements"""
@@ -218,7 +176,7 @@ pi_rgb_test_ids = [
 
 pi_rgb_testdata = [
     pytest.param(
-        sc_rgb_jpeg_dcmtk_411_YBR_FULL,
+        "SC_rgb_dcmtk_+eb+cy+n1.dcm",
         "YBR_FULL",
         [
             (253, 1, 0),
@@ -235,7 +193,7 @@ pi_rgb_testdata = [
         True,
     ),
     pytest.param(
-        sc_rgb_jpeg_dcmtk_411_YBR_FULL_422,
+        "SC_rgb_dcmtk_+eb+cy+np.dcm",
         "YBR_FULL_422",
         [
             (253, 1, 0),
@@ -252,7 +210,7 @@ pi_rgb_testdata = [
         True,
     ),
     pytest.param(
-        sc_rgb_jpeg_dcmtk_422_YBR_FULL,
+        "SC_rgb_dcmtk_+eb+cy+n2.dcm",
         "YBR_FULL",
         [
             (254, 0, 0),
@@ -269,7 +227,7 @@ pi_rgb_testdata = [
         True,
     ),
     pytest.param(
-        sc_rgb_jpeg_dcmtk_422_YBR_FULL_422,
+        "SC_rgb_dcmtk_+eb+cy+s2.dcm",
         "YBR_FULL_422",
         [
             (254, 0, 0),
@@ -286,7 +244,7 @@ pi_rgb_testdata = [
         True,
     ),
     pytest.param(
-        sc_rgb_jpeg_dcmtk_444_YBR_FULL,
+        "SC_rgb_dcmtk_+eb+cy+s4.dcm",
         "YBR_FULL",
         [
             (254, 0, 0),
@@ -331,65 +289,66 @@ class TestsWithGDCM:
         pydicom.config.pixel_data_handlers = original_handlers
 
     @pytest.fixture(scope='class')
-    def unicode_filename(self):
+    def unicode_filename(self, jpeg_ls_lossless_name):
         unicode_filename = os.path.join(
             tempfile.gettempdir(), "ДИКОМ.dcm")
         shutil.copyfile(jpeg_ls_lossless_name, unicode_filename)
         yield unicode_filename
         os.remove(unicode_filename)
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def jpeg_ls_lossless(self, unicode_filename):
         return dcmread(unicode_filename)
 
-    @pytest.fixture
-    def sc_rgb_jpeg2k_gdcm_KY(self):
-        return dcmread(sc_rgb_jpeg2k_gdcm_KY)
+    @pytest.fixture(scope="class")
+    def sc_rgb_jpeg2k_gdcm_KY(self, sc_rgb_jpeg2k_gdcm_ky_name):
+        return dcmread(sc_rgb_jpeg2k_gdcm_ky_name)
 
     @pytest.fixture(scope='class')
     def ground_truth_sc_rgb_jpeg2k_gdcm_KY_gdcm(self):
-        return dcmread(ground_truth_sc_rgb_jpeg2k_gdcm_KY_gdcm)
+        return dcmread(get_testdata_file("SC_rgb_gdcm2k_uncompressed.dcm"))
 
-    @pytest.fixture
-    def jpeg_2k(self):
+    @pytest.fixture(scope="class")
+    def jpeg_2k(self, jpeg2000_name):
         return dcmread(jpeg2000_name)
 
-    @pytest.fixture
-    def jpeg_2k_lossless(self):
+    @pytest.fixture(scope="class")
+    def jpeg_2k_lossless(self, jpeg2000_lossless_name):
         return dcmread(jpeg2000_lossless_name)
 
     @pytest.fixture(scope='class')
-    def mr_small(self):
+    def mr_small(self, mr_name):
         return dcmread(mr_name)
 
     @pytest.fixture(scope='class')
-    def emri_small(self):
+    def emri_small(self, emri_name):
         return dcmread(emri_name)
 
     @pytest.fixture
-    def emri_jpeg_ls_lossless(self):
-        return dcmread(emri_jpeg_ls_lossless)
+    def emri_jpeg_ls_lossless(self, emri_jpeg_ls_lossless_name):
+        return dcmread(emri_jpeg_ls_lossless_name)
 
     @pytest.fixture
-    def emri_jpeg_2k_lossless(self):
-        return dcmread(emri_jpeg_2k_lossless)
+    def emri_jpeg_2k_lossless(self, emri_jpeg_2k_lossless_name):
+        return dcmread(emri_jpeg_2k_lossless_name)
 
     @pytest.fixture
-    def color_3d_jpeg(self):
-        return dcmread(color_3d_jpeg_baseline)
+    def color_3d_jpeg(self, color_3d_jpeg_baseline_name):
+        return dcmread(color_3d_jpeg_baseline_name)
 
     @pytest.fixture
-    def jpeg_lossy(self):
+    def jpeg_lossy(self, jpeg_lossy_name):
         return dcmread(jpeg_lossy_name)
 
     @pytest.fixture
-    def jpeg_lossless(self):
+    def jpeg_lossless(self, jpeg_lossless_name):
         return dcmread(jpeg_lossless_name)
 
     @pytest.fixture
     def jpeg_lossless_odd_data_size(self):
-        return dcmread(jpeg_lossless_odd_data_size_name)
+        return dcmread(get_testdata_file("SC_rgb_small_odd_jpeg.dcm"))
 
+    @pytest.mark.skipif(not HAVE_NP, reason="Test needs installed NumPy")
     def test_JPEG_LS_PixelArray(self, jpeg_ls_lossless, mr_small):
         a = jpeg_ls_lossless.pixel_array
         b = mr_small.pixel_array
@@ -413,12 +372,14 @@ class TestsWithGDCM:
         got = jpeg_2k.DerivationCodeSequence[0].CodeMeaning
         assert 'Lossy Compression' == got
 
+    @pytest.mark.skipif(not HAVE_NP, reason="Test needs installed NumPy")
     def test_JPEG2000PixelArray(self, jpeg_2k_lossless, mr_small):
         a = jpeg_2k_lossless.pixel_array
         b = mr_small.pixel_array
         assert a.mean() == b.mean()
         assert a.flags.writeable
 
+    @pytest.mark.skipif(not HAVE_NP, reason="Test needs installed NumPy")
     def test_decompress_using_gdcm(self, jpeg_2k_lossless, mr_small):
         jpeg_2k_lossless.decompress(handler_name='gdcm')
         a = jpeg_2k_lossless.pixel_array
@@ -451,6 +412,7 @@ class TestsWithGDCM:
         assert 105 == a[230, 120]
         assert a.flags.writeable
 
+    @pytest.mark.skipif(not HAVE_NP, reason="Test needs installed NumPy")
     def test_JPEGlossless_odd_data_size(self, jpeg_lossless_odd_data_size):
         pixel_data = jpeg_lossless_odd_data_size.pixel_array
         assert 27 == pixel_data.nbytes
@@ -461,6 +423,7 @@ class TestsWithGDCM:
         got = jpeg_lossy.DerivationCodeSequence[0].CodeMeaning
         assert 'Lossy Compression' == got
 
+    @pytest.mark.skipif(not HAVE_NP, reason="Test needs installed NumPy")
     def test_JPEGlossyPixelArray(self, jpeg_lossy):
         a = jpeg_lossy.pixel_array
         assert (1024, 256) == a.shape
@@ -481,11 +444,12 @@ class TestsWithGDCM:
         assert (57, 57, 57) == tuple(a[3, 169, 290, :])
         assert "YBR_FULL_422" == color_3d_jpeg.PhotometricInterpretation
 
+    @pytest.mark.skipif(not HAVE_NP, reason="Test needs installed NumPy")
     @pytest.mark.parametrize(
         "image,pi,results,convert_yuv_to_rgb",
         pi_rgb_testdata, ids=pi_rgb_test_ids)
     def test_PI_RGB(self, image, pi, results, convert_yuv_to_rgb):
-        t = dcmread(image)
+        t = dcmread(get_testdata_file(image))
         assert t.PhotometricInterpretation == pi
         a = t.pixel_array
 
@@ -507,7 +471,8 @@ class TestsWithGDCM:
         assert results[9] == tuple(a[95, 50, :])
         assert pi == t.PhotometricInterpretation
 
-    def test_bytes_io(self):
+    @pytest.mark.skipif(not HAVE_NP, reason="Test needs installed NumPy")
+    def test_bytes_io(self, jpeg2000_name):
         """Test using a BytesIO as the dataset source."""
         with open(jpeg2000_name, 'rb') as f:
             bs = BytesIO(f.read())
@@ -517,9 +482,10 @@ class TestsWithGDCM:
         assert (1024, 256) == arr.shape
         assert arr.flags.writeable
 
+    @pytest.mark.skipif(not HAVE_NP, reason="Test needs installed NumPy")
     def test_pixel_rep_mismatch(self):
         """Test mismatched j2k sign and Pixel Representation."""
-        ds = dcmread(J2KR_16_13_1_1_1F_M2_MISMATCH)
+        ds = dcmread(get_testdata_file("J2K_pixelrep_mismatch.dcm"))
         assert 1 == ds.PixelRepresentation
         assert 13 == ds.BitsStored
 
@@ -544,16 +510,16 @@ class TestsWithGDCM:
 
 class TestSupportFunctions:
     @pytest.fixture(scope='class')
-    def dataset_2d(self):
+    def dataset_2d(self, mr_name):
         return dcmread(mr_name)
 
     @pytest.fixture(scope='class')
-    def dataset_2d_compressed(self):
+    def dataset_2d_compressed(self, jpeg2000_name):
         return dcmread(jpeg2000_name)
 
     @pytest.fixture(scope='class')
-    def dataset_3d(self):
-        return dcmread(color_3d_jpeg_baseline)
+    def dataset_3d(self, color_3d_jpeg_baseline_name):
+        return dcmread(color_3d_jpeg_baseline_name)
 
     @pytest.mark.skipif(not HAVE_GDCM_IN_MEMORY_SUPPORT,
                         reason=gdcm_im_missing_message)

--- a/pydicom/tests/test_jpeg_ls_pixel_data.py
+++ b/pydicom/tests/test_jpeg_ls_pixel_data.py
@@ -22,44 +22,6 @@ have_jpeg_ls_handler = jpeg_ls_handler.is_available()
 
 test_jpeg_ls_decoder = have_numpy_handler and have_jpeg_ls_handler
 
-empty_number_tags_name = get_testdata_file(
-    "reportsi_with_empty_number_tags.dcm")
-rtplan_name = get_testdata_file("rtplan.dcm")
-rtdose_name = get_testdata_file("rtdose.dcm")
-ct_name = get_testdata_file("CT_small.dcm")
-mr_name = get_testdata_file("MR_small.dcm")
-truncated_mr_name = get_testdata_file("MR_truncated.dcm")
-jpeg2000_name = get_testdata_file("JPEG2000.dcm")
-jpeg2000_lossless_name = get_testdata_file(
-    "MR_small_jp2klossless.dcm")
-jpeg_ls_lossless_name = get_testdata_file(
-    "MR_small_jpeg_ls_lossless.dcm")
-jpeg_lossy_name = get_testdata_file("JPEG-lossy.dcm")
-jpeg_lossless_name = get_testdata_file("JPEG-LL.dcm")
-deflate_name = get_testdata_file("image_dfl.dcm")
-rtstruct_name = get_testdata_file("rtstruct.dcm")
-priv_SQ_name = get_testdata_file("priv_SQ.dcm")
-nested_priv_SQ_name = get_testdata_file("nested_priv_SQ.dcm")
-meta_missing_tsyntax_name = get_testdata_file(
-    "meta_missing_tsyntax.dcm")
-no_meta_group_length = get_testdata_file(
-    "no_meta_group_length.dcm")
-gzip_name = get_testdata_file("zipMR.gz")
-color_px_name = get_testdata_file("color-px.dcm")
-color_pl_name = get_testdata_file("color-pl.dcm")
-explicit_vr_le_no_meta = get_testdata_file(
-    "ExplVR_LitEndNoMeta.dcm")
-explicit_vr_be_no_meta = get_testdata_file(
-    "ExplVR_BigEndNoMeta.dcm")
-emri_name = get_testdata_file("emri_small.dcm")
-emri_big_endian_name = get_testdata_file(
-    "emri_small_big_endian.dcm")
-emri_jpeg_ls_lossless = get_testdata_file(
-    "emri_small_jpeg_ls_lossless.dcm")
-emri_jpeg_2k_lossless = get_testdata_file(
-    "emri_small_jpeg_2k_lossless.dcm")
-color_3d_jpeg_baseline = get_testdata_file(
-    "color3d_jpeg_baseline.dcm")
 dir_name = os.path.dirname(sys.argv[0])
 save_dir = os.getcwd()
 
@@ -68,16 +30,17 @@ SUPPORTED_HANDLER_NAMES = (
 )
 
 class TestJPEGLS_no_jpeg_ls:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, mr_name, jpeg_ls_lossless_name, emri_name,
+              emri_jpeg_ls_lossless_name):
         self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
         self.mr_small = dcmread(mr_name)
-        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless_name)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.pixel_data_handlers
+        original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [numpy_handler]
-
-    def teardown_method(self):
-        pydicom.config.pixel_data_handlers = self.original_handlers
+        yield
+        pydicom.config.pixel_data_handlers = original_handlers
 
     def test_JPEG_LS_PixelArray(self):
         with pytest.raises((RuntimeError, NotImplementedError)):
@@ -85,17 +48,18 @@ class TestJPEGLS_no_jpeg_ls:
 
 
 class TestJPEGLS_JPEG2000_no_jpeg_ls:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, mr_name, jpeg2000_name, jpeg2000_lossless_name, emri_name,
+              emri_jpeg_2k_lossless_name):
         self.jpeg_2k = dcmread(jpeg2000_name)
         self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
         self.mr_small = dcmread(mr_name)
-        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
+        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless_name)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.pixel_data_handlers
+        original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [numpy_handler]
-
-    def teardown_method(self):
-        pydicom.config.pixel_data_handlers = self.original_handlers
+        yield
+        pydicom.config.pixel_data_handlers = original_handlers
 
     def test_JPEG2000PixelArray(self):
         """JPEG2000: Now works"""
@@ -109,14 +73,14 @@ class TestJPEGLS_JPEG2000_no_jpeg_ls:
 
 
 class TestJPEGLS_JPEGlossy_no_jpeg_ls:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, jpeg_lossy_name, color_3d_jpeg_baseline_name):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
-        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.pixel_data_handlers
+        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline_name)
+        original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [numpy_handler]
-
-    def teardown_method(self):
-        pydicom.config.pixel_data_handlers = self.original_handlers
+        yield
+        pydicom.config.pixel_data_handlers = original_handlers
 
     def testJPEGlossy(self):
         """JPEG-lossy: Returns correct values for sample data elements"""
@@ -134,13 +98,13 @@ class TestJPEGLS_JPEGlossy_no_jpeg_ls:
 
 
 class TestJPEGLS_JPEGlossless_no_jpeg_ls:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, jpeg_lossless_name):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.pixel_data_handlers
+        original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [numpy_handler]
-
-    def teardown_method(self):
-        pydicom.config.pixel_data_handlers = self.original_handlers
+        yield
+        pydicom.config.pixel_data_handlers = original_handlers
 
     def testJPEGlossless(self):
         """JPEGlossless: Returns correct values for sample data elements"""
@@ -158,16 +122,17 @@ class TestJPEGLS_JPEGlossless_no_jpeg_ls:
 
 @pytest.mark.skipif(not test_jpeg_ls_decoder, reason=jpeg_ls_missing_message)
 class TestJPEGLS_JPEG_LS_with_jpeg_ls:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, mr_name, jpeg_ls_lossless_name,
+              emri_jpeg_ls_lossless_name, emri_name):
         self.jpeg_ls_lossless = dcmread(jpeg_ls_lossless_name)
         self.mr_small = dcmread(mr_name)
-        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless)
+        self.emri_jpeg_ls_lossless = dcmread(emri_jpeg_ls_lossless_name)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.pixel_data_handlers
+        original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [jpeg_ls_handler, numpy_handler]
-
-    def teardown_method(self):
-        pydicom.config.pixel_data_handlers = self.original_handlers
+        yield
+        pydicom.config.pixel_data_handlers = original_handlers
 
     def test_JPEG_LS_PixelArray(self):
         a = self.jpeg_ls_lossless.pixel_array
@@ -191,17 +156,18 @@ class TestJPEGLS_JPEG_LS_with_jpeg_ls:
 
 @pytest.mark.skipif(not test_jpeg_ls_decoder, reason=jpeg_ls_missing_message)
 class TestJPEGLS_JPEG2000_with_jpeg_ls:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, mr_name, jpeg2000_name, jpeg2000_lossless_name, emri_name,
+              emri_jpeg_2k_lossless_name):
         self.jpeg_2k = dcmread(jpeg2000_name)
         self.jpeg_2k_lossless = dcmread(jpeg2000_lossless_name)
         self.mr_small = dcmread(mr_name)
-        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless)
+        self.emri_jpeg_2k_lossless = dcmread(emri_jpeg_2k_lossless_name)
         self.emri_small = dcmread(emri_name)
-        self.original_handlers = pydicom.config.pixel_data_handlers
+        original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [jpeg_ls_handler, numpy_handler]
-
-    def teardown_method(self):
-        pydicom.config.pixel_data_handlers = self.original_handlers
+        yield
+        pydicom.config.pixel_data_handlers = original_handlers
 
     def test_JPEG2000PixelArray(self):
         with pytest.raises(NotImplementedError):
@@ -214,14 +180,14 @@ class TestJPEGLS_JPEG2000_with_jpeg_ls:
 
 @pytest.mark.skipif(not test_jpeg_ls_decoder, reason=jpeg_ls_missing_message)
 class TestJPEGLS_JPEGlossy_with_jpeg_ls:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, jpeg_lossy_name, color_3d_jpeg_baseline_name):
         self.jpeg_lossy = dcmread(jpeg_lossy_name)
-        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline)
-        self.original_handlers = pydicom.config.pixel_data_handlers
+        self.color_3d_jpeg = dcmread(color_3d_jpeg_baseline_name)
+        original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [jpeg_ls_handler, numpy_handler]
-
-    def teardown_method(self):
-        pydicom.config.pixel_data_handlers = self.original_handlers
+        yield
+        pydicom.config.pixel_data_handlers = original_handlers
 
     def testJPEGlossy(self):
         """JPEG-lossy: Returns correct values for sample data elements"""
@@ -239,13 +205,13 @@ class TestJPEGLS_JPEGlossy_with_jpeg_ls:
 
 @pytest.mark.skipif(not test_jpeg_ls_decoder, reason=jpeg_ls_missing_message)
 class TestJPEGLS_JPEGlossless_with_jpeg_ls:
-    def setup_method(self):
+    @pytest.fixture(autouse=True)
+    def setup(self, jpeg_lossless_name):
         self.jpeg_lossless = dcmread(jpeg_lossless_name)
-        self.original_handlers = pydicom.config.pixel_data_handlers
+        original_handlers = pydicom.config.pixel_data_handlers
         pydicom.config.pixel_data_handlers = [jpeg_ls_handler, numpy_handler]
-
-    def teardown_method(self):
-        pydicom.config.pixel_data_handlers = self.original_handlers
+        yield
+        pydicom.config.pixel_data_handlers = original_handlers
 
     def testJPEGlossless(self):
         """JPEGlossless: Returns correct values for sample data elements"""

--- a/pydicom/tests/test_numpy_pixel_data.py
+++ b/pydicom/tests/test_numpy_pixel_data.py
@@ -66,11 +66,11 @@ except ImportError:
 # DEFL: Deflated Explicit VR Little Endian
 # EXPB: Explicit VR Big Endian
 # 1/1, 1 sample/pixel, 1 frame
-EXPL_1_1_1F = get_testdata_file("liver_1frame.dcm")
-EXPB_1_1_1F = get_testdata_file("liver_expb_1frame.dcm")
+EXPL_1_1_1F = "liver_1frame.dcm"
+EXPB_1_1_1F = "liver_expb_1frame.dcm"
 # 1/1, 1 sample/pixel, 3 frame
-EXPL_1_1_3F = get_testdata_file("liver.dcm")
-EXPB_1_1_3F = get_testdata_file("liver_expb.dcm")
+EXPL_1_1_3F = "liver.dcm"
+EXPB_1_1_3F = "liver_expb.dcm"
 # 1/1, 3 sample/pixel, 1 frame
 EXPL_1_3_1F = None
 EXPB_1_3_1F = None
@@ -78,74 +78,72 @@ EXPB_1_3_1F = None
 EXPL_1_3_XF = None
 EXPB_1_3_XF = None
 # 8/8, 1 sample/pixel, 1 frame
-DEFL_8_1_1F = get_testdata_file("image_dfl.dcm")
-EXPL_8_1_1F = get_testdata_file("OBXXXX1A.dcm")
-EXPB_8_1_1F = get_testdata_file("OBXXXX1A_expb.dcm")
+DEFL_8_1_1F = "image_dfl.dcm"
+EXPL_8_1_1F = "OBXXXX1A.dcm"
+EXPB_8_1_1F = "OBXXXX1A_expb.dcm"
 # 8/8, 1 sample/pixel, 2 frame
-EXPL_8_1_2F = get_testdata_file("OBXXXX1A_2frame.dcm")
-EXPB_8_1_2F = get_testdata_file("OBXXXX1A_expb_2frame.dcm")
+EXPL_8_1_2F = "OBXXXX1A_2frame.dcm"
+EXPB_8_1_2F = "OBXXXX1A_expb_2frame.dcm"
 # 8/8, 3 sample/pixel, 1 frame
-EXPL_8_3_1F = get_testdata_file("SC_rgb.dcm")
-EXPB_8_3_1F = get_testdata_file("SC_rgb_expb.dcm")
+EXPL_8_3_1F = "SC_rgb.dcm"
+EXPB_8_3_1F = "SC_rgb_expb.dcm"
 # 8/8, 3 samples/pixel, 1 frame, 3 x 3
-EXPL_8_3_1F_ODD = get_testdata_file('SC_rgb_small_odd.dcm')
-EXPL_8_3_1F_ODD_BIGE = get_testdata_file('SC_rgb_small_odd_big_endian.dcm')
+EXPL_8_3_1F_ODD = 'SC_rgb_small_odd.dcm'
+EXPL_8_3_1F_ODD_BIGE = 'SC_rgb_small_odd_big_endian.dcm'
 # 8/8, 3 sample/pixel, 1 frame, YBR_FULL_422
-EXPL_8_3_1F_YBR422 = get_testdata_file('SC_ybr_full_422_uncompressed.dcm')
+EXPL_8_3_1F_YBR422 = 'SC_ybr_full_422_uncompressed.dcm'
 # 8/8, 3 sample/pixel, 1 frame, YBR_FULL
-EXPL_8_3_1F_YBR = get_testdata_file('SC_ybr_full_uncompressed.dcm')
+EXPL_8_3_1F_YBR = 'SC_ybr_full_uncompressed.dcm'
 # 8/8, 3 sample/pixel, 2 frame
-EXPL_8_3_2F = get_testdata_file("SC_rgb_2frame.dcm")
-EXPB_8_3_2F = get_testdata_file("SC_rgb_expb_2frame.dcm")
+EXPL_8_3_2F = "SC_rgb_2frame.dcm"
+EXPB_8_3_2F = "SC_rgb_expb_2frame.dcm"
 # 16/16, 1 sample/pixel, 1 frame
-IMPL_16_1_1F = get_testdata_file("MR_small_implicit.dcm")
-EXPL_16_1_1F = get_testdata_file("MR_small.dcm")
-EXPB_16_1_1F = get_testdata_file("MR_small_expb.dcm")
+IMPL_16_1_1F = "MR_small_implicit.dcm"
+EXPL_16_1_1F = "MR_small.dcm"
+EXPB_16_1_1F = "MR_small_expb.dcm"
 # Pixel Data with 128 bytes trailing padding
-EXPL_16_1_1F_PAD = get_testdata_file("MR_small_padded.dcm")
+EXPL_16_1_1F_PAD = "MR_small_padded.dcm"
 # 16/12, 1 sample/pixel, 10 frame
-EXPL_16_1_10F = get_testdata_file("emri_small.dcm")
-EXPB_16_1_10F = get_testdata_file("emri_small_big_endian.dcm")
+EXPL_16_1_10F = "emri_small.dcm"
+EXPB_16_1_10F = "emri_small_big_endian.dcm"
 # 16/16, 3 sample/pixel, 1 frame
-EXPL_16_3_1F = get_testdata_file("SC_rgb_16bit.dcm")
-EXPB_16_3_1F = get_testdata_file("SC_rgb_expb_16bit.dcm")
+EXPL_16_3_1F = "SC_rgb_16bit.dcm"
+EXPB_16_3_1F = "SC_rgb_expb_16bit.dcm"
 # 16/16, 3 sample/pixel, 2 frame
-EXPL_16_3_2F = get_testdata_file("SC_rgb_16bit_2frame.dcm")
-EXPB_16_3_2F = get_testdata_file("SC_rgb_expb_16bit_2frame.dcm")
+EXPL_16_3_2F = "SC_rgb_16bit_2frame.dcm"
+EXPB_16_3_2F = "SC_rgb_expb_16bit_2frame.dcm"
 # 32/32, 1 sample/pixel, 1 frame
-IMPL_32_1_1F = get_testdata_file("rtdose_1frame.dcm")
-EXPB_32_1_1F = get_testdata_file("rtdose_expb_1frame.dcm")
+IMPL_32_1_1F = "rtdose_1frame.dcm"
+EXPB_32_1_1F = "rtdose_expb_1frame.dcm"
 # 32/32, 1 sample/pixel, 15 frame
-IMPL_32_1_15F = get_testdata_file("rtdose.dcm")
-EXPB_32_1_15F = get_testdata_file("rtdose_expb.dcm")
+IMPL_32_1_15F = "rtdose.dcm"
+EXPB_32_1_15F = "rtdose_expb.dcm"
 # 32/32, 3 sample/pixel, 1 frame
-EXPL_32_3_1F = get_testdata_file("SC_rgb_32bit.dcm")
-EXPB_32_3_1F = get_testdata_file("SC_rgb_expb_32bit.dcm")
+EXPL_32_3_1F = "SC_rgb_32bit.dcm"
+EXPB_32_3_1F = "SC_rgb_expb_32bit.dcm"
 # 32/32, 3 sample/pixel, 2 frame
-EXPL_32_3_2F = get_testdata_file("SC_rgb_32bit_2frame.dcm")
-EXPB_32_3_2F = get_testdata_file("SC_rgb_expb_32bit_2frame.dcm")
+EXPL_32_3_2F = "SC_rgb_32bit_2frame.dcm"
+EXPB_32_3_2F = "SC_rgb_expb_32bit_2frame.dcm"
 
 # Transfer syntaxes supported by other handlers
 # JPEG Baseline (Process 1)
-JPEG_BASELINE_1 = get_testdata_file("SC_rgb_jpeg_dcmtk.dcm")
-# JPEG Baseline (Process 2 and 4)
-JPEG_EXTENDED_2 = get_testdata_file("JPEG-lossy.dcm")
-# JPEG Lossless (Process 14)
+JPEG_BASELINE_1 = "SC_rgb_jpeg_dcmtk.dcm"
+# JPEG Baseline (Process 2 and 4
+JPEG_EXTENDED_2 = "JPEG-lossy.dcm"
+# JPEG Lossless (Process 14
 JPEG_LOSSLESS_14 = None
 # JPEG Lossless (Process 14, Selection Value 1)
-JPEG_LOSSLESS_14_1 = get_testdata_file("SC_rgb_jpeg_gdcm.dcm")
+JPEG_LOSSLESS_14_1 = "SC_rgb_jpeg_gdcm.dcm"
 # JPEG-LS Lossless
-JPEG_LS_LOSSLESS = get_testdata_file("MR_small_jpeg_ls_lossless.dcm")
+JPEG_LS_LOSSLESS = "MR_small_jpeg_ls_lossless.dcm"
 # JPEG-LS Lossy
 JPEG_LS_LOSSY = None
 # JPEG2k Lossless
-JPEG_2K_LOSSLESS = get_testdata_file("emri_small_jpeg_2k_lossless.dcm")
+JPEG_2K_LOSSLESS = "emri_small_jpeg_2k_lossless.dcm"
 # JPEG2k
-JPEG_2K = get_testdata_file("JPEG2000.dcm")
+JPEG_2K = "JPEG2000.dcm"
 # RLE Lossless
-RLE = get_testdata_file("MR_small_RLE.dcm")
-# No Image Pixel module
-NO_PIXEL = get_testdata_file("rtplan.dcm")
+RLE = "MR_small_RLE.dcm"
 
 
 # Transfer Syntaxes (non-retired + Explicit VR Big Endian)
@@ -201,38 +199,38 @@ class TestNoNumpy_NoNumpyHandler:
         assert not HAVE_NP
         assert NP_HANDLER is not None
 
-    def test_can_access_supported_dataset(self):
+    def test_can_access_supported_dataset(self, deflate_name):
         """Test that we can read and access elements in dataset."""
         # Explicit little
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         assert 'CompressedSamples^MR1' == ds.PatientName
         assert 8192 == len(ds.PixelData)
 
         # Implicit little
-        ds = dcmread(IMPL_16_1_1F)
+        ds = dcmread(get_testdata_file(IMPL_16_1_1F))
         assert 'CompressedSamples^MR1' == ds.PatientName
         assert 8192 == len(ds.PixelData)
 
         # Deflated little
-        ds = dcmread(DEFL_8_1_1F)
+        ds = dcmread(deflate_name)
         assert '^^^^' == ds.PatientName
         assert 262144 == len(ds.PixelData)
 
         # Explicit big
-        ds = dcmread(EXPB_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPB_16_1_1F))
         assert 'CompressedSamples^MR1' == ds.PatientName
         assert 8192 == len(ds.PixelData)
 
     @pytest.mark.parametrize("fpath,data", REFERENCE_DATA_UNSUPPORTED)
     def test_can_access_unsupported_dataset(self, fpath, data):
         """Test can read and access elements in unsupported datasets."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert data[0] == ds.file_meta.TransferSyntaxUID
         assert data[1] == ds.PatientName
 
     def test_pixel_array_raises(self):
         """Test pixel_array raises exception for all syntaxes."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         for uid in AllTransferSyntaxes:
             ds.file_meta.TransferSyntaxUID = uid
             with pytest.raises(NotImplementedError,
@@ -240,7 +238,7 @@ class TestNoNumpy_NoNumpyHandler:
                 ds.pixel_array
 
     def test_using_numpy_handler_raises(self):
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         msg = ("The pixel data handler 'numpy' is not available on your "
                "system. Please refer to the pydicom documentation*")
         with pytest.raises(RuntimeError, match=msg):
@@ -266,38 +264,38 @@ class TestNoNumpy_NumpyHandler:
         assert not HAVE_NP
         assert NP_HANDLER is not None
 
-    def test_can_access_supported_dataset(self):
+    def test_can_access_supported_dataset(self, deflate_name):
         """Test that we can read and access elements in dataset."""
         # Explicit little
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         assert 'CompressedSamples^MR1' == ds.PatientName
         assert 8192 == len(ds.PixelData)
 
         # Implicit little
-        ds = dcmread(IMPL_16_1_1F)
+        ds = dcmread(get_testdata_file(IMPL_16_1_1F))
         assert 'CompressedSamples^MR1' == ds.PatientName
         assert 8192 == len(ds.PixelData)
 
         # Deflated little
-        ds = dcmread(DEFL_8_1_1F)
+        ds = dcmread(deflate_name)
         assert '^^^^' == ds.PatientName
         assert 262144 == len(ds.PixelData)
 
         # Explicit big
-        ds = dcmread(EXPB_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPB_16_1_1F))
         assert 'CompressedSamples^MR1' == ds.PatientName
         assert 8192 == len(ds.PixelData)
 
     @pytest.mark.parametrize("fpath,data", REFERENCE_DATA_UNSUPPORTED)
     def test_can_access_unsupported_dataset(self, fpath, data):
         """Test can read and access elements in unsupported datasets."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert data[0] == ds.file_meta.TransferSyntaxUID
         assert data[1] == ds.PatientName
 
     def test_unsupported_pixel_array_raises(self):
         """Test pixel_array raises exception for unsupported syntaxes."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         for uid in UNSUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             with pytest.raises(NotImplementedError,
@@ -306,7 +304,7 @@ class TestNoNumpy_NumpyHandler:
 
     def test_supported_pixel_array_raises(self):
         """Test pixel_array raises exception for supported syntaxes."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         for uid in SUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             exc_msg = (
@@ -338,38 +336,38 @@ class TestNumpy_NoNumpyHandler:
         # We numpy handler should still be available
         assert NP_HANDLER is not None
 
-    def test_can_access_supported_dataset(self):
+    def test_can_access_supported_dataset(self, deflate_name):
         """Test that we can read and access elements in dataset."""
         # Explicit little
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         assert 'CompressedSamples^MR1' == ds.PatientName
         assert 8192 == len(ds.PixelData)
 
         # Implicit little
-        ds = dcmread(IMPL_16_1_1F)
+        ds = dcmread(get_testdata_file(IMPL_16_1_1F))
         assert 'CompressedSamples^MR1' == ds.PatientName
         assert 8192 == len(ds.PixelData)
 
         # Deflated little
-        ds = dcmread(DEFL_8_1_1F)
+        ds = dcmread(deflate_name)
         assert '^^^^' == ds.PatientName
         assert 262144 == len(ds.PixelData)
 
         # Explicit big
-        ds = dcmread(EXPB_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPB_16_1_1F))
         assert 'CompressedSamples^MR1' == ds.PatientName
         assert 8192 == len(ds.PixelData)
 
     @pytest.mark.parametrize("fpath,data", REFERENCE_DATA_UNSUPPORTED)
     def test_can_access_unsupported_dataset(self, fpath, data):
         """Test can read and access elements in unsupported datasets."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert data[0] == ds.file_meta.TransferSyntaxUID
         assert data[1] == ds.PatientName
 
     def test_pixel_array_raises(self):
         """Test pixel_array raises exception for all syntaxes."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         for uid in AllTransferSyntaxes:
             ds.file_meta.TransferSyntaxUID = uid
             with pytest.raises((NotImplementedError, RuntimeError)):
@@ -437,7 +435,7 @@ class TestNumpy_NumpyHandler:
 
     def test_unsupported_syntax_raises(self):
         """Test pixel_array raises exception for unsupported syntaxes."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
 
         for uid in UNSUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
@@ -446,7 +444,7 @@ class TestNumpy_NumpyHandler:
 
     def test_dataset_pixel_array_handler_needs_convert(self):
         """Test Dataset.pixel_array when converting to RGB."""
-        ds = dcmread(EXPL_8_3_1F)
+        ds = dcmread(get_testdata_file(EXPL_8_3_1F))
         # Convert to YBR first
         arr = ds.pixel_array
         assert (255, 0, 0) == tuple(arr[5, 50, :])
@@ -472,9 +470,9 @@ class TestNumpy_NumpyHandler:
         # Reset
         NP_HANDLER.needs_to_convert_to_RGB = orig_fn
 
-    def test_dataset_pixel_array_no_pixels(self):
+    def test_dataset_pixel_array_no_pixels(self, rtplan_name):
         """Test good exception message if no pixel data in dataset."""
-        ds = dcmread(NO_PIXEL)
+        ds = dcmread(rtplan_name)
         msg = (
             r"Unable to convert the pixel data: one of Pixel Data, Float "
             r"Pixel Data or Double Float Pixel Data must be present in the "
@@ -486,18 +484,18 @@ class TestNumpy_NumpyHandler:
     @pytest.mark.parametrize("fpath, data", REFERENCE_DATA_UNSUPPORTED)
     def test_can_access_unsupported_dataset(self, fpath, data):
         """Test can read and access elements in unsupported datasets."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert data[0] == ds.file_meta.TransferSyntaxUID
         assert data[1] == ds.PatientName
 
-    def test_pixel_array_8bit_un_signed(self):
+    def test_pixel_array_8bit_un_signed(self, mono_8bit_1frame_name):
         """Test pixel_array for 8-bit unsigned -> signed data."""
-        ds = dcmread(EXPL_8_1_1F)
+        ds = dcmread(mono_8bit_1frame_name)
         # 0 is unsigned int, 1 is 2's complement
         assert ds.PixelRepresentation == 0
         ds.PixelRepresentation = 1
         arr = ds.pixel_array
-        ref = dcmread(EXPL_8_1_1F)
+        ref = dcmread(mono_8bit_1frame_name)
 
         assert not np.array_equal(arr, ref.pixel_array)
         assert (600, 800) == arr.shape
@@ -506,9 +504,9 @@ class TestNumpy_NumpyHandler:
         assert 0 == arr[-1].min() == arr[-1].max()
 
     @pytest.mark.parametrize("handler_name", SUPPORTED_HANDLER_NAMES)
-    def test_decompress_using_handler(self, handler_name):
+    def test_decompress_using_handler(self, handler_name, mono_8bit_1frame_name):
         """Test different possibilities for the numpy handler name."""
-        ds = dcmread(EXPL_8_1_1F)
+        ds = dcmread(mono_8bit_1frame_name)
         ds.decompress(handler_name)
         assert (600, 800) == ds.pixel_array.shape
         assert 244 == ds.pixel_array[0].min() == ds.pixel_array[0].max()
@@ -517,12 +515,12 @@ class TestNumpy_NumpyHandler:
 
     def test_pixel_array_16bit_un_signed(self):
         """Test pixel_array for 16-bit unsigned -> signed."""
-        ds = dcmread(EXPL_16_3_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_3_1F))
         # 0 is unsigned int, 1 is 2's complement
         assert ds.PixelRepresentation == 0
         ds.PixelRepresentation = 1
         arr = ds.pixel_array
-        ref = dcmread(EXPL_16_3_1F)
+        ref = dcmread(get_testdata_file(EXPL_16_3_1F))
 
         assert not np.array_equal(arr, ref.pixel_array)
         assert (100, 100, 3) == arr.shape
@@ -531,12 +529,12 @@ class TestNumpy_NumpyHandler:
 
     def test_pixel_array_32bit_un_signed(self):
         """Test pixel_array for 32-bit unsigned -> signed."""
-        ds = dcmread(EXPL_32_3_1F)
+        ds = dcmread(get_testdata_file(EXPL_32_3_1F))
         # 0 is unsigned int, 1 is 2's complement
         assert ds.PixelRepresentation == 0
         ds.PixelRepresentation = 1
         arr = ds.pixel_array
-        ref = dcmread(EXPL_32_3_1F)
+        ref = dcmread(get_testdata_file(EXPL_32_3_1F))
 
         assert not np.array_equal(arr, ref.pixel_array)
         assert (100, 100, 3) == arr.shape
@@ -544,10 +542,10 @@ class TestNumpy_NumpyHandler:
         assert -2139062144 == arr[50, :, 0].min() == arr[50, :, 0].max()
 
     # Endian independent datasets
-    def test_8bit_1sample_1frame(self):
+    def test_8bit_1sample_1frame(self, mono_8bit_1frame_name):
         """Test pixel_array for 8-bit, 1 sample/pixel, 1 frame."""
         # Check supported syntaxes
-        ds = dcmread(EXPL_8_1_1F)
+        ds = dcmread(mono_8bit_1frame_name)
         for uid in SUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -562,7 +560,7 @@ class TestNumpy_NumpyHandler:
     def test_8bit_1sample_2frame(self):
         """Test pixel_array for 8-bit, 1 sample/pixel, 2 frame."""
         # Check supported syntaxes
-        ds = dcmread(EXPL_8_1_2F)
+        ds = dcmread(get_testdata_file(EXPL_8_1_2F))
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -580,7 +578,7 @@ class TestNumpy_NumpyHandler:
     def test_8bit_3sample_1frame_odd_size(self):
         """Test pixel_array for odd sized (3x3) pixel data."""
         # Check supported syntaxes
-        ds = dcmread(EXPL_8_3_1F_ODD)
+        ds = dcmread(get_testdata_file(EXPL_8_3_1F_ODD))
         for uid in SUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -597,7 +595,7 @@ class TestNumpy_NumpyHandler:
 
     def test_8bit_3sample_1frame_ybr422(self):
         """Test pixel_array for YBR_FULL_422 pixel data."""
-        ds = dcmread(EXPL_8_3_1F_YBR422)
+        ds = dcmread(get_testdata_file(EXPL_8_3_1F_YBR422))
         assert ds.PhotometricInterpretation == 'YBR_FULL_422'
         arr = ds.pixel_array
 
@@ -623,7 +621,7 @@ class TestNumpy_NumpyHandler:
     def test_8bit_3sample_1frame(self):
         """Test pixel_array for 8-bit, 3 sample/pixel, 1 frame."""
         # Check supported syntaxes
-        ds = dcmread(EXPL_8_3_1F)
+        ds = dcmread(get_testdata_file(EXPL_8_3_1F))
         for uid in SUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -641,10 +639,10 @@ class TestNumpy_NumpyHandler:
             assert (192, 192, 192) == tuple(arr[85, 50, :])
             assert (255, 255, 255) == tuple(arr[95, 50, :])
 
-    def test_8bit_3sample_2frame(self):
+    def test_8bit_3sample_2frame(self, rgb_8bit_2frames_name):
         """Test pixel_array for 8-bit, 3 sample/pixel, 2 frame."""
         # Check supported syntaxes
-        ds = dcmread(EXPL_8_3_2F)
+        ds = dcmread(rgb_8bit_2frames_name)
         for uid in SUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -670,7 +668,7 @@ class TestNumpy_NumpyHandler:
     @pytest.mark.parametrize('fpath, data', REFERENCE_DATA_LITTLE)
     def test_properties(self, fpath, data):
         """Test dataset and pixel array properties are as expected."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert ds.file_meta.TransferSyntaxUID == data[0]
         assert ds.BitsAllocated == data[1]
         assert ds.SamplesPerPixel == data[2]
@@ -698,7 +696,7 @@ class TestNumpy_NumpyHandler:
     def test_little_1bit_1sample_1frame(self):
         """Test pixel_array for little 1-bit, 1 sample/pixel, 1 frame."""
         # Check all little endian syntaxes
-        ds = dcmread(EXPL_1_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_1_1_1F))
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -716,7 +714,7 @@ class TestNumpy_NumpyHandler:
     def test_little_1bit_1sample_3frame(self):
         """Test pixel_array for little 1-bit, 1 sample/pixel, 3 frame."""
         # Check all little endian syntaxes
-        ds = dcmread(EXPL_1_1_3F)
+        ds = dcmread(get_testdata_file(EXPL_1_1_3F))
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -777,7 +775,7 @@ class TestNumpy_NumpyHandler:
     def test_little_16bit_1sample_1frame(self):
         """Test pixel_array for little 16-bit, 1 sample/pixel, 1 frame."""
         # Check all little endian syntaxes
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -792,7 +790,7 @@ class TestNumpy_NumpyHandler:
 
     def test_little_16bit_1sample_1frame_padded(self):
         """Test with padded little 16-bit, 1 sample/pixel, 1 frame."""
-        ds = dcmread(EXPL_16_1_1F_PAD)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F_PAD))
         assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
         assert ds.BitsAllocated == 16
         assert ds.SamplesPerPixel == 1
@@ -827,7 +825,7 @@ class TestNumpy_NumpyHandler:
     def test_little_16bit_1sample_10frame(self):
         """Test pixel_array for little 16-bit, 1 sample/pixel, 10 frame."""
         # Check all little endian syntaxes
-        ds = dcmread(EXPL_16_1_10F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_10F))
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -850,7 +848,7 @@ class TestNumpy_NumpyHandler:
     def test_little_16bit_3sample_1frame(self):
         """Test pixel_array for little 16-bit, 3 sample/pixel, 1 frame."""
         # Check all little endian syntaxes
-        ds = dcmread(EXPL_16_3_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_3_1F))
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -871,7 +869,7 @@ class TestNumpy_NumpyHandler:
     def test_little_16bit_3sample_2frame(self):
         """Test pixel_array for little 16-bit, 3 sample/pixel, 2 frame."""
         # Check all little endian syntaxes
-        ds = dcmread(EXPL_16_3_2F)
+        ds = dcmread(get_testdata_file(EXPL_16_3_2F))
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -895,7 +893,7 @@ class TestNumpy_NumpyHandler:
     def test_little_32bit_1sample_1frame(self):
         """Test pixel_array for little 32-bit, 1 sample/pixel, 1 frame."""
         # Check all little endian syntaxes
-        ds = dcmread(IMPL_32_1_1F)
+        ds = dcmread(get_testdata_file(IMPL_32_1_1F))
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -909,7 +907,7 @@ class TestNumpy_NumpyHandler:
     def test_little_32bit_1sample_15frame(self):
         """Test pixel_array for little 32-bit, 1 sample/pixel, 15 frame."""
         # Check all little endian syntaxes
-        ds = dcmread(IMPL_32_1_15F)
+        ds = dcmread(get_testdata_file(IMPL_32_1_15F))
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -932,7 +930,7 @@ class TestNumpy_NumpyHandler:
     def test_little_32bit_3sample_1frame(self):
         """Test pixel_array for little 32-bit, 3 sample/pixel, 1 frame."""
         # Check all little endian syntaxes
-        ds = dcmread(EXPL_32_3_1F)
+        ds = dcmread(get_testdata_file(EXPL_32_3_1F))
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             ar = ds.pixel_array
@@ -953,7 +951,7 @@ class TestNumpy_NumpyHandler:
     def test_little_32bit_3sample_2frame(self):
         """Test pixel_array for little 32-bit, 3 sample/pixel, 10 frame."""
         # Check all little endian syntaxes
-        ds = dcmread(EXPL_32_3_2F)
+        ds = dcmread(get_testdata_file(EXPL_32_3_2F))
         for uid in SUPPORTED_SYNTAXES[:3]:
             ds.file_meta.TransferSyntaxUID = uid
             arr = ds.pixel_array
@@ -988,7 +986,7 @@ class TestNumpy_NumpyHandler:
 
     def test_little_32bit_float_1frame(self):
         """Test pixel_array for float pixel data, 1 frame."""
-        ds = dcmread(IMPL_32_1_1F)
+        ds = dcmread(get_testdata_file(IMPL_32_1_1F))
         ds.FloatPixelData = ds.PixelData
         del ds.PixelData
         for uid in SUPPORTED_SYNTAXES[:3]:
@@ -1004,7 +1002,7 @@ class TestNumpy_NumpyHandler:
 
     def test_little_32bit_float_15frame(self):
         """Test pixel_array for float pixel data, 15 frames."""
-        ds = dcmread(IMPL_32_1_15F)
+        ds = dcmread(get_testdata_file(IMPL_32_1_15F))
         ds.FloatPixelData = ds.PixelData
         del ds.PixelData
         for uid in SUPPORTED_SYNTAXES[:3]:
@@ -1020,7 +1018,7 @@ class TestNumpy_NumpyHandler:
 
     def test_little_64bit_float_1frame(self):
         """Test pixel_array for double float pixel data, 1 frame."""
-        ds = dcmread(IMPL_32_1_1F)
+        ds = dcmread(get_testdata_file(IMPL_32_1_1F))
         ds.DoubleFloatPixelData = ds.PixelData + ds.PixelData
         del ds.PixelData
         ds.BitsAllocated = 64
@@ -1037,7 +1035,7 @@ class TestNumpy_NumpyHandler:
 
     def test_little_64bit_float_15frame(self):
         """Test pixel_array for double float pixel data, 15 frames."""
-        ds = dcmread(IMPL_32_1_15F)
+        ds = dcmread(get_testdata_file(IMPL_32_1_15F))
         ds.DoubleFloatPixelData = ds.PixelData + ds.PixelData
         del ds.PixelData
         ds.BitsAllocated = 64
@@ -1056,9 +1054,9 @@ class TestNumpy_NumpyHandler:
     @pytest.mark.parametrize('little, big', MATCHING_DATASETS)
     def test_big_endian_datasets(self, little, big):
         """Test pixel_array for big endian matches little."""
-        ds = dcmread(big)
+        ds = dcmread(get_testdata_file(big))
         assert ds.file_meta.TransferSyntaxUID == ExplicitVRBigEndian
-        ref = dcmread(little)
+        ref = dcmread(get_testdata_file(little))
         assert ref.file_meta.TransferSyntaxUID != ExplicitVRBigEndian
         assert np.array_equal(ds.pixel_array, ref.pixel_array)
 
@@ -1080,9 +1078,9 @@ class TestNumpy_NumpyHandler:
 
         assert ds.pixel_array.max() == 1
 
-    def test_read_only(self):
+    def test_read_only(self, mono_8bit_1frame_name):
         """Test for #717, returned array read-only."""
-        ds = dcmread(EXPL_8_1_1F)
+        ds = dcmread(mono_8bit_1frame_name)
         arr = ds.pixel_array
         assert 0 != arr[0, 0]
         arr[0, 0] = 0
@@ -1096,7 +1094,7 @@ class TestNumpy_GetPixelData:
     """Tests for numpy_handler.get_pixeldata with numpy."""
     def test_no_pixel_data_raises(self):
         """Test get_pixeldata raises if dataset has no PixelData."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         del ds.PixelData
         assert 'PixelData' not in ds
         assert 'FloatPixelData' not in ds
@@ -1121,7 +1119,7 @@ class TestNumpy_GetPixelData:
             'PixelRepresentation',
         )
         for attr in required_attrs:
-            ds = dcmread(EXPL_16_1_1F)
+            ds = dcmread(get_testdata_file(EXPL_16_1_1F))
             delattr(ds, attr)
             msg = (
                 r"Unable to convert the pixel data as the following required "
@@ -1132,7 +1130,7 @@ class TestNumpy_GetPixelData:
 
     def test_missing_required_elem_pixel_data_color(self):
         """Tet get_pixeldata raises if dataset missing required element."""
-        ds = dcmread(EXPL_8_3_1F)
+        ds = dcmread(get_testdata_file(EXPL_8_3_1F))
         del ds.Rows
         del ds.Columns
         msg = (
@@ -1144,7 +1142,7 @@ class TestNumpy_GetPixelData:
 
     def test_missing_conditionally_required_elem_pixel_data_color(self):
         """Tet get_pixeldata raises if dataset missing required element."""
-        ds = dcmread(EXPL_8_3_1F)
+        ds = dcmread(get_testdata_file(EXPL_8_3_1F))
         del ds.PlanarConfiguration
         msg = (
             r"Unable to convert the pixel data as the following conditionally "
@@ -1156,7 +1154,7 @@ class TestNumpy_GetPixelData:
 
     def test_missing_required_elem_float_pixel_data_monochrome(self):
         """Tet get_pixeldata raises if dataset missing required element."""
-        ds = dcmread(IMPL_32_1_1F)
+        ds = dcmread(get_testdata_file(IMPL_32_1_1F))
         ds.FloatPixelData = ds.PixelData
         del ds.PixelData
         del ds.Rows
@@ -1169,7 +1167,7 @@ class TestNumpy_GetPixelData:
 
     def test_unknown_pixel_representation_raises(self):
         """Test get_pixeldata raises if unsupported PixelRepresentation."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         ds.PixelRepresentation = 2
         with pytest.raises(ValueError,
                            match=r"value of '2' for '\(0028,0103"):
@@ -1177,15 +1175,15 @@ class TestNumpy_GetPixelData:
 
     def test_unsupported_syntaxes_raises(self):
         """Test get_pixeldata raises if unsupported Transfer Syntax."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         ds.file_meta.TransferSyntaxUID = '1.2.840.10008.1.2.4.50'
         with pytest.raises(NotImplementedError,
                            match=' the transfer syntax is not supported'):
             get_pixeldata(ds)
 
-    def test_bad_length_raises(self):
+    def test_bad_length_raises(self, mono_8bit_1frame_name):
         """Test bad pixel data length raises exception."""
-        ds = dcmread(EXPL_8_1_1F)
+        ds = dcmread(mono_8bit_1frame_name)
         # Too short
         ds.PixelData = ds.PixelData[:-1]
         msg = (
@@ -1199,7 +1197,7 @@ class TestNumpy_GetPixelData:
 
     def test_missing_padding_warns(self):
         """A warning shall be issued if the padding for odd data is missing."""
-        ds = dcmread(EXPL_8_3_1F_ODD)
+        ds = dcmread(get_testdata_file(EXPL_8_3_1F_ODD))
         # remove the padding byte
         ds.PixelData = ds.PixelData[:-1]
         msg = r"The odd length pixel data is missing a trailing padding byte"
@@ -1214,7 +1212,7 @@ class TestNumpy_GetPixelData:
             return True
 
         # Test default
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         assert ds.PhotometricInterpretation == 'MONOCHROME2'
 
         get_pixeldata(ds)
@@ -1229,9 +1227,9 @@ class TestNumpy_GetPixelData:
 
         NP_HANDLER.should_change_PhotometricInterpretation_to_RGB = orig_fn
 
-    def test_array_read_only(self):
+    def test_array_read_only(self, mono_8bit_1frame_name):
         """Test returning a read only array for BitsAllocated > 8."""
-        ds = dcmread(EXPL_8_1_1F)
+        ds = dcmread(mono_8bit_1frame_name)
         arr = get_pixeldata(ds, read_only=False)
         assert arr.flags.writeable
         assert 0 != arr[10]
@@ -1245,7 +1243,7 @@ class TestNumpy_GetPixelData:
 
     def test_array_read_only_bit_packed(self):
         """Test returning a read only array for BitsAllocated = 1."""
-        ds = dcmread(EXPL_1_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_1_1_1F))
         arr = get_pixeldata(ds, read_only=False)
         assert arr.flags.writeable
 
@@ -1254,7 +1252,7 @@ class TestNumpy_GetPixelData:
 
     def test_ybr422_excess_padding(self):
         """Test YBR data with excess padding."""
-        ds = dcmread(EXPL_8_3_1F_YBR422)
+        ds = dcmread(get_testdata_file(EXPL_8_3_1F_YBR422))
         assert ds.PhotometricInterpretation == 'YBR_FULL_422'
         ds.PixelData += b'\x00\x00\x00\x00'
         msg = (
@@ -1278,7 +1276,7 @@ class TestNumpy_GetPixelData:
 
     def test_ybr422_wrong_interpretation(self):
         """Test YBR data with wrong Photometric Interpretation."""
-        ds = dcmread(EXPL_8_3_1F_YBR)
+        ds = dcmread(get_testdata_file(EXPL_8_3_1F_YBR))
         assert ds.PhotometricInterpretation == 'YBR_FULL'
         assert len(ds.PixelData) == 30000
         ds.PhotometricInterpretation = 'YBR_FULL_422'
@@ -1292,7 +1290,7 @@ class TestNumpy_GetPixelData:
     def test_float_pixel_data(self):
         """Test handling of Float Pixel Data."""
         # Only 1 sample per pixel allowed
-        ds = dcmread(IMPL_32_1_1F)
+        ds = dcmread(get_testdata_file(IMPL_32_1_1F))
         ds.FloatPixelData = ds.PixelData
         del ds.PixelData
         assert 32 == ds.BitsAllocated
@@ -1302,7 +1300,7 @@ class TestNumpy_GetPixelData:
     def test_double_float_pixel_data(self):
         """Test handling of Double Float Pixel Data."""
         # Only 1 sample per pixel allowed
-        ds = dcmread(IMPL_32_1_1F)
+        ds = dcmread(get_testdata_file(IMPL_32_1_1F))
         ds.DoubleFloatPixelData = ds.PixelData + ds.PixelData
         del ds.PixelData
         ds.BitsAllocated = 64
@@ -1312,9 +1310,9 @@ class TestNumpy_GetPixelData:
     def test_big_endian_rgb_data(self):
         """RGB data encoded as OW in Big Endian transfer syntax shall
         yield the same data as if encoded in Little Endian."""
-        ds1 = dcmread(EXPL_8_3_1F_ODD)
+        ds1 = dcmread(get_testdata_file(EXPL_8_3_1F_ODD))
         data1 = ds1.pixel_array
-        ds2 = dcmread(EXPL_8_3_1F_ODD_BIGE)
+        ds2 = dcmread(get_testdata_file(EXPL_8_3_1F_ODD_BIGE))
         data2 = ds2.pixel_array
         assert len(data1) == len(data2)
         assert (data1 == data2).all()

--- a/pydicom/tests/test_pillow_pixel_data.py
+++ b/pydicom/tests/test_pillow_pixel_data.py
@@ -55,51 +55,49 @@ TEST_JPEG2K = TEST_PIL and HAVE_JPEG2K
 # PI: PhotometricInterpretation
 # FMT_BA_BV_SPX_PR_FRAMESF_PI
 # JPGB: 1.2.840.10008.1.2.4.50 - JPEG Baseline (8-bit only)
-JPGB_08_08_3_0_1F_YBR_FULL = get_testdata_file("SC_rgb_small_odd_jpeg.dcm")
-JPGB_08_08_3_0_120F_YBR_FULL_422 = get_testdata_file("color3d_jpeg_baseline.dcm")  # noqa
+JPGB_08_08_3_0_120F_YBR_FULL_422 = "color3d_jpeg_baseline.dcm"
 # Different subsampling 411, 422, 444
-JPGB_08_08_3_0_1F_YBR_FULL_422_411 = get_testdata_file("SC_rgb_dcmtk_+eb+cy+np.dcm")  # noqa
-JPGB_08_08_3_0_1F_YBR_FULL_422_422 = get_testdata_file("SC_rgb_dcmtk_+eb+cy+s2.dcm")  # noqa
-JPGB_08_08_3_0_1F_YBR_FULL_411 = get_testdata_file("SC_rgb_dcmtk_+eb+cy+n1.dcm")  # noqa
-JPGB_08_08_3_0_1F_YBR_FULL_422 = get_testdata_file("SC_rgb_dcmtk_+eb+cy+n2.dcm")  # noqa
-JPGB_08_08_3_0_1F_YBR_FULL_444 = get_testdata_file("SC_rgb_dcmtk_+eb+cy+s4.dcm")  # noqa
-JPGB_08_08_3_0_1F_RGB = get_testdata_file("SC_jpeg_no_color_transform.dcm")
-JPGB_08_08_3_0_1F_RGB_APP14 = get_testdata_file("SC_jpeg_no_color_transform_2.dcm")  # noqa
+JPGB_08_08_3_0_1F_YBR_FULL_422_411 = "SC_rgb_dcmtk_+eb+cy+np.dcm"
+JPGB_08_08_3_0_1F_YBR_FULL_422_422 = "SC_rgb_dcmtk_+eb+cy+s2.dcm"
+JPGB_08_08_3_0_1F_YBR_FULL_411 = "SC_rgb_dcmtk_+eb+cy+n1.dcm"
+JPGB_08_08_3_0_1F_YBR_FULL_422 = "SC_rgb_dcmtk_+eb+cy+n2.dcm"
+JPGB_08_08_3_0_1F_YBR_FULL_444 = "SC_rgb_dcmtk_+eb+cy+s4.dcm"
+JPGB_08_08_3_0_1F_RGB = "SC_jpeg_no_color_transform.dcm"
+JPGB_08_08_3_0_1F_RGB_APP14 = "SC_jpeg_no_color_transform_2.dcm"
 # JPGE: 1.2.840.10008.1.2.4.51 - JPEG Extended (Process 2 and 4) (8 and 12-bit)
 # No supported datasets available
 
 # JPEG 2000 - ISO/IEC 15444 Standard
 # J2KR: 1.2.840.100008.1.2.4.90 - JPEG 2000 Lossless
-J2KR_08_08_3_0_1F_YBR_ICT = get_testdata_file("US1_J2KR.dcm")
-J2KR_16_10_1_0_1F_M1 = get_testdata_file("RG3_J2KR.dcm")
-J2KR_16_12_1_0_1F_M2 = get_testdata_file("MR2_J2KR.dcm")
-J2KR_16_15_1_0_1F_M1 = get_testdata_file("RG1_J2KR.dcm")
-J2KR_16_16_1_0_10F_M2 = get_testdata_file("emri_small_jpeg_2k_lossless.dcm")
-J2KR_16_14_1_1_1F_M2 = get_testdata_file("693_J2KR.dcm")
-J2KR_16_16_1_1_1F_M2 = get_testdata_file("MR_small_jp2klossless.dcm")
-J2KR_16_13_1_1_1F_M2_MISMATCH = get_testdata_file("J2K_pixelrep_mismatch.dcm")
+J2KR_08_08_3_0_1F_YBR_ICT = "US1_J2KR.dcm"
+J2KR_16_10_1_0_1F_M1 = "RG3_J2KR.dcm"
+J2KR_16_12_1_0_1F_M2 = "MR2_J2KR.dcm"
+J2KR_16_15_1_0_1F_M1 = "RG1_J2KR.dcm"
+J2KR_16_16_1_0_10F_M2 = "emri_small_jpeg_2k_lossless.dcm"
+J2KR_16_14_1_1_1F_M2 = "693_J2KR.dcm"
+J2KR_16_16_1_1_1F_M2 = "MR_small_jp2klossless.dcm"
+J2KR_16_13_1_1_1F_M2_MISMATCH = "J2K_pixelrep_mismatch.dcm"
 # J2KI: 1.2.840.10008.1.2.4.91 - JPEG 2000
-J2KI_08_08_3_0_1F_RGB = get_testdata_file("SC_rgb_gdcm_KY.dcm")
-J2KI_08_08_3_0_1F_YBR_ICT = get_testdata_file("US1_J2KI.dcm")
-J2KI_16_10_1_0_1F_M1 = get_testdata_file("RG3_J2KI.dcm")
-J2KI_16_12_1_0_1F_M2 = get_testdata_file("MR2_J2KI.dcm")
-J2KI_16_15_1_0_1F_M1 = get_testdata_file("RG1_J2KI.dcm")
-J2KI_16_14_1_1_1F_M2 = get_testdata_file("693_J2KI.dcm")
-J2KI_16_16_1_1_1F_M2 = get_testdata_file("JPEG2000.dcm")
+J2KI_08_08_3_0_1F_RGB = "SC_rgb_gdcm_KY.dcm"
+J2KI_08_08_3_0_1F_YBR_ICT = "US1_J2KI.dcm"
+J2KI_16_10_1_0_1F_M1 = "RG3_J2KI.dcm"
+J2KI_16_12_1_0_1F_M2 = "MR2_J2KI.dcm"
+J2KI_16_15_1_0_1F_M1 = "RG1_J2KI.dcm"
+J2KI_16_14_1_1_1F_M2 = "693_J2KI.dcm"
+J2KI_16_16_1_1_1F_M2 = "JPEG2000.dcm"
 
 # Transfer syntaxes supported by other handlers
-IMPL = get_testdata_file("MR_small_implicit.dcm")
-EXPL = get_testdata_file("OBXXXX1A.dcm")
-EXPB = get_testdata_file("OBXXXX1A_expb.dcm")
-DEFL = get_testdata_file("image_dfl.dcm")
-JPEG_LS_LOSSLESS = get_testdata_file("MR_small_jpeg_ls_lossless.dcm")
-RLE = get_testdata_file("MR_small_RLE.dcm")
-JPGE_16_12_1_0_1F_M2 = get_testdata_file("JPEG-lossy.dcm")
-JPGL_16_16_1_1_1F_M2 = get_testdata_file("JPEG-LL.dcm")
+IMPL = "MR_small_implicit.dcm"
+EXPL = "OBXXXX1A.dcm"
+EXPB = "OBXXXX1A_expb.dcm"
+DEFL = "image_dfl.dcm"
+JPEG_LS_LOSSLESS = "MR_small_jpeg_ls_lossless.dcm"
+RLE = "MR_small_RLE.dcm"
+JPGE_16_12_1_0_1F_M2 = "JPEG-lossy.dcm"
 # JPGL14: 1.2.840.10008.1.2.4.57 - JPEG Lossless P14
 # No datasets available
 # JPGL: 1.2.840.10008.1.2.4.70 - JPEG Lossless, Non-hierarchical, 1st Order
-JPGL_08_08_1_0_1F = get_testdata_file("JPGLosslessP14SV1_1s_1f_8b.dcm")
+JPGL_08_08_1_0_1F = "JPGLosslessP14SV1_1s_1f_8b.dcm"
 
 
 # Transfer Syntaxes (non-retired + Explicit VR Big Endian)
@@ -153,43 +151,44 @@ class TestNoNumpy_NoPillowHandler:
         assert not HAVE_NP
         assert PIL_HANDLER is not None
 
-    def test_can_access_supported_dataset(self):
+    def test_can_access_supported_dataset(
+            self, jpeg_lossless_name, color_3d_jpeg_baseline_name, jpeg_lossy_name):
         """Test that we can read and access elements in dataset."""
         # JPEG Baseline
-        ds = dcmread(JPGB_08_08_3_0_120F_YBR_FULL_422)
+        ds = dcmread(color_3d_jpeg_baseline_name)
         assert 'PLA' == ds.PatientName
         assert 6108928 == len(ds.PixelData)
 
         # JPEG Extended
-        ds = dcmread(JPGE_16_12_1_0_1F_M2)
+        ds = dcmread(jpeg_lossy_name)
         assert 'CompressedSamples^NM1' == ds.PatientName
         assert 6846 == len(ds.PixelData)
 
         # JPEG Lossless
-        ds = dcmread(JPGL_16_16_1_1_1F_M2)
+        ds = dcmread(jpeg_lossless_name)
         assert 'CompressedSamples^NM1' == ds.PatientName
         assert 116076 == len(ds.PixelData)
 
         # JPEG 2000
-        ds = dcmread(J2KR_16_10_1_0_1F_M1)
+        ds = dcmread(get_testdata_file(J2KR_16_10_1_0_1F_M1))
         assert 'CompressedSamples^RG3' == ds.PatientName
         assert 830542 == len(ds.PixelData)
 
         # JPEG 2000 Lossless
-        ds = dcmread(J2KI_08_08_3_0_1F_RGB)
+        ds = dcmread(get_testdata_file(J2KI_08_08_3_0_1F_RGB))
         assert 'Lestrade^G' == ds.PatientName
         assert 1286 == len(ds.PixelData)
 
     @pytest.mark.parametrize("fpath,data", REFERENCE_DATA_UNSUPPORTED)
     def test_can_access_unsupported_dataset(self, fpath, data):
         """Test can read and access elements in unsupported datasets."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert data[0] == ds.file_meta.TransferSyntaxUID
         assert data[1] == ds.PatientName
 
     def test_pixel_array_raises(self):
         """Test pixel_array raises exception for all syntaxes."""
-        ds = dcmread(IMPL)
+        ds = dcmread(get_testdata_file(IMPL))
         for uid in AllTransferSyntaxes:
             ds.file_meta.TransferSyntaxUID = uid
             with pytest.raises(NotImplementedError,
@@ -197,7 +196,7 @@ class TestNoNumpy_NoPillowHandler:
                 ds.pixel_array
 
     def test_using_pillow_handler_raises(self):
-        ds = dcmread(J2KI_08_08_3_0_1F_RGB)
+        ds = dcmread(get_testdata_file(J2KI_08_08_3_0_1F_RGB))
         msg = ("The pixel data handler 'pillow' is not available on your "
                "system. Please refer to the pydicom documentation*")
         with pytest.raises(RuntimeError, match=msg):
@@ -239,7 +238,7 @@ JPEG_MATCHING_DATASETS = [
     # (compressed, reference, hard coded check values)
     pytest.param(
         JPGB_08_08_3_0_1F_YBR_FULL_422_411,
-        get_testdata_file("SC_rgb_dcmtk_ebcynp_dcmd.dcm"),
+        "SC_rgb_dcmtk_ebcynp_dcmd.dcm",
         [
             (253, 1, 0), (253, 128, 132), (0, 255, 5), (127, 255, 127),
             (1, 0, 254), (127, 128, 255), (0, 0, 0), (64, 64, 64),
@@ -249,7 +248,7 @@ JPEG_MATCHING_DATASETS = [
     ),
     pytest.param(
         JPGB_08_08_3_0_1F_YBR_FULL_422_422,
-        get_testdata_file("SC_rgb_dcmtk_ebcys2_dcmd.dcm"),
+        "SC_rgb_dcmtk_ebcys2_dcmd.dcm",
         [
             (254, 0, 0), (255, 127, 127), (0, 255, 5), (129, 255, 129),
             (0, 0, 254), (128, 127, 255), (0, 0, 0), (64, 64, 64),
@@ -258,7 +257,7 @@ JPEG_MATCHING_DATASETS = [
     ),
     pytest.param(
         JPGB_08_08_3_0_1F_YBR_FULL_411,
-        get_testdata_file("SC_rgb_dcmtk_ebcyn1_dcmd.dcm"),
+        "SC_rgb_dcmtk_ebcyn1_dcmd.dcm",
         [
             (253, 1, 0), (253, 128, 132), (0, 255, 5), (127, 255, 127),
             (1, 0, 254), (127, 128, 255), (0, 0, 0), (64, 64, 64),
@@ -268,7 +267,7 @@ JPEG_MATCHING_DATASETS = [
     ),
     pytest.param(
         JPGB_08_08_3_0_1F_YBR_FULL_422,
-        get_testdata_file("SC_rgb_dcmtk_ebcyn2_dcmd.dcm"),
+        "SC_rgb_dcmtk_ebcyn2_dcmd.dcm",
         [
             (254, 0, 0), (255, 127, 127), (0, 255, 5), (129, 255, 129),
             (0, 0, 254), (128, 127, 255), (0, 0, 0), (64, 64, 64),
@@ -277,7 +276,7 @@ JPEG_MATCHING_DATASETS = [
     ),
     pytest.param(
         JPGB_08_08_3_0_1F_YBR_FULL_444,
-        get_testdata_file("SC_rgb_dcmtk_ebcys4_dcmd.dcm"),
+        "SC_rgb_dcmtk_ebcys4_dcmd.dcm",
         [
             (254, 0, 0), (255, 127, 127), (0, 255, 5), (129, 255, 129),
             (0, 0, 254), (128, 127, 255), (0, 0, 0), (64, 64, 64),
@@ -286,7 +285,7 @@ JPEG_MATCHING_DATASETS = [
     ),
     pytest.param(
         JPGB_08_08_3_0_1F_RGB,
-        get_testdata_file("SC_rgb_jpeg_dcmd.dcm"),
+        "SC_rgb_jpeg_dcmd.dcm",
         [
             (244, 244, 244), (244, 244, 244), (244, 244, 244), (244, 244, 244),
             (236, 237, 234), (244, 244, 244), (244, 244, 244), (244, 244, 244),
@@ -295,7 +294,7 @@ JPEG_MATCHING_DATASETS = [
     ),
     pytest.param(
         JPGB_08_08_3_0_1F_RGB_APP14,
-        get_testdata_file("SC_rgb_jpeg_app14_dcmd.dcm"),
+        "SC_rgb_jpeg_app14_dcmd.dcm",
         [
             (246, 246, 246), (246, 246, 246), (246, 246, 246), (246, 246, 246),
             (246, 246, 246), (244, 244, 246), (246, 246, 246), (246, 246, 246),
@@ -307,78 +306,78 @@ JPEG2K_MATCHING_DATASETS = [
     # (compressed, reference, fixes)
     pytest.param(
         J2KR_08_08_3_0_1F_YBR_ICT,
-        get_testdata_file("US1_UNCR.dcm"),
+        "US1_UNCR.dcm",
         {},
     ),
     pytest.param(
         J2KR_16_10_1_0_1F_M1,
-        get_testdata_file("RG3_UNCR.dcm"),
+        "RG3_UNCR.dcm",
         {},
     ),
     pytest.param(
         J2KR_16_12_1_0_1F_M2,
-        get_testdata_file("MR2_UNCR.dcm"),
+        "MR2_UNCR.dcm",
         {},
     ),
     pytest.param(
         J2KR_16_15_1_0_1F_M1,
-        get_testdata_file("RG1_UNCR.dcm"),
+        "RG1_UNCR.dcm",
         {},
     ),
     pytest.param(
         J2KR_16_16_1_0_10F_M2,
-        get_testdata_file("emri_small.dcm"),
+        "emri_small.dcm",
         {'BitsStored': 16},
     ),
     pytest.param(
         J2KR_16_14_1_1_1F_M2,
-        get_testdata_file("693_UNCR.dcm"),
+        "693_UNCR.dcm",
         {'BitsStored': 14},
     ),
     pytest.param(
         J2KR_16_16_1_1_1F_M2,
-        get_testdata_file("MR_small.dcm"),
+        "MR_small.dcm",
         {},
     ),
     pytest.param(
         J2KI_08_08_3_0_1F_RGB,
-        get_testdata_file("SC_rgb_gdcm2k_uncompressed.dcm"),
+        "SC_rgb_gdcm2k_uncompressed.dcm",
         {},
     ),
     pytest.param(
         J2KI_08_08_3_0_1F_YBR_ICT,
-        get_testdata_file("US1_UNCI.dcm"),
+        "US1_UNCI.dcm",
         {},
     ),
     pytest.param(
         J2KI_16_10_1_0_1F_M1,
-        get_testdata_file("RG3_UNCI.dcm"),
+        "RG3_UNCI.dcm",
         {},
     ),
     pytest.param(
         J2KI_16_12_1_0_1F_M2,
-        get_testdata_file("MR2_UNCI.dcm"),
+        "MR2_UNCI.dcm",
         {},
     ),
     pytest.param(
         J2KI_16_15_1_0_1F_M1,
-        get_testdata_file("RG1_UNCI.dcm"),
+        "RG1_UNCI.dcm",
         {},
     ),
     pytest.param(
         J2KI_16_14_1_1_1F_M2,
-        get_testdata_file("693_UNCI.dcm"),
+        "693_UNCI.dcm",
         {'BitsStored': 16},
     ),
     pytest.param(
         J2KI_16_16_1_1_1F_M2,
-        get_testdata_file("JPEG2000_UNC.dcm"),
+        "JPEG2000_UNC.dcm",
         {},
     ),
 ]
 
 
-@pytest.mark.skipif(not HAVE_JPEG2K, reason='Pillow or JPEG2K not available')
+@pytest.mark.skipif(not TEST_JPEG2K, reason='Pillow or JPEG2K not available')
 class TestPillowHandler_JPEG2K:
     """Tests for handling Pixel Data with the handler."""
     def setup_method(self):
@@ -402,7 +401,7 @@ class TestPillowHandler_JPEG2K:
         """Test pixel_array raises exception for unsupported syntaxes."""
         pydicom.config.pixel_data_handlers = [PIL_HANDLER]
 
-        ds = dcmread(EXPL)
+        ds = dcmread(get_testdata_file(EXPL))
         for uid in UNSUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             with pytest.raises((NotImplementedError, RuntimeError)):
@@ -411,7 +410,7 @@ class TestPillowHandler_JPEG2K:
     @pytest.mark.parametrize("fpath, data", REFERENCE_DATA_UNSUPPORTED)
     def test_can_access_unsupported_dataset(self, fpath, data):
         """Test can read and access elements in unsupported datasets."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert data[0] == ds.file_meta.TransferSyntaxUID
         assert data[1] == ds.PatientName
 
@@ -421,7 +420,7 @@ class TestPillowHandler_JPEG2K:
         if data[0] not in JPEG2K_SUPPORTED_SYNTAXES:
             return
 
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert ds.file_meta.TransferSyntaxUID == data[0]
         assert ds.BitsAllocated == data[1]
         assert ds.SamplesPerPixel == data[2]
@@ -442,7 +441,7 @@ class TestPillowHandler_JPEG2K:
     @pytest.mark.parametrize('fpath, rpath, fixes', JPEG2K_MATCHING_DATASETS)
     def test_array(self, fpath, rpath, fixes):
         """Test pixel_array returns correct values."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         # May need to correct some element values
         for kw, val in fixes.items():
             setattr(ds, kw, val)
@@ -450,12 +449,12 @@ class TestPillowHandler_JPEG2K:
         if 'YBR_FULL' in ds.PhotometricInterpretation:
             arr = convert_color_space(arr, ds.PhotometricInterpretation, 'RGB')
 
-        ref = dcmread(rpath).pixel_array
+        ref = dcmread(get_testdata_file(rpath)).pixel_array
         assert np.array_equal(arr, ref)
 
     def test_warning(self):
         """Test that the precision warning works OK."""
-        ds = dcmread(J2KR_16_14_1_1_1F_M2)
+        ds = dcmread(get_testdata_file(J2KR_16_14_1_1_1F_M2))
         msg = (
             r"The \(0028,0101\) 'Bits Stored' value \(16-bit\) doesn't match "
             r"the JPEG 2000 data \(14-bit\). It's recommended that you "
@@ -466,7 +465,7 @@ class TestPillowHandler_JPEG2K:
 
     def test_decompress_using_pillow(self):
         """Test decompressing JPEG2K with pillow handler succeeds."""
-        ds = dcmread(J2KR_16_14_1_1_1F_M2)
+        ds = dcmread(get_testdata_file(J2KR_16_14_1_1_1F_M2))
         ds.BitsStored = 14
         ds.decompress(handler_name='pillow')
         arr = ds.pixel_array
@@ -477,7 +476,7 @@ class TestPillowHandler_JPEG2K:
     def test_changing_bits_stored(self):
         """Test changing BitsStored affects the pixel data."""
         pydicom.config.APPLY_J2K_CORRECTIONS = False
-        ds = dcmread(J2KR_16_14_1_1_1F_M2)
+        ds = dcmread(get_testdata_file(J2KR_16_14_1_1_1F_M2))
         assert 16 == ds.BitsStored
         with pytest.warns(UserWarning):
             arr = ds.pixel_array
@@ -488,7 +487,7 @@ class TestPillowHandler_JPEG2K:
 
     def test_pixel_rep_mismatch(self):
         """Test mismatched j2k sign and Pixel Representation."""
-        ds = dcmread(J2KR_16_13_1_1_1F_M2_MISMATCH)
+        ds = dcmread(get_testdata_file(J2KR_16_13_1_1_1F_M2_MISMATCH))
         assert 1 == ds.PixelRepresentation
         assert 13 == ds.BitsStored
 
@@ -511,7 +510,7 @@ class TestPillowHandler_JPEG2K:
         )
 
 
-@pytest.mark.skipif(not HAVE_JPEG, reason='Pillow or JPEG not available')
+@pytest.mark.skipif(not TEST_JPEG, reason='Pillow or JPEG not available')
 class TestPillowHandler_JPEG:
     """Tests for handling Pixel Data with the handler."""
     def setup_method(self):
@@ -533,7 +532,7 @@ class TestPillowHandler_JPEG:
         """Test pixel_array raises exception for unsupported syntaxes."""
         pydicom.config.pixel_data_handlers = [PIL_HANDLER]
 
-        ds = dcmread(EXPL)
+        ds = dcmread(get_testdata_file(EXPL))
         for uid in UNSUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             with pytest.raises((NotImplementedError, RuntimeError)):
@@ -542,7 +541,7 @@ class TestPillowHandler_JPEG:
     @pytest.mark.parametrize("fpath, data", REFERENCE_DATA_UNSUPPORTED)
     def test_can_access_unsupported_dataset(self, fpath, data):
         """Test can read and access elements in unsupported datasets."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert data[0] == ds.file_meta.TransferSyntaxUID
         assert data[1] == ds.PatientName
 
@@ -552,7 +551,7 @@ class TestPillowHandler_JPEG:
         if data[0] not in JPEG_SUPPORTED_SYNTAXES:
             return
 
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert ds.file_meta.TransferSyntaxUID == data[0]
         assert ds.BitsAllocated == data[1]
         assert ds.SamplesPerPixel == data[2]
@@ -567,12 +566,12 @@ class TestPillowHandler_JPEG:
     @pytest.mark.parametrize('fpath, rpath, values', JPEG_MATCHING_DATASETS)
     def test_array(self, fpath, rpath, values):
         """Test pixel_array returns correct values."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         arr = ds.pixel_array
         if 'YBR' in ds.PhotometricInterpretation:
             arr = convert_color_space(arr, ds.PhotometricInterpretation, 'RGB')
 
-        ref = dcmread(rpath).pixel_array
+        ref = dcmread(get_testdata_file(rpath)).pixel_array
 
         if values:
             assert tuple(arr[5, 50, :]) == values[0]
@@ -590,7 +589,7 @@ class TestPillowHandler_JPEG:
 
     def test_color_3d(self):
         """Test decoding JPEG with pillow handler succeeds."""
-        ds = dcmread(JPGB_08_08_3_0_120F_YBR_FULL_422)
+        ds = dcmread(get_testdata_file("color3d_jpeg_baseline.dcm"))
         assert "YBR_FULL_422" == ds.PhotometricInterpretation
         arr = ds.pixel_array
         assert arr.flags.writeable
@@ -604,7 +603,7 @@ class TestPillowHandler_JPEG:
 
     def test_JPGE_16bit_raises(self):
         """Test decoding JPEG lossy with pillow handler fails."""
-        ds = dcmread(JPGE_16_12_1_0_1F_M2)
+        ds = dcmread(get_testdata_file(JPGE_16_12_1_0_1F_M2))
         msg = (
             r"1.2.840.10008.1.2.4.51 - JPEG Extended \(Process 2 and 4\) only "
             r"supported by Pillow if Bits Allocated = 8"
@@ -612,16 +611,16 @@ class TestPillowHandler_JPEG:
         with pytest.raises(NotImplementedError, match=msg):
             ds.pixel_array
 
-    def test_JPGL_raises(self):
+    def test_JPGL_raises(self, jpeg_lossless_name):
         """Test decoding JPEG Lossless with pillow handler fails."""
-        ds = dcmread(JPGL_16_16_1_1_1F_M2)
+        ds = dcmread(jpeg_lossless_name)
         msg = r"as there are no pixel data handlers available that support it"
         with pytest.raises(NotImplementedError, match=msg):
             ds.pixel_array
 
     def test_JPGB_odd_data_size(self):
         """Test decoding JPEG Baseline with pillow handler succeeds."""
-        ds = dcmread(JPGB_08_08_3_0_1F_YBR_FULL)
+        ds = dcmread(get_testdata_file("SC_rgb_small_odd_jpeg.dcm"))
         pixel_data = ds.pixel_array
         assert pixel_data.nbytes == 27
         assert pixel_data.shape == (3, 3, 3)

--- a/pydicom/tests/test_pylibjpeg.py
+++ b/pydicom/tests/test_pylibjpeg.py
@@ -72,10 +72,10 @@ UNSUPPORTED_SYNTAXES = list(
 )
 
 # Transfer syntaxes supported by other handlers
-IMPL = get_testdata_file("MR_small_implicit.dcm")
-EXPL = get_testdata_file("OBXXXX1A.dcm")
-EXPB = get_testdata_file("OBXXXX1A_expb.dcm")
-DEFL = get_testdata_file("image_dfl.dcm")
+IMPL = "MR_small_implicit.dcm"
+EXPL = "OBXXXX1A.dcm"
+EXPB = "OBXXXX1A_expb.dcm"
+DEFL = "image_dfl.dcm"
 
 REFERENCE_DATA_UNSUPPORTED = [
     (IMPL, ('1.2.840.10008.1.2', 'CompressedSamples^MR1')),
@@ -85,37 +85,37 @@ REFERENCE_DATA_UNSUPPORTED = [
 ]
 
 # RLE Lossless - PackBits algorithm
-RLE_8_1_1F = get_testdata_file("OBXXXX1A_rle.dcm")
-RLE_8_1_2F = get_testdata_file("OBXXXX1A_rle_2frame.dcm")
-RLE_8_3_1F = get_testdata_file("SC_rgb_rle.dcm")
-RLE_8_3_2F = get_testdata_file("SC_rgb_rle_2frame.dcm")
-RLE_16_1_1F = get_testdata_file("MR_small_RLE.dcm")
-RLE_16_1_10F = get_testdata_file("emri_small_RLE.dcm")
-RLE_16_3_1F = get_testdata_file("SC_rgb_rle_16bit.dcm")
-RLE_16_3_2F = get_testdata_file("SC_rgb_rle_16bit_2frame.dcm")
-RLE_32_1_1F = get_testdata_file("rtdose_rle_1frame.dcm")
-RLE_32_1_15F = get_testdata_file("rtdose_rle.dcm")
-RLE_32_3_1F = get_testdata_file("SC_rgb_rle_32bit.dcm")
-RLE_32_3_2F = get_testdata_file("SC_rgb_rle_32bit_2frame.dcm")
+RLE_8_1_1F = "OBXXXX1A_rle.dcm"
+RLE_8_1_2F = "OBXXXX1A_rle_2frame.dcm"
+RLE_8_3_1F = "SC_rgb_rle.dcm"
+RLE_8_3_2F = "SC_rgb_rle_2frame.dcm"
+RLE_16_1_1F = "MR_small_RLE.dcm"
+RLE_16_1_10F = "emri_small_RLE.dcm"
+RLE_16_3_1F = "SC_rgb_rle_16bit.dcm"
+RLE_16_3_2F = "SC_rgb_rle_16bit_2frame.dcm"
+RLE_32_1_1F = "rtdose_rle_1frame.dcm"
+RLE_32_1_15F = "rtdose_rle.dcm"
+RLE_32_3_1F = "SC_rgb_rle_32bit.dcm"
+RLE_32_3_2F = "SC_rgb_rle_32bit_2frame.dcm"
 
 # JPEG - ISO/IEC 10918 Standard
 # FMT_BA_BV_SPX_PR_FRAMESF_PI
 # JPGB: 1.2.840.10008.1.2.4.50 - JPEG Baseline (8-bit only)
-JPGB_08_08_3_0_1F_YBR_FULL = get_testdata_file("SC_rgb_small_odd_jpeg.dcm")
-JPGB_08_08_3_0_120F_YBR_FULL_422 = get_testdata_file("color3d_jpeg_baseline.dcm")  # noqa
+JPGB_08_08_3_0_1F_YBR_FULL = "SC_rgb_small_odd_jpeg.dcm"
+JPGB_08_08_3_0_120F_YBR_FULL_422 = "color3d_jpeg_baseline.dcm"  # noqa
 # Different subsampling 411, 422, 444
-JPGB_08_08_3_0_1F_YBR_FULL_422_411 = get_testdata_file("SC_rgb_dcmtk_+eb+cy+np.dcm")  # noqa
-JPGB_08_08_3_0_1F_YBR_FULL_422_422 = get_testdata_file("SC_rgb_dcmtk_+eb+cy+s2.dcm")  # noqa
-JPGB_08_08_3_0_1F_YBR_FULL_411 = get_testdata_file("SC_rgb_dcmtk_+eb+cy+n1.dcm")  # noqa
-JPGB_08_08_3_0_1F_YBR_FULL_422 = get_testdata_file("SC_rgb_dcmtk_+eb+cy+n2.dcm")  # noqa
-JPGB_08_08_3_0_1F_YBR_FULL_444 = get_testdata_file("SC_rgb_dcmtk_+eb+cy+s4.dcm")  # noqa
-JPGB_08_08_3_0_1F_RGB = get_testdata_file("SC_rgb_dcmtk_+eb+cr.dcm")
+JPGB_08_08_3_0_1F_YBR_FULL_422_411 = "SC_rgb_dcmtk_+eb+cy+np.dcm"  # noqa
+JPGB_08_08_3_0_1F_YBR_FULL_422_422 = "SC_rgb_dcmtk_+eb+cy+s2.dcm"  # noqa
+JPGB_08_08_3_0_1F_YBR_FULL_411 = "SC_rgb_dcmtk_+eb+cy+n1.dcm"  # noqa
+JPGB_08_08_3_0_1F_YBR_FULL_422 = "SC_rgb_dcmtk_+eb+cy+n2.dcm"  # noqa
+JPGB_08_08_3_0_1F_YBR_FULL_444 = "SC_rgb_dcmtk_+eb+cy+s4.dcm"  # noqa
+JPGB_08_08_3_0_1F_RGB = "SC_rgb_dcmtk_+eb+cr.dcm"
 # JPGE: 1.2.840.1.2.4.51 - JPEG Extended
-JPGE_BAD = get_testdata_file("JPEG-lossy.dcm")  # Bad JPEG file
-JPGE_16_12_1_0_1F_M2 = get_testdata_file("JPGExtended.dcm")  # Fixed version
+JPGE_BAD = "JPEG-lossy.dcm"  # Bad JPEG file
+JPGE_16_12_1_0_1F_M2 = "JPGExtended.dcm"  # Fixed version
 # JPGL: 1.2.840.10008.1.2.4.70 - JPEG Lossless, Non-hierarchical, 1st Order
-JPGL_08_08_1_0_1F = get_testdata_file("JPGLosslessP14SV1_1s_1f_8b.dcm")
-JPGL_16_16_1_1_1F_M2 = get_testdata_file("JPEG-LL.dcm")
+JPGL_08_08_1_0_1F = "JPGLosslessP14SV1_1s_1f_8b.dcm"
+JPGL_16_16_1_1_1F_M2 = "JPEG-LL.dcm"
 
 JPGB = JPEGBaseline8Bit
 JPGE = JPEGExtended12Bit
@@ -138,7 +138,7 @@ JPG_MATCHING_DATASETS = [
     # (compressed, reference, hard coded check values), px tolerance
     pytest.param(
         JPGB_08_08_3_0_1F_YBR_FULL_422_411,
-        get_testdata_file("SC_rgb_dcmtk_ebcynp_dcmd.dcm"),
+        "SC_rgb_dcmtk_ebcynp_dcmd.dcm",
         [
             (253, 1, 0), (253, 129, 131), (0, 255, 5), (127, 255, 129),
             (0, 0, 254), (127, 128, 255), (0, 0, 0), (64, 64, 64),
@@ -148,7 +148,7 @@ JPG_MATCHING_DATASETS = [
     ),
     pytest.param(
         JPGB_08_08_3_0_1F_YBR_FULL_422_422,
-        get_testdata_file("SC_rgb_dcmtk_ebcys2_dcmd.dcm"),
+        "SC_rgb_dcmtk_ebcys2_dcmd.dcm",
         [
             (254, 0, 0), (255, 127, 127), (0, 255, 5), (129, 255, 129),
             (0, 0, 254), (128, 127, 255), (0, 0, 0), (64, 64, 64),
@@ -158,7 +158,7 @@ JPG_MATCHING_DATASETS = [
     ),
     pytest.param(
         JPGB_08_08_3_0_1F_YBR_FULL_411,
-        get_testdata_file("SC_rgb_dcmtk_ebcyn1_dcmd.dcm"),
+        "SC_rgb_dcmtk_ebcyn1_dcmd.dcm",
         [
             (253, 1, 0), (253, 129, 131), (0, 255, 5), (127, 255, 129),
             (0, 0, 254), (127, 128, 255), (0, 0, 0), (64, 64, 64),
@@ -168,7 +168,7 @@ JPG_MATCHING_DATASETS = [
     ),
     pytest.param(
         JPGB_08_08_3_0_1F_YBR_FULL_422,
-        get_testdata_file("SC_rgb_dcmtk_ebcyn2_dcmd.dcm"),
+        "SC_rgb_dcmtk_ebcyn2_dcmd.dcm",
         [
             (254, 0, 0), (255, 127, 127), (0, 255, 5), (129, 255, 129),
             (0, 0, 254), (128, 127, 255), (0, 0, 0), (64, 64, 64),
@@ -178,7 +178,7 @@ JPG_MATCHING_DATASETS = [
     ),
     pytest.param(
         JPGB_08_08_3_0_1F_YBR_FULL_444,
-        get_testdata_file("SC_rgb_dcmtk_ebcys4_dcmd.dcm"),
+        "SC_rgb_dcmtk_ebcys4_dcmd.dcm",
         [
             (254, 0, 0), (255, 127, 127), (0, 255, 5), (129, 255, 129),
             (0, 0, 254), (128, 127, 255), (0, 0, 0), (64, 64, 64),
@@ -188,7 +188,7 @@ JPG_MATCHING_DATASETS = [
     ),
     pytest.param(
         JPGB_08_08_3_0_1F_RGB,
-        get_testdata_file("SC_rgb_dcmtk_ebcr_dcmd.dcm"),
+        "SC_rgb_dcmtk_ebcr_dcmd.dcm",
         [
             (255, 0, 0), (255, 128, 128), (0, 255, 0), (128, 255, 128),
             (0, 0, 255), (128, 128, 255), (0, 0, 0), (64, 64, 64),
@@ -202,7 +202,7 @@ JPG_MATCHING_DATASETS = [
 # JPEG-LS - ISO/IEC 14495 Standard
 JLSL = JPEGLSNearLossless
 JLSN = JPEGLSLossless
-JPEG_LS_LOSSLESS = get_testdata_file("MR_small_jpeg_ls_lossless.dcm")
+JPEG_LS_LOSSLESS = "MR_small_jpeg_ls_lossless.dcm"
 JLS_REFERENCE_DATA = [
     # fpath, (syntax, bits, nr samples, pixel repr, nr frames, shape, dtype)
     (JPEG_LS_LOSSLESS, (JLSN, 16, 1, 1, 1, (64, 64), 'int16')),
@@ -212,24 +212,24 @@ JLS_REFERENCE_DATA = [
 J2KR = JPEG2000Lossless
 J2KI = JPEG2000
 # J2KR: 1.2.840.100008.1.2.4.90 - JPEG 2000 Lossless
-J2KR_08_08_3_0_1F_YBR_ICT = get_testdata_file("US1_J2KR.dcm")
-J2KR_16_10_1_0_1F_M1 = get_testdata_file("RG3_J2KR.dcm")
-J2KR_16_12_1_0_1F_M2 = get_testdata_file("MR2_J2KR.dcm")
-J2KR_16_15_1_0_1F_M1 = get_testdata_file("RG1_J2KR.dcm")
-J2KR_16_16_1_0_10F_M2 = get_testdata_file("emri_small_jpeg_2k_lossless.dcm")
-J2KR_16_14_1_1_1F_M2 = get_testdata_file("693_J2KR.dcm")
-J2KR_16_16_1_1_1F_M2 = get_testdata_file("MR_small_jp2klossless.dcm")
-J2KR_16_13_1_1_1F_M2_MISMATCH = get_testdata_file("J2K_pixelrep_mismatch.dcm")
+J2KR_08_08_3_0_1F_YBR_ICT = "US1_J2KR.dcm"
+J2KR_16_10_1_0_1F_M1 = "RG3_J2KR.dcm"
+J2KR_16_12_1_0_1F_M2 = "MR2_J2KR.dcm"
+J2KR_16_15_1_0_1F_M1 = "RG1_J2KR.dcm"
+J2KR_16_16_1_0_10F_M2 = "emri_small_jpeg_2k_lossless.dcm"
+J2KR_16_14_1_1_1F_M2 = "693_J2KR.dcm"
+J2KR_16_16_1_1_1F_M2 = "MR_small_jp2klossless.dcm"
+J2KR_16_13_1_1_1F_M2_MISMATCH = "J2K_pixelrep_mismatch.dcm"
 # Non-conformant pixel data -> JP2 header present
-J2KR_08_08_3_0_1F_YBR_RCT = get_testdata_file("GDCMJ2K_TextGBR.dcm")
+J2KR_08_08_3_0_1F_YBR_RCT = "GDCMJ2K_TextGBR.dcm"
 # J2KI: 1.2.840.10008.1.2.4.91 - JPEG 2000
-J2KI_08_08_3_0_1F_RGB = get_testdata_file("SC_rgb_gdcm_KY.dcm")
-J2KI_08_08_3_0_1F_YBR_ICT = get_testdata_file("US1_J2KI.dcm")
-J2KI_16_10_1_0_1F_M1 = get_testdata_file("RG3_J2KI.dcm")
-J2KI_16_12_1_0_1F_M2 = get_testdata_file("MR2_J2KI.dcm")
-J2KI_16_15_1_0_1F_M1 = get_testdata_file("RG1_J2KI.dcm")
-J2KI_16_14_1_1_1F_M2 = get_testdata_file("693_J2KI.dcm")
-J2KI_16_16_1_1_1F_M2 = get_testdata_file("JPEG2000.dcm")
+J2KI_08_08_3_0_1F_RGB = "SC_rgb_gdcm_KY.dcm"
+J2KI_08_08_3_0_1F_YBR_ICT = "US1_J2KI.dcm"
+J2KI_16_10_1_0_1F_M1 = "RG3_J2KI.dcm"
+J2KI_16_12_1_0_1F_M2 = "MR2_J2KI.dcm"
+J2KI_16_15_1_0_1F_M1 = "RG1_J2KI.dcm"
+J2KI_16_14_1_1_1F_M2 = "693_J2KI.dcm"
+J2KI_16_16_1_1_1F_M2 = "JPEG2000.dcm"
 
 J2K_REFERENCE_DATA = [
     # fpath, (syntax, bits, nr samples, pixel repr, nr frames, shape, dtype)
@@ -255,72 +255,72 @@ J2K_MATCHING_DATASETS = [
     # (compressed, reference, fixes)
     pytest.param(
         J2KR_08_08_3_0_1F_YBR_ICT,
-        get_testdata_file("US1_UNCR.dcm"),
+        "US1_UNCR.dcm",
         {},
     ),
     pytest.param(
         J2KR_16_10_1_0_1F_M1,
-        get_testdata_file("RG3_UNCR.dcm"),
+        "RG3_UNCR.dcm",
         {},
     ),
     pytest.param(
         J2KR_16_12_1_0_1F_M2,
-        get_testdata_file("MR2_UNCR.dcm"),
+        "MR2_UNCR.dcm",
         {},
     ),
     pytest.param(
         J2KR_16_15_1_0_1F_M1,
-        get_testdata_file("RG1_UNCR.dcm"),
+        "RG1_UNCR.dcm",
         {},
     ),
     pytest.param(
         J2KR_16_16_1_0_10F_M2,
-        get_testdata_file("emri_small.dcm"),
+        "emri_small.dcm",
         {'BitsStored': 16},
     ),
     pytest.param(
         J2KR_16_14_1_1_1F_M2,
-        get_testdata_file("693_UNCR.dcm"),
+        "693_UNCR.dcm",
         {'BitsStored': 14},
     ),
     pytest.param(
         J2KR_16_16_1_1_1F_M2,
-        get_testdata_file("MR_small.dcm"),
+        "MR_small.dcm",
         {},
     ),
     pytest.param(
         J2KI_08_08_3_0_1F_RGB,
-        get_testdata_file("SC_rgb_gdcm2k_uncompressed.dcm"),
+        "SC_rgb_gdcm2k_uncompressed.dcm",
         {},
     ),
     pytest.param(
         J2KI_08_08_3_0_1F_YBR_ICT,
-        get_testdata_file("US1_UNCI.dcm"),
+        "US1_UNCI.dcm",
         {},
     ),
     pytest.param(
         J2KI_16_10_1_0_1F_M1,
-        get_testdata_file("RG3_UNCI.dcm"),
+        "RG3_UNCI.dcm",
         {},
     ),
     pytest.param(
         J2KI_16_12_1_0_1F_M2,
-        get_testdata_file("MR2_UNCI.dcm"),
+        "MR2_UNCI.dcm",
         {},
     ),
     pytest.param(
         J2KI_16_15_1_0_1F_M1,
-        get_testdata_file("RG1_UNCI.dcm"),
+        "RG1_UNCI.dcm",
         {},
     ),
     pytest.param(
         J2KI_16_14_1_1_1F_M2,
-        get_testdata_file("693_UNCI.dcm"),
+        "693_UNCI.dcm",
         {'BitsStored': 16},
     ),
     pytest.param(
         J2KI_16_16_1_1_1F_M2,
-        get_testdata_file("JPEG2000_UNC.dcm"),
+        "JPEG2000_UNC.dcm",
         {},
     ),
 ]
@@ -351,11 +351,11 @@ class TestHandler:
         assert HAVE_PYLIBJPEG
         assert LJ_HANDLER is not None
 
-    def test_unsupported_syntax_raises(self):
+    def test_unsupported_syntax_raises(self, mono_8bit_1frame_name):
         """Test pixel_array raises exception for unsupported syntaxes."""
         pydicom.config.pixel_data_handlers = [LJ_HANDLER]
 
-        ds = dcmread(EXPL)
+        ds = dcmread(mono_8bit_1frame_name)
         for uid in UNSUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             with pytest.raises((NotImplementedError, RuntimeError)):
@@ -366,7 +366,7 @@ class TestHandler:
     )
     def test_no_plugins_raises(self):
         """Test exception raised if required plugin missing."""
-        ds = dcmread(JPGB_08_08_3_0_1F_YBR_FULL)
+        ds = dcmread(get_testdata_file(JPGB_08_08_3_0_1F_YBR_FULL))
         msg = (
             r"Unable to convert the Pixel Data as the 'pylibjpeg-libjpeg' "
             r"plugin is not installed"
@@ -374,7 +374,7 @@ class TestHandler:
         with pytest.raises(RuntimeError, match=msg):
             ds.pixel_array
 
-        ds = dcmread(J2KI_08_08_3_0_1F_RGB)
+        ds = dcmread(get_testdata_file(J2KI_08_08_3_0_1F_RGB))
         msg = (
             r"Unable to convert the Pixel Data as the 'pylibjpeg-openjpeg' "
             r"plugin is not installed"
@@ -383,7 +383,7 @@ class TestHandler:
             ds.pixel_array
 
         # Don't use pydicom decoder
-        ds = dcmread(RLE_8_1_1F)
+        ds = dcmread(get_testdata_file(RLE_8_1_1F))
         msg = (
             r"Unable to convert the Pixel Data as the 'pylibjpeg-rle' "
             r"plugin is not installed"
@@ -393,7 +393,7 @@ class TestHandler:
 
     def test_change_photometric_interpretation(self):
         """Test returned value."""
-        ds = dcmread(J2KR_16_12_1_0_1F_M2)
+        ds = dcmread(get_testdata_file(J2KR_16_12_1_0_1F_M2))
         func = LJ_HANDLER.should_change_PhotometricInterpretation_to_RGB
         assert func(ds) is False
 
@@ -412,7 +412,7 @@ class TestJPEG:
     @pytest.mark.parametrize('fpath, data', JPG_REFERENCE_DATA)
     def test_properties(self, fpath, data):
         """Test dataset and pixel array properties are as expected."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert ds.file_meta.TransferSyntaxUID == data[0]
         assert ds.BitsAllocated == data[1]
         assert ds.SamplesPerPixel == data[2]
@@ -428,12 +428,12 @@ class TestJPEG:
     @pytest.mark.parametrize('fpath, rpath, val, tol', JPG_MATCHING_DATASETS)
     def test_array(self, fpath, rpath, val, tol):
         """Test pixel_array returns correct values."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         arr = ds.pixel_array
         if 'YBR' in ds.PhotometricInterpretation:
             arr = convert_color_space(arr, ds.PhotometricInterpretation, 'RGB')
 
-        ref = dcmread(rpath).pixel_array
+        ref = dcmread(get_testdata_file(rpath)).pixel_array
 
         if val:
             assert tuple(arr[5, 50, :]) == val[0]
@@ -453,9 +453,9 @@ class TestJPEG:
     @pytest.mark.parametrize('fpath, rpath, val, tol', JPG_MATCHING_DATASETS)
     def test_generate_frames(self, fpath, rpath, val, tol):
         """Test pixel_array returns correct values."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         frame_generator = generate_frames(ds)
-        ref = dcmread(rpath).pixel_array
+        ref = dcmread(get_testdata_file(rpath)).pixel_array
 
         nr_frames = getattr(ds, 'NumberOfFrames', 1)
         for ii in range(nr_frames):
@@ -475,7 +475,7 @@ class TestJPEG:
 
     def test_bad_file_raises(self):
         """Test a bad JPEG file raises an exception."""
-        ds = dcmread(JPGE_BAD)
+        ds = dcmread(get_testdata_file(JPGE_BAD))
         msg = (
             r"libjpeg error code '-1038' returned from Decode\(\): A "
             r"misplaced marker segment was found - scan start must be zero "
@@ -486,7 +486,7 @@ class TestJPEG:
 
     def test_missing_element_raises(self):
         """Test that missing required element raises exception."""
-        ds = dcmread(JPGB_08_08_3_0_1F_YBR_FULL)
+        ds = dcmread(get_testdata_file(JPGB_08_08_3_0_1F_YBR_FULL))
         del ds.PixelData
         msg = (
             r"Unable to convert the pixel data as the following required "
@@ -510,7 +510,7 @@ class TestJPEGLS:
     @pytest.mark.parametrize('fpath, data', JLS_REFERENCE_DATA)
     def test_properties(self, fpath, data):
         """Test dataset and pixel array properties are as expected."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert ds.file_meta.TransferSyntaxUID == data[0]
         assert ds.BitsAllocated == data[1]
         assert ds.SamplesPerPixel == data[2]
@@ -525,7 +525,7 @@ class TestJPEGLS:
 
     def test_arrary(self):
         """Test returned array values are OK."""
-        ds = dcmread(JPEG_LS_LOSSLESS)
+        ds = dcmread(get_testdata_file(JPEG_LS_LOSSLESS))
         arr = ds.pixel_array
 
         # Checked against GDCM
@@ -555,7 +555,7 @@ class TestJPEG2K:
             J2KI_16_14_1_1_1F_M2
         ]
 
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert ds.file_meta.TransferSyntaxUID == data[0]
         assert ds.BitsAllocated == data[1]
         assert ds.SamplesPerPixel == data[2]
@@ -587,22 +587,22 @@ class TestJPEG2K:
     @pytest.mark.parametrize('fpath, rpath, fixes', J2K_MATCHING_DATASETS)
     def test_array(self, fpath, rpath, fixes):
         """Test pixel_array returns correct values."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         if fixes:
             with pytest.warns(UserWarning):
                 arr = ds.pixel_array
         else:
             arr = ds.pixel_array
 
-        ref = dcmread(rpath).pixel_array
+        ref = dcmread(get_testdata_file(rpath)).pixel_array
         assert np.array_equal(arr, ref)
 
     @pytest.mark.parametrize('fpath, rpath, fixes', J2K_MATCHING_DATASETS)
     def test_generate_frames(self, fpath, rpath, fixes):
         """Test pixel_array returns correct values."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         frame_generator = generate_frames(ds)
-        ref = dcmread(rpath).pixel_array
+        ref = dcmread(get_testdata_file(rpath)).pixel_array
 
         nr_frames = getattr(ds, 'NumberOfFrames', 1)
         for ii in range(nr_frames):
@@ -623,7 +623,7 @@ class TestJPEG2K:
     def test_warnings(self):
         """Test the plugin warnings work."""
         # Bits Stored
-        ds = dcmread(J2KR_16_14_1_1_1F_M2)
+        ds = dcmread(get_testdata_file(J2KR_16_14_1_1_1F_M2))
         msg = (
             r"The \(0028,0101\) Bits Stored value '16' in the dataset does "
             r"not match the component precision value '14' found in the JPEG "
@@ -658,7 +658,7 @@ class TestJPEG2K:
                 ds.pixel_array
 
         # JP2 header
-        ds = dcmread(J2KR_08_08_3_0_1F_YBR_RCT)
+        ds = dcmread(get_testdata_file(J2KR_08_08_3_0_1F_YBR_RCT))
         msg = (
             r"The \(7FE0,0010\) Pixel Data contains a JPEG 2000 codestream "
             r"with the optional JP2 file format header, which is "
@@ -669,7 +669,7 @@ class TestJPEG2K:
 
     def test_decompress_using_pylibjpeg(self):
         """Test decompressing JPEG2K with pylibjpeg handler succeeds."""
-        ds = dcmread(J2KR_16_12_1_0_1F_M2)
+        ds = dcmread(get_testdata_file(J2KR_16_12_1_0_1F_M2))
         ds.decompress(handler_name='pylibjpeg')
         arr = ds.pixel_array
 
@@ -679,7 +679,7 @@ class TestJPEG2K:
 
     def test_pixel_rep_mismatch(self):
         """Test mismatched j2k sign and Pixel Representation."""
-        ds = dcmread(J2KR_16_13_1_1_1F_M2_MISMATCH)
+        ds = dcmread(get_testdata_file(J2KR_16_13_1_1_1F_M2_MISMATCH))
         assert 1 == ds.PixelRepresentation
         assert 13 == ds.BitsStored
 
@@ -722,18 +722,18 @@ RLE_REFERENCE_DATA = [
 ]
 RLE_MATCHING_DATASETS = [
     # (compressed, reference)
-    pytest.param(RLE_8_1_1F, get_testdata_file("OBXXXX1A.dcm")),
-    pytest.param(RLE_8_1_2F, get_testdata_file("OBXXXX1A_2frame.dcm")),
-    pytest.param(RLE_8_3_1F, get_testdata_file("SC_rgb.dcm")),
-    pytest.param(RLE_8_3_2F, get_testdata_file("SC_rgb_2frame.dcm")),
-    pytest.param(RLE_16_1_1F, get_testdata_file("MR_small.dcm")),
-    pytest.param(RLE_16_1_10F, get_testdata_file("emri_small.dcm")),
-    pytest.param(RLE_16_3_1F, get_testdata_file("SC_rgb_16bit.dcm")),
-    pytest.param(RLE_16_3_2F, get_testdata_file("SC_rgb_16bit_2frame.dcm")),
-    pytest.param(RLE_32_1_1F, get_testdata_file("rtdose_1frame.dcm")),
-    pytest.param(RLE_32_1_15F, get_testdata_file("rtdose.dcm")),
-    pytest.param(RLE_32_3_1F, get_testdata_file("SC_rgb_32bit.dcm")),
-    pytest.param(RLE_32_3_2F, get_testdata_file("SC_rgb_32bit_2frame.dcm")),
+    pytest.param(RLE_8_1_1F, "OBXXXX1A.dcm"),
+    pytest.param(RLE_8_1_2F, "OBXXXX1A_2frame.dcm"),
+    pytest.param(RLE_8_3_1F, "SC_rgb.dcm"),
+    pytest.param(RLE_8_3_2F, "SC_rgb_2frame.dcm"),
+    pytest.param(RLE_16_1_1F, "MR_small.dcm"),
+    pytest.param(RLE_16_1_10F, "emri_small.dcm"),
+    pytest.param(RLE_16_3_1F, "SC_rgb_16bit.dcm"),
+    pytest.param(RLE_16_3_2F, "SC_rgb_16bit_2frame.dcm"),
+    pytest.param(RLE_32_1_1F, "rtdose_1frame.dcm"),
+    pytest.param(RLE_32_1_15F, "rtdose.dcm"),
+    pytest.param(RLE_32_3_1F, "SC_rgb_32bit.dcm"),
+    pytest.param(RLE_32_3_2F, "SC_rgb_32bit_2frame.dcm"),
 ]
 
 
@@ -741,7 +741,7 @@ RLE_MATCHING_DATASETS = [
 class TestRLE:
     def test_decompress_using_pylibjpeg(self):
         """Test decompressing RLE with pylibjpeg handler succeeds."""
-        ds = dcmread(RLE_8_3_1F)
+        ds = dcmread(get_testdata_file(RLE_8_3_1F))
         ds.decompress(handler_name='pylibjpeg')
         arr = ds.pixel_array
 
@@ -752,7 +752,7 @@ class TestRLE:
     @pytest.mark.parametrize('fpath, data', RLE_REFERENCE_DATA)
     def test_properties_as_array(self, fpath, data):
         """Test dataset, pixel_array and as_array() are as expected."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert RLELossless == ds.file_meta.TransferSyntaxUID
         assert ds.BitsAllocated == data[0]
         assert ds.SamplesPerPixel == data[1]
@@ -769,7 +769,7 @@ class TestRLE:
         assert arr.dtype == data[5]
 
         # Check handler's as_array() function
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         arr = as_array(ds)
         assert arr.flags.writeable
         assert data[4] == arr.shape
@@ -778,19 +778,19 @@ class TestRLE:
     @pytest.mark.parametrize('fpath, rpath', RLE_MATCHING_DATASETS)
     def test_array(self, fpath, rpath):
         """Test pixel_array returns correct values."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         ds.decompress("pylibjpeg")
         arr = ds.pixel_array
 
-        ref = dcmread(rpath).pixel_array
+        ref = dcmread(get_testdata_file(rpath)).pixel_array
         assert np.array_equal(arr, ref)
 
     @pytest.mark.parametrize('fpath, rpath', RLE_MATCHING_DATASETS)
     def test_generate_frames(self, fpath, rpath):
         """Test pixel_array returns correct values."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         frame_generator = generate_frames(ds)
-        ref = dcmread(rpath).pixel_array
+        ref = dcmread(get_testdata_file(rpath)).pixel_array
 
         nr_frames = getattr(ds, 'NumberOfFrames', 1)
         for ii in range(nr_frames):
@@ -807,9 +807,9 @@ class TestRLE:
 
 @pytest.mark.skipif(not TEST_RLE, reason="no -rle plugin")
 class TestRLEEncoding:
-    def test_encode(self):
+    def test_encode(self, mono_8bit_1frame_name):
         """Test encoding"""
-        ds = dcmread(EXPL)
+        ds = dcmread(mono_8bit_1frame_name)
         assert 'PlanarConfiguration' not in ds
         expected = get_expected_length(ds, 'bytes')
         assert expected == len(ds.PixelData)
@@ -821,9 +821,9 @@ class TestRLEEncoding:
         assert np.array_equal(ref, ds.pixel_array)
         assert ref is not ds.pixel_array
 
-    def test_encode_bit(self):
+    def test_encode_bit(self, mr_implicit_name):
         """Test encoding big-endian src"""
-        ds = dcmread(IMPL)
+        ds = dcmread(mr_implicit_name)
         ref = ds.pixel_array
         del ds._pixel_array
         ds.compress(

--- a/pydicom/tests/test_rle_pixel_data.py
+++ b/pydicom/tests/test_rle_pixel_data.py
@@ -59,67 +59,62 @@ except ImportError:
 # EXPL: Explicit VR Little Endian
 # RLE: RLE Lossless
 # 8/8-bit, 1 sample/pixel, 1 frame
-EXPL_8_1_1F = get_testdata_file("OBXXXX1A.dcm")
-RLE_8_1_1F = get_testdata_file("OBXXXX1A_rle.dcm")
+RLE_8_1_1F = "OBXXXX1A_rle.dcm"
 # 8/8-bit, 1 sample/pixel, 2 frame
-EXPL_8_1_2F = get_testdata_file("OBXXXX1A_2frame.dcm")
-RLE_8_1_2F = get_testdata_file("OBXXXX1A_rle_2frame.dcm")
+RLE_8_1_2F = "OBXXXX1A_rle_2frame.dcm"
 # 8/8-bit, 3 sample/pixel, 1 frame
-EXPL_8_3_1F = get_testdata_file("SC_rgb.dcm")
-RLE_8_3_1F = get_testdata_file("SC_rgb_rle.dcm")
+EXPL_8_3_1F = "SC_rgb.dcm"
+RLE_8_3_1F = "SC_rgb_rle.dcm"
 # 8/8-bit, 3 sample/pixel, 2 frame
-EXPL_8_3_2F = get_testdata_file("SC_rgb_2frame.dcm")
-RLE_8_3_2F = get_testdata_file("SC_rgb_rle_2frame.dcm")
+RLE_8_3_2F = "SC_rgb_rle_2frame.dcm"
 # 16/16-bit, 1 sample/pixel, 1 frame
-EXPL_16_1_1F = get_testdata_file("MR_small.dcm")
-RLE_16_1_1F = get_testdata_file("MR_small_RLE.dcm")
+EXPL_16_1_1F = "MR_small.dcm"
+RLE_16_1_1F = "MR_small_RLE.dcm"
 # 16/12-bit, 1 sample/pixel, 10 frame
-EXPL_16_1_10F = get_testdata_file("emri_small.dcm")
-RLE_16_1_10F = get_testdata_file("emri_small_RLE.dcm")
+EXPL_16_1_10F = "emri_small.dcm"
+RLE_16_1_10F = "emri_small_RLE.dcm"
 # 16/16-bit, 3 sample/pixel, 1 frame
-EXPL_16_3_1F = get_testdata_file("SC_rgb_16bit.dcm")
-RLE_16_3_1F = get_testdata_file("SC_rgb_rle_16bit.dcm")
+EXPL_16_3_1F = "SC_rgb_16bit.dcm"
+RLE_16_3_1F = "SC_rgb_rle_16bit.dcm"
 # 16/16-bit, 3 sample/pixel, 2 frame
-EXPL_16_3_2F = get_testdata_file("SC_rgb_16bit_2frame.dcm")
-RLE_16_3_2F = get_testdata_file("SC_rgb_rle_16bit_2frame.dcm")
+EXPL_16_3_2F = "SC_rgb_16bit_2frame.dcm"
+RLE_16_3_2F = "SC_rgb_rle_16bit_2frame.dcm"
 # 32/32-bit, 1 sample/pixel, 1 frame
-EXPL_32_1_1F = get_testdata_file("rtdose_1frame.dcm")
-RLE_32_1_1F = get_testdata_file("rtdose_rle_1frame.dcm")
+EXPL_32_1_1F = "rtdose_1frame.dcm"
+RLE_32_1_1F = "rtdose_rle_1frame.dcm"
 # 32/32-bit, 1 sample/pixel, 15 frame
-EXPL_32_1_15F = get_testdata_file("rtdose.dcm")
-RLE_32_1_15F = get_testdata_file("rtdose_rle.dcm")
+EXPL_32_1_15F = "rtdose.dcm"
+RLE_32_1_15F = "rtdose_rle.dcm"
 # 32/32-bit, 3 sample/pixel, 1 frame
-EXPL_32_3_1F = get_testdata_file("SC_rgb_32bit.dcm")
-RLE_32_3_1F = get_testdata_file("SC_rgb_rle_32bit.dcm")
+EXPL_32_3_1F = "SC_rgb_32bit.dcm"
+RLE_32_3_1F = "SC_rgb_rle_32bit.dcm"
 # 32/32-bit, 3 sample/pixel, 2 frame
-EXPL_32_3_2F = get_testdata_file("SC_rgb_32bit_2frame.dcm")
-RLE_32_3_2F = get_testdata_file("SC_rgb_rle_32bit_2frame.dcm")
+EXPL_32_3_2F = "SC_rgb_32bit_2frame.dcm"
+RLE_32_3_2F = "SC_rgb_rle_32bit_2frame.dcm"
 
 # Transfer syntaxes supported by other handlers
 # Implicit VR Little Endian
-IMPL = get_testdata_file("rtdose_1frame.dcm")
+IMPL = "rtdose_1frame.dcm"
 # Deflated Explicit VR Little Endian
-DELF = get_testdata_file("image_dfl.dcm")
+DELF = "image_dfl.dcm"
 # Explicit VR Big Endian
-EXPB = get_testdata_file("SC_rgb_expb_2frame.dcm")
+EXPB = "SC_rgb_expb_2frame.dcm"
 # JPEG Baseline (Process 1)
-JPEG_BASELINE_1 = get_testdata_file("SC_rgb_jpeg_dcmtk.dcm")
+JPEG_BASELINE_1 = "SC_rgb_jpeg_dcmtk.dcm"
 # JPEG Baseline (Process 2 and 4)
-JPEG_EXTENDED_2 = get_testdata_file("JPEG-lossy.dcm")
+JPEG_EXTENDED_2 = "JPEG-lossy.dcm"
 # JPEG Lossless (Process 14)
 JPEG_LOSSLESS_14 = None
 # JPEG Lossless (Process 14, Selection Value 1)
-JPEG_LOSSLESS_14_1 = get_testdata_file("SC_rgb_jpeg_gdcm.dcm")
+JPEG_LOSSLESS_14_1 = "SC_rgb_jpeg_gdcm.dcm"
 # JPEG-LS Lossless
-JPEG_LS_LOSSLESS = get_testdata_file("MR_small_jpeg_ls_lossless.dcm")
+JPEG_LS_LOSSLESS = "MR_small_jpeg_ls_lossless.dcm"
 # JPEG-LS Lossy
 JPEG_LS_LOSSY = None
 # JPEG2k Lossless
-JPEG_2K_LOSSLESS = get_testdata_file("emri_small_jpeg_2k_lossless.dcm")
+JPEG_2K_LOSSLESS = "emri_small_jpeg_2k_lossless.dcm"
 # JPEG2k
-JPEG_2K = get_testdata_file("JPEG2000.dcm")
-# RLE Lossless
-RLE = get_testdata_file("MR_small_RLE.dcm")
+JPEG_2K = "JPEG2000.dcm"
 
 # Transfer Syntaxes (non-retired + Explicit VR Big Endian)
 SUPPORTED_SYNTAXES = [RLELossless]
@@ -201,20 +196,20 @@ class TestNoNumpy_NoRLEHandler:
 
     def test_can_access_supported_dataset(self):
         """Test that we can read and access elements in an RLE dataset."""
-        ds = dcmread(RLE_16_1_1F)
+        ds = dcmread(get_testdata_file(RLE_16_1_1F))
         assert ds.PatientName == 'CompressedSamples^MR1'
         assert len(ds.PixelData) == 6128
 
     @pytest.mark.parametrize("fpath,data", REFERENCE_DATA_UNSUPPORTED)
     def test_can_access_unsupported_dataset(self, fpath, data):
         """Test can read and access elements in unsupported datasets."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert ds.file_meta.TransferSyntaxUID == data[0]
         assert ds.PatientName == data[1]
 
     def test_pixel_array_raises(self):
         """Test pixel_array raises exception for all syntaxes."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         for uid in AllTransferSyntaxes:
             ds.file_meta.TransferSyntaxUID = uid
             exc_msg = (
@@ -246,20 +241,20 @@ class TestNoNumpy_RLEHandler:
 
     def test_can_access_supported_dataset(self):
         """Test that we can read and access elements in an RLE dataset."""
-        ds = dcmread(RLE_16_1_1F)
+        ds = dcmread(get_testdata_file(RLE_16_1_1F))
         assert ds.PatientName == 'CompressedSamples^MR1'
         assert len(ds.PixelData) == 6128
 
     @pytest.mark.parametrize("fpath,data", REFERENCE_DATA_UNSUPPORTED)
     def test_can_access_unsupported_dataset(self, fpath, data):
         """Test can read and access elements in unsupported datasets."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert ds.file_meta.TransferSyntaxUID == data[0]
         assert ds.PatientName == data[1]
 
     def test_unsupported_pixel_array_raises(self):
         """Test pixel_array raises exception for unsupported syntaxes."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         for uid in UNSUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             exc_msg = (
@@ -271,7 +266,7 @@ class TestNoNumpy_RLEHandler:
 
     def test_supported_pixel_array_raises(self):
         """Test pixel_array raises exception for supported syntaxes."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         for uid in SUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             exc_msg = (
@@ -304,20 +299,20 @@ class TestNumpy_NoRLEHandler:
 
     def test_can_access_supported_dataset(self):
         """Test that we can read and access elements in an RLE dataset."""
-        ds = dcmread(RLE_16_1_1F)
+        ds = dcmread(get_testdata_file(RLE_16_1_1F))
         assert ds.PatientName == 'CompressedSamples^MR1'
         assert len(ds.PixelData) == 6128
 
     @pytest.mark.parametrize("fpath,data", REFERENCE_DATA_UNSUPPORTED)
     def test_can_access_unsupported_dataset(self, fpath, data):
         """Test can read and access elements in unsupported datasets."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert data[0] == ds.file_meta.TransferSyntaxUID
         assert data[1] == ds.PatientName
 
     def test_pixel_array_raises(self):
         """Test pixel_array raises exception for all syntaxes."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         for uid in AllTransferSyntaxes:
             ds.file_meta.TransferSyntaxUID = uid
             exc_msg = (
@@ -348,7 +343,7 @@ class TestNumpy_RLEHandler:
 
     def test_unsupported_syntax_raises(self):
         """Test pixel_array raises exception for unsupported syntaxes."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         for uid in UNSUPPORTED_SYNTAXES:
             ds.file_meta.TransferSyntaxUID = uid
             msg = (
@@ -363,18 +358,18 @@ class TestNumpy_RLEHandler:
     @pytest.mark.parametrize("fpath,data", REFERENCE_DATA_UNSUPPORTED)
     def test_can_access_unsupported_dataset(self, fpath, data):
         """Test can read and access elements in unsupported datasets."""
-        ds = dcmread(fpath)
+        ds = dcmread(get_testdata_file(fpath))
         assert ds.file_meta.TransferSyntaxUID == data[0]
         assert ds.PatientName == data[1]
         assert len(ds.PixelData)
 
-    def test_pixel_array_signed(self):
+    def test_pixel_array_signed(self, mono_8bit_1frame_name):
         """Test pixel_array for unsigned -> signed data."""
-        ds = dcmread(RLE_8_1_1F)
+        ds = dcmread(get_testdata_file(RLE_8_1_1F))
         # 0 is unsigned int, 1 is 2's complement
         assert ds.PixelRepresentation == 0
         ds.PixelRepresentation = 1
-        ref = _get_pixel_array(EXPL_8_1_1F)
+        ref = _get_pixel_array(mono_8bit_1frame_name)
         arr = ds.pixel_array
 
         assert not np.array_equal(arr, ref)
@@ -385,21 +380,21 @@ class TestNumpy_RLEHandler:
 
     def test_pixel_array_1bit_raises(self):
         """Test pixel_array for 1-bit raises exception."""
-        ds = dcmread(RLE_8_3_1F)
+        ds = dcmread(get_testdata_file(RLE_8_3_1F))
         ds.BitsAllocated = 1
         msg = r"Bits Allocated' value of 1"
         with pytest.raises(NotImplementedError, match=msg):
             ds.pixel_array
 
-    def test_pixel_array_8bit_1sample_1f(self):
+    def test_pixel_array_8bit_1sample_1f(self, mono_8bit_1frame_name):
         """Test pixel_array for 8-bit, 1 sample/pixel, 1 frame."""
-        ds = dcmread(RLE_8_1_1F)
+        ds = dcmread(get_testdata_file(RLE_8_1_1F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 8
         assert ds.SamplesPerPixel == 1
         assert ds.PixelRepresentation == 0
         assert 'NumberOfFrames' not in ds
-        ref = _get_pixel_array(EXPL_8_1_1F)
+        ref = _get_pixel_array(mono_8bit_1frame_name)
         arr = ds.pixel_array
 
         assert arr.flags.writeable
@@ -411,7 +406,7 @@ class TestNumpy_RLEHandler:
 
     def test_decompress_with_handler(self):
         """Test that decompress works with the correct handler."""
-        ds = dcmread(RLE_8_1_1F)
+        ds = dcmread(get_testdata_file(RLE_8_1_1F))
         msg = r"'zip' is not a known handler name"
         with pytest.raises(ValueError, match=msg):
             ds.decompress(handler_name='zip')
@@ -428,13 +423,13 @@ class TestNumpy_RLEHandler:
 
     def test_pixel_array_8bit_1sample_2f(self):
         """Test pixel_array for 8-bit, 1 sample/pixel, 2 frame."""
-        ds = dcmread(RLE_8_1_2F)
+        ds = dcmread(get_testdata_file(RLE_8_1_2F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 8
         assert ds.SamplesPerPixel == 1
         assert ds.NumberOfFrames == 2
         assert ds.PixelRepresentation == 0
-        ref = _get_pixel_array(EXPL_8_1_2F)
+        ref = _get_pixel_array(get_testdata_file("OBXXXX1A_2frame.dcm"))
         arr = ds.pixel_array
 
         assert arr.flags.writeable
@@ -449,13 +444,13 @@ class TestNumpy_RLEHandler:
 
     def test_pixel_array_8bit_3sample_1f(self):
         """Test pixel_array for 8-bit, 3 sample/pixel, 1 frame."""
-        ds = dcmread(RLE_8_3_1F)
+        ds = dcmread(get_testdata_file(RLE_8_3_1F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 8
         assert ds.SamplesPerPixel == 3
         assert ds.PixelRepresentation == 0
         assert 'NumberOfFrames' not in ds
-        ref = _get_pixel_array(EXPL_8_3_1F)
+        ref = _get_pixel_array(get_testdata_file(EXPL_8_3_1F))
         arr = ds.pixel_array
 
         assert arr.flags.writeable
@@ -472,15 +467,15 @@ class TestNumpy_RLEHandler:
         assert tuple(arr[85, 50, :]) == (192, 192, 192)
         assert tuple(arr[95, 50, :]) == (255, 255, 255)
 
-    def test_pixel_array_8bit_3sample_2f(self):
+    def test_pixel_array_8bit_3sample_2f(self, rgb_8bit_2frames_name):
         """Test pixel_array for 8-bit, 3 sample/pixel, 2 frame."""
-        ds = dcmread(RLE_8_3_2F)
+        ds = dcmread(get_testdata_file(RLE_8_3_2F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 8
         assert ds.SamplesPerPixel == 3
         assert ds.NumberOfFrames == 2
         assert ds.PixelRepresentation == 0
-        ref = _get_pixel_array(EXPL_8_3_2F)
+        ref = _get_pixel_array(rgb_8bit_2frames_name)
         arr = ds.pixel_array
 
         assert arr.flags.writeable
@@ -504,13 +499,13 @@ class TestNumpy_RLEHandler:
 
     def test_pixel_array_16bit_1sample_1f(self):
         """Test pixel_array for 16-bit, 1 sample/pixel, 1 frame."""
-        ds = dcmread(RLE_16_1_1F)
+        ds = dcmread(get_testdata_file(RLE_16_1_1F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 16
         assert ds.SamplesPerPixel == 1
         assert 'NumberOfFrames' not in ds
         assert ds.PixelRepresentation == 1
-        ref = _get_pixel_array(EXPL_16_1_1F)
+        ref = _get_pixel_array(get_testdata_file(EXPL_16_1_1F))
         arr = ds.pixel_array
 
         assert arr.flags.writeable
@@ -523,13 +518,13 @@ class TestNumpy_RLEHandler:
 
     def test_pixel_array_16bit_1sample_10f(self):
         """Test pixel_array for 16-bit, 1, sample/pixel, 10 frame."""
-        ds = dcmread(RLE_16_1_10F)
+        ds = dcmread(get_testdata_file(RLE_16_1_10F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 16
         assert ds.SamplesPerPixel == 1
         assert ds.NumberOfFrames == 10
         assert ds.PixelRepresentation == 0
-        ref = _get_pixel_array(EXPL_16_1_10F)
+        ref = _get_pixel_array(get_testdata_file(EXPL_16_1_10F))
         arr = ds.pixel_array
 
         assert arr.flags.writeable
@@ -554,14 +549,14 @@ class TestNumpy_RLEHandler:
 
     def test_pixel_array_16bit_3sample_1f(self):
         """Test pixel_array for 16-bit, 3 sample/pixel, 1 frame."""
-        ds = dcmread(RLE_16_3_1F)
+        ds = dcmread(get_testdata_file(RLE_16_3_1F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 16
         assert ds.SamplesPerPixel == 3
         assert ds.PixelRepresentation == 0
         assert 'NumberOfFrames' not in ds
         arr = ds.pixel_array
-        ref = _get_pixel_array(EXPL_16_3_1F)
+        ref = _get_pixel_array(get_testdata_file(EXPL_16_3_1F))
 
         assert arr.flags.writeable
         assert arr.dtype == '<u2'
@@ -580,14 +575,14 @@ class TestNumpy_RLEHandler:
 
     def test_pixel_array_16bit_3sample_2f(self):
         """Test pixel_array for 16-bit, 3, sample/pixel, 10 frame."""
-        ds = dcmread(RLE_16_3_2F)
+        ds = dcmread(get_testdata_file(RLE_16_3_2F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 16
         assert ds.SamplesPerPixel == 3
         assert ds.NumberOfFrames == 2
         assert ds.PixelRepresentation == 0
         arr = ds.pixel_array
-        ref = _get_pixel_array(EXPL_16_3_2F)
+        ref = _get_pixel_array(get_testdata_file(EXPL_16_3_2F))
 
         assert arr.flags.writeable
         assert arr.dtype == '<u2'
@@ -611,13 +606,13 @@ class TestNumpy_RLEHandler:
 
     def test_pixel_array_32bit_1sample_1f(self):
         """Test pixel_array for 32-bit, 1 sample/pixel, 1 frame."""
-        ds = dcmread(RLE_32_1_1F)
+        ds = dcmread(get_testdata_file(RLE_32_1_1F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 32
         assert ds.SamplesPerPixel == 1
         assert ds.PixelRepresentation == 0
         assert 'NumberOfFrames' not in ds
-        ref = _get_pixel_array(EXPL_32_1_1F)
+        ref = _get_pixel_array(get_testdata_file(EXPL_32_1_1F))
         arr = ds.pixel_array
 
         assert arr.flags.writeable
@@ -631,13 +626,13 @@ class TestNumpy_RLEHandler:
 
     def test_pixel_array_32bit_1sample_15f(self):
         """Test pixel_array for 32-bit, 1, sample/pixel, 15 frame."""
-        ds = dcmread(RLE_32_1_15F)
+        ds = dcmread(get_testdata_file(RLE_32_1_15F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 32
         assert ds.SamplesPerPixel == 1
         assert ds.NumberOfFrames == 15
         assert ds.PixelRepresentation == 0
-        ref = _get_pixel_array(EXPL_32_1_15F)
+        ref = _get_pixel_array(get_testdata_file(EXPL_32_1_15F))
         arr = ds.pixel_array
 
         assert arr.flags.writeable
@@ -662,14 +657,14 @@ class TestNumpy_RLEHandler:
 
     def test_pixel_array_32bit_3sample_1f(self):
         """Test pixel_array for 32-bit, 3 sample/pixel, 1 frame."""
-        ds = dcmread(RLE_32_3_1F)
+        ds = dcmread(get_testdata_file(RLE_32_3_1F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 32
         assert ds.SamplesPerPixel == 3
         assert ds.PixelRepresentation == 0
         assert 'NumberOfFrames' not in ds
         arr = ds.pixel_array
-        ref = _get_pixel_array(EXPL_32_3_1F)
+        ref = _get_pixel_array(get_testdata_file(EXPL_32_3_1F))
 
         assert arr.flags.writeable
         assert arr.dtype == '<u4'
@@ -688,14 +683,14 @@ class TestNumpy_RLEHandler:
 
     def test_pixel_array_32bit_3sample_2f(self):
         """Test pixel_array for 32-bit, 3, sample/pixel, 2 frame."""
-        ds = dcmread(RLE_32_3_2F)
+        ds = dcmread(get_testdata_file(RLE_32_3_2F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 32
         assert ds.SamplesPerPixel == 3
         assert ds.NumberOfFrames == 2
         assert ds.PixelRepresentation == 0
         arr = ds.pixel_array
-        ref = _get_pixel_array(EXPL_32_3_2F)
+        ref = _get_pixel_array(get_testdata_file(EXPL_32_3_2F))
 
         assert arr.flags.writeable
         assert arr.dtype == '<u4'
@@ -723,7 +718,7 @@ class TestNumpy_GetPixelData:
     """Tests for rle_handler.get_pixeldata with numpy."""
     def test_no_pixel_data_raises(self):
         """Test get_pixeldata raises if dataset has no PixelData."""
-        ds = dcmread(RLE_16_1_1F)
+        ds = dcmread(get_testdata_file(RLE_16_1_1F))
         del ds.PixelData
         assert 'PixelData' not in ds
         with pytest.raises(AttributeError, match=' dataset: PixelData'):
@@ -731,14 +726,14 @@ class TestNumpy_GetPixelData:
 
     def test_unknown_pixel_representation_raises(self):
         """Test get_pixeldata raises if invalid PixelRepresentation."""
-        ds = dcmread(RLE_16_1_1F)
+        ds = dcmread(get_testdata_file(RLE_16_1_1F))
         ds.PixelRepresentation = 2
         with pytest.raises(ValueError, match=r"value of '2' for '\(0028,0103"):
             get_pixeldata(ds)
 
     def test_unsupported_syntaxes_raises(self):
         """Test get_pixeldata raises if unsupported Transfer Syntax."""
-        ds = dcmread(EXPL_16_1_1F)
+        ds = dcmread(get_testdata_file(EXPL_16_1_1F))
         msg = r'syntax is not supported by the RLE pixel'
         with pytest.raises(NotImplementedError, match=msg):
             get_pixeldata(ds)
@@ -750,7 +745,7 @@ class TestNumpy_GetPixelData:
             return True
 
         # Test default
-        ds = dcmread(RLE_16_1_1F)
+        ds = dcmread(get_testdata_file(RLE_16_1_1F))
         assert ds.PhotometricInterpretation == 'MONOCHROME2'
 
         get_pixeldata(ds)
@@ -767,7 +762,7 @@ class TestNumpy_GetPixelData:
 
     def test_little_endian_segment_order(self):
         """Test interpreting segment order as little endian."""
-        ds = dcmread(RLE_16_1_1F)
+        ds = dcmread(get_testdata_file(RLE_16_1_1F))
         assert ds.file_meta.TransferSyntaxUID == RLELossless
         assert ds.BitsAllocated == 16
         assert ds.SamplesPerPixel == 1
@@ -883,7 +878,7 @@ class TestNumpy_RLEDecodeFrame:
 
     def test_invalid_segment_data_raises(self):
         """Test invalid segment data raises exception"""
-        ds = dcmread(RLE_16_1_1F)
+        ds = dcmread(get_testdata_file(RLE_16_1_1F))
         pixel_data = defragment_data(ds.PixelData)
         msg = r"amount \(4095 vs. 4096 bytes\)"
         with pytest.raises(ValueError, match=msg):
@@ -897,7 +892,7 @@ class TestNumpy_RLEDecodeFrame:
 
     def test_nonconf_segment_padding_warns(self):
         """Test non-conformant segment padding warns"""
-        ds = dcmread(RLE_16_1_1F)
+        ds = dcmread(get_testdata_file(RLE_16_1_1F))
         pixel_data = defragment_data(ds.PixelData)
         msg = (
             r"The decoded RLE segment contains non-conformant padding - 4097 "

--- a/pydicom/tests/test_util.py
+++ b/pydicom/tests/test_util.py
@@ -191,10 +191,9 @@ class TestDump:
         assert print_character(0x7A) == 'z'
         assert print_character(0x00) == '.'
 
-    def test_filedump(self):
+    def test_filedump(self, ct_name):
         """Test utils.dump.filedump"""
-        p = get_testdata_file("CT_small.dcm")
-        s = filedump(p, start_address=500, stop_address=1000)
+        s = filedump(ct_name, start_address=500, stop_address=1000)
 
         assert (
             "000  49 49 2A 00 54 18 08 00 00 00 00 00 00 00 00 00  "
@@ -277,9 +276,9 @@ class TestDump:
             ".1.1.1.1.2004011"
         ) in s
 
-    def test_pretty_print(self, capsys):
+    def test_pretty_print(self, capsys, ct_name):
         """Test utils.dump.pretty_print"""
-        ds = get_testdata_file("CT_small.dcm", read=True)
+        ds = dcmread(ct_name)
         pretty_print(ds)
 
         s = capsys.readouterr().out
@@ -458,11 +457,10 @@ class TestDataElementCallbackTests:
 
 
 class TestLeanRead:
-    def test_explicit_little(self):
-        p = get_testdata_file("CT_small.dcm")
-        ds = dcmread(p)
+    def test_explicit_little(self, ct_name):
+        ds = dcmread(ct_name)
         assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
-        with dicomfile(p) as ds:
+        with dicomfile(ct_name) as ds:
             assert ds.preamble is not None
             for elem in ds:
                 if elem[0] == (0x7fe0, 0x0010):


### PR DESCRIPTION
- depends on env var NO_EXTERNAL_DATA being 1
- moved all usages of get_testdata_file() into tests and fixtures
- change old-style setup() to fixtures

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
