### PR TITLE
Fix deepcopy of Dataset and Sequence

### DIFF
--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -469,7 +469,8 @@ class Dataset:
         self._parent = weakref.ref(value)
 
     def __deepcopy__(self, memo: Optional[Dict[int, Any]]) -> "Dataset":
-        copied = Dataset()
+        cls = self.__class__
+        copied = cls.__new__(cls)
         if memo:
             memo[id(self)] = copied   # add the new class to the memo
         # Insert a deepcopy of all instance attributes

--- a/src/pydicom/sequence.py
+++ b/src/pydicom/sequence.py
@@ -80,7 +80,8 @@ class Sequence(MultiValue[Dataset]):
             ds.parent_seq = self  # type: ignore
 
     def __deepcopy__(self, memo: Optional[Dict[int, Any]]) -> "Sequence":
-        copied = Sequence()
+        cls = self.__class__
+        copied = cls.__new__(cls)
         if memo is not None:
             memo[id(self)] = copied
         copied.__dict__.update(deepcopy(self.__dict__, memo))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1972,6 +1972,16 @@ class TestFileDataset:
         ds2 = copy.deepcopy(ds)
         assert ds2.filename == ""
 
+    def test_deepcopy_dataset_subclass(self):
+        """Regression test for #1813."""
+        class MyDatasetSubclass(pydicom.Dataset):
+            pass
+
+        my_dataset_subclass = MyDatasetSubclass()
+
+        ds2 = copy.deepcopy(my_dataset_subclass)
+        assert ds2.__class__ is MyDatasetSubclass
+
 
 class TestDatasetOverlayArray:
     """Tests for Dataset.overlay_array()."""

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,6 +1,7 @@
 # Copyright 2008-2020 pydicom authors. See LICENSE file for details.
 """Unit tests for the pydicom.sequence module."""
 
+import copy
 import weakref
 
 import pytest
@@ -174,3 +175,13 @@ class TestSequence:
 
         for ds in seq:
             assert isinstance(ds.parent_seq, weakref.ReferenceType)
+
+    def test_deepcopy_sequence_subclass(self):
+        """Regression test for #1813."""
+        class MySequenceSubclass(Sequence):
+            pass
+
+        my_sequence_subclass = MySequenceSubclass()
+
+        seq2 = copy.deepcopy(my_sequence_subclass)
+        assert seq2.__class__ is MySequenceSubclass


### PR DESCRIPTION
#### Describe the changes
Fix for #1813.

In the `__deepcopy__` methods of `Sequence` and `Dataset`, the returned object should be initialised to an instance of the type of `self` rather than the literal `Dataset` and `Sequence` types. This way the methods also work for subclasses.

Since this has caused some significant issues with highdicom, wsiDicomizer, and possibly other libraries, would you consider a 2.4.1 patch release for this fix?

#### Tasks
- [ x] Unit tests added that reproduce the issue or prove feature is working
- [ x] Fix or feature added
- [ x] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ x] Unit tests passing and overall coverage the same or better
