### PR TITLE
[MRG] Stop GDCM and pylibjpeg handlers modifying Pixel Representation

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -16,6 +16,9 @@ Enhancements
 
 Fixes
 -----
+* Fixed the GDCM and pylibjpeg handlers changing the *Pixel Representation* value to 0
+  when the J2K stream disagrees with the dataset and
+  :attr:`~pydicom.config.APPLY_J2K_CORRECTIONS` is `True` (:issue:`1689`)
 
 Pydicom Internals
 -----------------

--- a/doc/tutorials/installation.rst
+++ b/doc/tutorials/installation.rst
@@ -166,16 +166,16 @@ Using pip::
 Install the development version
 ===============================
 
-To install a snapshot of the latest code (the ``master`` branch) from
+To install a snapshot of the latest code (the ``main`` branch) from
 :gh:`GitHub <pydicom>`::
 
   pip install git+https://github.com/pydicom/pydicom
 
-The ``master`` branch is under active development and while it is usually
+The ``main`` branch is under active development and while it is usually
 stable, it may have undocumented changes or bugs.
 
 If you want to keep up-to-date with the latest code, make sure you have
-`Git <https://git-scm.com/>`_ installed and then clone the ``master``
+`Git <https://git-scm.com/>`_ installed and then clone the ``main``
 branch (this will create a ``pydicom`` directory in your current directory)::
 
   git clone --depth=1 https://github.com/pydicom/pydicom.git

--- a/src/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/src/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -3,6 +3,7 @@
 pixel transfer syntaxes.
 """
 
+from copy import deepcopy
 import os
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, cast
@@ -294,7 +295,8 @@ def get_pixeldata(ds: "Dataset") -> "numpy.ndarray":
         if not j2k_sign and ds.PixelRepresentation == 1:
             # Convert unsigned J2K data to 2's complement
             shift = cast(int, ds.BitsAllocated) - j2k_precision
-            pixel_module = ds.group_dataset(0x0028)
+            # Need a copy of the pixel module to avoid modifying the original
+            pixel_module = deepcopy(ds.group_dataset(0x0028))
             pixel_module.PixelRepresentation = 0
             dtype = pixel_dtype(pixel_module)
             arr = (arr.astype(dtype) << shift).astype(numpy_dtype) >> shift

--- a/src/pydicom/pixel_data_handlers/pylibjpeg_handler.py
+++ b/src/pydicom/pixel_data_handlers/pylibjpeg_handler.py
@@ -47,6 +47,7 @@ values given in the table below.
 
 """
 
+from copy import deepcopy
 import logging
 from typing import TYPE_CHECKING, cast
 from collections.abc import Iterable
@@ -264,7 +265,8 @@ def generate_frames(ds: "Dataset", reshape: bool = True) -> Iterable["np.ndarray
     LOGGER.debug(f"Decoding {tsyntax.name} encoded Pixel Data using {decoder}")
 
     nr_frames = get_nr_frames(ds, warn=False)
-    pixel_module = ds.group_dataset(0x0028)
+    # Need a copy of the pixel module to avoid modifying the original
+    pixel_module = deepcopy(ds.group_dataset(0x0028))
     dtype = pixel_dtype(ds)
 
     bits_stored = cast(int, ds.BitsStored)

--- a/tests/test_gdcm_pixel_data.py
+++ b/tests/test_gdcm_pixel_data.py
@@ -519,6 +519,7 @@ class TestsWithGDCM:
         assert 13 == params["precision"]
         assert not params["is_signed"]
         arr = ds.pixel_array
+        assert 1 == ds.PixelRepresentation
 
         assert "int16" == arr.dtype
         assert (512, 512) == arr.shape

--- a/tests/test_pylibjpeg.py
+++ b/tests/test_pylibjpeg.py
@@ -756,6 +756,7 @@ class TestJPEG2K:
         with pytest.warns(UserWarning, match=msg):
             arr = ds.pixel_array
 
+        assert 1 == ds.PixelRepresentation
         assert "int16" == arr.dtype
         assert (512, 512) == arr.shape
         assert arr.flags.writeable


### PR DESCRIPTION
#### Describe the changes
* Change code to copy the pixel module to avoid making changes to the dataset as originally intended (closes #1689)
* Updates the install tutorial to refer to the `main` branch

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/ad4b5221-d505-49d5-98b0-98b02ae48a28/artifacts/0/doc/_build/html/tutorials/installation.html)
- [x] Unit tests passing and overall coverage the same or better
