### PR TITLE
[MRG] Add error handling to convert_tag and convert_AE_string

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -5,7 +5,8 @@ Changes
 -------
 * Removed support for Python <= 3.9
 * compat module removed
-
+* values with VR AE with an incorrect value length are now handled
+  gracefully (extra bytes are ignored with a warning)
 
 Enhancements
 ------------

--- a/src/pydicom/values.py
+++ b/src/pydicom/values.py
@@ -45,7 +45,7 @@ from pydicom.valuerep import PersonName
 
 def convert_tag(byte_string: bytes, is_little_endian: bool, offset: int = 0) -> BaseTag:
     """Return a decoded :class:`BaseTag<pydicom.tag.BaseTag>` from the encoded
-    `byte_string`.
+    `byte_string`. `byte_string` must be at least 4 bytes long.
 
     Parameters
     ----------
@@ -60,9 +60,16 @@ def convert_tag(byte_string: bytes, is_little_endian: bool, offset: int = 0) -> 
     -------
     BaseTag
         The decoded tag.
+
+    Raises
+    ------
+    ValueError
+        If `byte_string` is too short.
     """
+    if len(byte_string) < 4:
+        raise ValueError("byte string too short - must be at least 4 bytes long.")
     fmt = "<HH" if is_little_endian else ">HH"
-    value = cast(tuple[int, int], unpack(fmt, byte_string[offset : offset + 4]))
+    value = cast(tuple[int, int], unpack(fmt, byte_string[offset: offset + 4]))
     return TupleTag(value)
 
 
@@ -124,6 +131,7 @@ def convert_ATvalue(
         logger.warning(
             "Expected length to be multiple of 4 for VR 'AT', " f"got length {length}"
         )
+        length -= length % 4
     return MultiValue(
         Tag,
         [

--- a/src/pydicom/values.py
+++ b/src/pydicom/values.py
@@ -69,7 +69,7 @@ def convert_tag(byte_string: bytes, is_little_endian: bool, offset: int = 0) -> 
     if len(byte_string) < 4:
         raise ValueError("byte string too short - must be at least 4 bytes long.")
     fmt = "<HH" if is_little_endian else ">HH"
-    value = cast(tuple[int, int], unpack(fmt, byte_string[offset: offset + 4]))
+    value = cast(tuple[int, int], unpack(fmt, byte_string[offset : offset + 4]))
     return TupleTag(value)
 
 

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -1281,7 +1281,6 @@ class TestReadDataElement:
         new = DataElement(0xFFFE0002, "SV", 2**63 - 1)
         assert elem == new
 
-    @pytest.mark.skip("No public elements with VR of SV")
     def test_read_SV_explicit_little(self):
         """Check reading element with VR of SV encoded as explicit"""
         ds = dcmread(self.fp_ex, force=True)

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -185,8 +185,10 @@ class TestConvertAT:
         assert Tag(0x0010, 0x0030) in out
         assert len(caplog.records) == 1
         assert caplog.records[0].levelno == logging.WARNING
-        assert (caplog.records[0].message ==
-                "Expected length to be multiple of 4 for VR 'AT', got length 9")
+        assert (
+            caplog.records[0].message
+            == "Expected length to be multiple of 4 for VR 'AT', got length 9"
+        )
 
 
 class TestConvertDA:


### PR DESCRIPTION
- convert_AE_String handles incorrect value length gracefully
- convert_tag now raises if the byte_string is too short

These are minor changes related to the previously skipped tests. `convert_AE_String` had previously warned for incorrect length, but than crashed - it now just ignores extra bytes.
`convert_tag` is only used in `convert_AE_String`, but on the chance it is used from outside I raise an exception if the byte string is too short (instead of letting it just crash).

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
