### PR TITLE
Update names to new "main" branch

### DIFF
--- a/.github/workflows/merge-pytest.yml
+++ b/.github/workflows/merge-pytest.yml
@@ -3,7 +3,7 @@ name: unit-tests
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test-all:

--- a/.github/workflows/merge-typing.yml
+++ b/.github/workflows/merge-typing.yml
@@ -2,7 +2,7 @@ name: type-hints
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/merge-typing.yml
+++ b/.github/workflows/merge-typing.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install typing dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install mypy
+        python -m pip install mypy==1.3.0
         python -m pip install --upgrade types-requests
     - name: Run typing check with mypy
       run: |

--- a/.github/workflows/pr-pytest.yml
+++ b/.github/workflows/pr-pytest.yml
@@ -2,7 +2,7 @@ name: pr-unit-tests
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test-pypy:

--- a/.github/workflows/pr-type-spell.yml
+++ b/.github/workflows/pr-type-spell.yml
@@ -2,7 +2,7 @@ name: pr-type-lint-spell
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 
@@ -37,4 +37,4 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: codespell-project/actions-codespell@master
+      - uses: codespell-project/actions-codespell@main

--- a/.github/workflows/pr-type-spell.yml
+++ b/.github/workflows/pr-type-spell.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install typing dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install mypy
+        python -m pip install mypy==1.3.0
         python -m pip install --upgrade types-requests
     - name: Run typing check with mypy
       run: |
