### PR TITLE
[WIP] Additional info in exception message for fileset::add

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -9,6 +9,7 @@ Changes
 
 Enhancements
 ------------
+* Added details of missing required tag information when adding Dataset to Fileset
 
 Fixes
 -----

--- a/src/pydicom/fileset.py
+++ b/src/pydicom/fileset.py
@@ -1869,8 +1869,8 @@ class FileSet:
             except ValueError as exc:
                 raise ValueError(
                     f"Unable to use the default '{record_type}' "
-                    "record creator as the instance is missing a "
-                    "required element or value. Either update the instance, "
+                    f"record creator: {exc}. See DICOM PS3.3 Section F.5. "
+                    "Either update the instance, "
                     "define your own record creation function or use "
                     "'FileSet.add_custom()' instead"
                 ) from exc
@@ -1898,8 +1898,8 @@ class FileSet:
             except ValueError as exc:
                 raise ValueError(
                     f"Unable to use the default '{record_type}' "
-                    "record creator as the instance is missing a "
-                    "required element or value. Either update the instance, "
+                    f"record creator: {exc}. See DICOM PS3.3 Section F.5. "
+                    "Either update the instance, "
                     "define your own record creation function or use "
                     "'FileSet.add_custom()' instead"
                 ) from exc

--- a/tests/test_fileset.py
+++ b/tests/test_fileset.py
@@ -1390,9 +1390,10 @@ class TestFileSet:
         ct.PatientID = None
         fs = FileSet()
         msg = (
-            r"Unable to use the default 'PATIENT' record creator "
-            r"as the instance is missing a required element or value. Either "
-            r"update the instance, define your own record creation function "
+            r"Unable to use the default 'PATIENT' record creator: "
+            r"The instance's \(0010, 0020\) 'Patient ID' element cannot be empty. "
+            r"See DICOM PS3.3 Section F.5. Either update the instance, "
+            r"define your own record creation function "
             r"or use 'FileSet.add_custom\(\)' instead"
         )
         with pytest.raises(ValueError, match=msg):
@@ -2355,9 +2356,10 @@ class TestFileSet_Modify:
         ds = dcmread(get_testdata_file("rtdose.dcm"))
         del ds.InstanceNumber
         msg = (
-            r"Unable to use the default 'RT DOSE' record creator "
-            r"as the instance is missing a required element or value. Either "
-            r"update the instance, define your own record creation function "
+            r"Unable to use the default 'RT DOSE' record creator: "
+            r"The instance's \(0020, 0013\) 'Instance Number' element is missing. "
+            r"See DICOM PS3.3 Section F.5. Either update the instance, "
+            r"define your own record creation function "
             r"or use 'FileSet.add_custom\(\)' instead"
         )
         with pytest.raises(ValueError, match=msg):
@@ -2369,9 +2371,10 @@ class TestFileSet_Modify:
         ds = dcmread(get_testdata_file("rtdose.dcm"))
         ds.InstanceNumber = None
         msg = (
-            r"Unable to use the default 'RT DOSE' record creator "
-            r"as the instance is missing a required element or value. Either "
-            r"update the instance, define your own record creation function "
+            r"Unable to use the default 'RT DOSE' record creator: "
+            r"The instance's \(0020, 0013\) 'Instance Number' element cannot be empty. "
+            r"See DICOM PS3.3 Section F.5. Either update the instance, "
+            r"define your own record creation function "
             r"or use 'FileSet.add_custom\(\)' instead"
         )
         with pytest.raises(ValueError, match=msg):
@@ -2445,10 +2448,11 @@ class TestFileSet_Modify:
         del ds.HangingProtocolCreator
         fs = FileSet()
         msg = (
-            r"Unable to use the default 'HANGING PROTOCOL' record creator "
-            r"as the instance is missing a required element or value. Either "
-            r"update the instance, define your own record creation function "
-            r"or use 'FileSet.add_custom\(\)' instead"
+            r"Unable to use the default 'HANGING PROTOCOL' record creator: "
+            r"The instance's \(0072, 0008\) 'Hanging Protocol Creator' element "
+            r"is missing. See DICOM PS3.3 Section F.5. Either update the "
+            r"instance, define your own record creation function or use "
+            r"'FileSet.add_custom\(\)' instead"
         )
         with pytest.raises(ValueError, match=msg):
             fs.add(ds)


### PR DESCRIPTION
#### Describe the changes
Related issue: #1818 .
- Added information for incorrect tags in exception message.
- Added reference to DICOM PS3.3 Section 5.1 in the message
- Updated unit tests

TODOs:

- [x] Check code duplication in `fileset.py:_recordify` function, after line 1870

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