@@ -37,4 +37,4 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: codespell-project/actions-codespell@main
+      - uses: codespell-project/actions-codespell@master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ GitHub, clone, and develop on a branch. Steps:
    $ git checkout -b my-feature
    ```
 
-   Always use a ``feature`` branch. It's good practice to never work on the ``master`` branch!
+   Always use a ``feature`` branch. It's good practice to never work on the ``main`` branch!
 
 4. Develop the feature on your feature branch. Add changed files using ``git add`` and then ``git commit`` files:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![unit-tests](https://github.com/pydicom/pydicom/workflows/unit-tests/badge.svg)](https://github.com/pydicom/pydicom/actions?query=workflow%3Aunit-tests)
 [![type-hints](https://github.com/pydicom/pydicom/workflows/type-hints/badge.svg)](https://github.com/pydicom/pydicom/actions?query=workflow%3Atype-hints)
-[![doc-build](https://circleci.com/gh/pydicom/pydicom/tree/master.svg?style=shield)](https://circleci.com/gh/pydicom/pydicom/tree/master)
-[![test-coverage](https://codecov.io/gh/pydicom/pydicom/branch/master/graph/badge.svg)](https://codecov.io/gh/pydicom/pydicom)
+[![doc-build](https://circleci.com/gh/pydicom/pydicom/tree/main.svg?style=shield)](https://circleci.com/gh/pydicom/pydicom/tree/main)
+[![test-coverage](https://codecov.io/gh/pydicom/pydicom/branch/main/graph/badge.svg)](https://codecov.io/gh/pydicom/pydicom)
 [![Python version](https://img.shields.io/pypi/pyversions/pydicom.svg)](https://img.shields.io/pypi/pyversions/pydicom.svg)
 [![PyPI version](https://badge.fury.io/py/pydicom.svg)](https://badge.fury.io/py/pydicom)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8034250.svg)](https://doi.org/10.5281/zenodo.8034250)
@@ -124,7 +124,7 @@ plt.show()
 We are all volunteers working on *pydicom* in our free time. As our 
 resources are limited, we very much value your contributions, be it bug fixes, new 
 core features, or documentation improvements. For more information, please
-read our [contribution guide](https://github.com/pydicom/pydicom/blob/master/CONTRIBUTING.md).
+read our [contribution guide](https://github.com/pydicom/pydicom/blob/main/CONTRIBUTING.md).
 
 If you have examples or extensions of *pydicom* that don't belong with the 
 core software, but that you deem useful to others, you can add them to our 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -17,9 +17,9 @@
     //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     // ],
 
-    // List of branches to benchmark. If not provided, defaults to "master"
+    // List of branches to benchmark. If not provided, defaults to "main"
     // (for git) or "default" (for mercurial).
-    "branches": ["nested-seq-speed", "master"],
+    "branches": ["nested-seq-speed", "main"],
 
     "environment_type": "virtualenv",
 

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -9,7 +9,7 @@ set -e
 # instead of relying on the subsequent rules.
 #
 # We always build the documentation for jobs that are not related to a specific
-# PR (e.g. a merge to master or a maintenance branch).
+# PR (e.g. a merge to main or a maintenance branch).
 #
 # If this is a PR, do a full build if there are some files in this PR that are
 # under the "doc/" or "examples/" folders, otherwise perform a quick build.
@@ -49,8 +49,8 @@ get_build_type() {
         echo BUILD: not a pull request
         return
     fi
-    git_range="origin/master...$CIRCLE_SHA1"
-    git fetch origin master >&2 || (echo QUICK BUILD: failed to get changed filenames for $git_range; return)
+    git_range="origin/main...$CIRCLE_SHA1"
+    git fetch origin main >&2 || (echo QUICK BUILD: failed to get changed filenames for $git_range; return)
     filenames=$(git diff --name-only $git_range)
     if [ -z "$filenames" ]
     then
@@ -72,7 +72,7 @@ then
     exit 0
 fi
 
-if [[ "$CIRCLE_BRANCH" =~ ^master$|^[0-9]+\.[0-9]+\.X$ && -z "$CI_PULL_REQUEST" ]]
+if [[ "$CIRCLE_BRANCH" =~ ^main$|^[0-9]+\.[0-9]+\.X$ && -z "$CI_PULL_REQUEST" ]]
 then
     # PDF linked into HTML
     MAKE_TARGET="dist LATEXMKOPTS=-halt-on-error"

--- a/build_tools/circle/push_doc.sh
+++ b/build_tools/circle/push_doc.sh
@@ -4,7 +4,7 @@
 # in .circleci/config.yml. See https://circleci.com/docs/2.0 for more details.
 
 # We have three possible workflows:
-#   If the git branch is 'master' then we want to commit and merge the dev/
+#   If the git branch is 'main' then we want to commit and merge the dev/
 #       docs on gh-pages
 #   If the git branch is [0-9].[0.9].X (i.e. 0.9.X, 1.0.X, 1.2.X, 41.21.X) then
 #        we want to commit and merge the major.minor/ docs on gh-pages
@@ -54,9 +54,9 @@ echo $GIT_AUTHOR_EMAIL
 echo $GIT_AUTHOR_NAME
 
 # Determine which of the three workflows to take
-if [ "$CIRCLE_BRANCH" = "master" ]
+if [ "$CIRCLE_BRANCH" = "main" ]
 then
-    # build of current master
+    # build of current main
     echo "Performing commit and push to $CIRCLE_PROJECT_REPONAME/$DOC_BRANCH for $CIRCLE_BRANCH"
     # Changes are made to dev/ directory
     DIR=dev

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -132,7 +132,7 @@ source_suffix = '.rst'
 # The encoding of source files.
 # source_encoding = 'utf-8'
 
-# The master toctree document.
+# The main toctree document.
 master_doc = 'index'
 
 # General information about the project.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ docs = [
 
 [project.urls]
 documentation = "https://pydicom.github.io/pydicom"
-download = "https://github.com/pydicom/pydicom/archive/master.zip"
+download = "https://github.com/pydicom/pydicom/archive/main.zip"
 homepage = "https://github.com/pydicom/pydicom"
 repository = "https://github.com/pydicom/pydicom"
 

--- a/util/generate_dict/generate_private_dict.py
+++ b/util/generate_dict/generate_private_dict.py
@@ -10,9 +10,11 @@ except ImportError:
     import urllib.request as urllib2
     # python3
 
-GDCM_PRIVATE_DICT = "https://raw.githubusercontent.com/malaterre/GDCM"
-GDCM_PRIVATE_DICT = '%s/master/Source/DataDictionary' % (GDCM_PRIVATE_DICT)
-GDCM_PRIVATE_DICT = "%s/privatedicts.xml" % (GDCM_PRIVATE_DICT)
+
+GDCM_PRIVATE_DICT = (
+    r"https://raw.githubusercontent.com/malaterre/GDCM/"
+    r"master/Source/DataDictionary/privatedicts.xml"
+)
 PYDICOM_DICT_NAME = (
     'private_dictionaries: Dict[str, Dict[str, Tuple[str, str, str, str]]]'
 )


### PR DESCRIPTION
Found instances of old main branch name still in use

* checked gdcm private dict file, still 'master', but cleaned up the setting of the url.
* pinned mypy, as already got a new 'error' that wasn't there in last commit
