### PR TITLE
[MRG] Remove deprecated UIDs, add new UIDs

### DIFF
--- a/doc/reference/uid.rst
+++ b/doc/reference/uid.rst
@@ -17,7 +17,7 @@ Transfer Syntax UIDs
    ExplicitVRBigEndian
    JPEGBaseline8Bit
    JPEGExtended12Bit
-   JPEGLosslessP14
+   JPEGLossless
    JPEGLosslessSV1
    JPEGLSLossless
    JPEGLSNearLossless
@@ -26,15 +26,25 @@ Transfer Syntax UIDs
    JPEG2000MCLossless
    JPEG2000MC
    MPEG2MPML
+   MPEG2MPMLF
    MPEG2MPHL
+   MPEG2MPHLF
    MPEG4HP41
+   MPEG4HP41F
    MPEG4HP41BD
+   MPEG4HP41BDF
    MPEG4HP422D
+   MPEG4HP422DF
    MPEG4HP423D
+   MPEG4HP423DF
    MPEG4HP42STEREO
+   MPEG4HP42STEREOF
    HEVCMP51
    HEVCM10P51
    RLELossless
+   SMPTEST211020UncompressedProgressiveActiveVideo
+   SMPTEST211020UncompressedInterlacedActiveVideo
+   SMPTEST211030PCMDigitalAudio
 
 
 Transfer Syntax Lists

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -16,11 +16,48 @@ Changes
 * The `read_file` and `write_file` functions have been removed, use
   :func:`~pydicom.filereader.dcmread` and :func:`~pydicom.filewriter.dcmwrite`
   instead.
+* The value for ``JPEGLossless`` has changed from
+  1.2.840.10008.1.2.4.70 to 1.2.840.10008.1.2.4.57 to match its UID keyword. Use
+  :attr:`~pydicom.uid.JPEGLosslessSV1` instead for 1.2.840.10008.1.2.4.70
+* The following UID constants have been removed:
+
+    * ``JPEGBaseline`` (use :attr:`~pydicom.uid.JPEGBaseline8Bit` instead)
+    * ``JPEGExtended`` (use :attr:`~pydicom.uid.JPEGExtended12Bit` instead)
+    * ``JPEGLSLossy`` (use :attr:`~pydicom.uid.JPEGLSNearLossless` instead)
+    * ``JPEG2000MultiComponentLossless`` (use
+      :attr:`~pydicom.uid.JPEG2000MCLossless` instead)
+    * ``JPEG2000MultiComponent`` (use :attr:`~pydicom.uid.JPEG2000MC` instead)
+* The following UID lists have been removed:
+
+    * ``JPEGLossyCompressedPixelTransferSyntaxes``: use
+      :attr:`~pydicom.uid.JPEGTransferSyntaxes`
+    * ``JPEGLSSupportedCompressedPixelTransferSyntaxes``: use
+      :attr:`~pydicom.uid.JPEGLSTransferSyntaxes`
+    * ``JPEG2000CompressedPixelTransferSyntaxes``: use
+      :attr:`~pydicom.uid.JPEG2000TransferSyntaxes`
+    * ``RLECompressedLosslessSyntaxes``: use
+      :attr:`~pydicom.uid.RLETransferSyntaxes`
+    * ``UncompressedPixelTransferSyntaxes``: use
+      :attr:`~pydicom.uid.UncompressedTransferSyntaxes`
+    * ``PILSupportedCompressedPixelTransferSyntaxes``
 
 Enhancements
 ------------
 * Added details of missing required tag information when adding a dataset to a
   File-set (:issue:`1752`)
+* The following UID constants have been added:
+
+    * :attr:`~pydicom.uid.JPEGBaseline8Bit`
+    * :attr:`~pydicom.uid.MPEG2MPMLF`
+    * :attr:`~pydicom.uid.MPEG2MPHLF`
+    * :attr:`~pydicom.uid.MPEG4HP41F`
+    * :attr:`~pydicom.uid.MPEG4HP41BDF`
+    * :attr:`~pydicom.uid.MPEG4HP422DF`
+    * :attr:`~pydicom.uid.MPEG4HP423DF`
+    * :attr:`~pydicom.uid.MPEG4HP42STEREOF`
+    * :attr:`~pydicom.uid.SMPTEST211020UncompressedProgressiveActiveVideo`
+    * :attr:`~pydicom.uid.SMPTEST211020UncompressedInterlacedActiveVideo`
+    * :attr:`~pydicom.uid.SMPTEST211030PCMDigitalAudio`
 
 Fixes
 -----

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -47,7 +47,6 @@ Enhancements
   File-set (:issue:`1752`)
 * The following UID constants have been added:
 
-    * :attr:`~pydicom.uid.JPEGBaseline8Bit`
     * :attr:`~pydicom.uid.MPEG2MPMLF`
     * :attr:`~pydicom.uid.MPEG2MPHLF`
     * :attr:`~pydicom.uid.MPEG4HP41F`

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -16,7 +16,7 @@ Changes
 * The `read_file` and `write_file` functions have been removed, use
   :func:`~pydicom.filereader.dcmread` and :func:`~pydicom.filewriter.dcmwrite`
   instead.
-* The value for ``JPEGLossless`` has changed from
+* The value for :attr:`~pydicom.uid.JPEGLossless` has changed from
   1.2.840.10008.1.2.4.70 to 1.2.840.10008.1.2.4.57 to match its UID keyword. Use
   :attr:`~pydicom.uid.JPEGLosslessSV1` instead for 1.2.840.10008.1.2.4.70
 * The following UID constants have been removed:

--- a/src/pydicom/encoders/base.py
+++ b/src/pydicom/encoders/base.py
@@ -11,7 +11,7 @@ from pydicom.uid import (
     UID,
     JPEGBaseline8Bit,
     JPEGExtended12Bit,
-    JPEGLosslessP14,
+    JPEGLossless,
     JPEGLosslessSV1,
     JPEGLSLossless,
     JPEGLSNearLossless,
@@ -803,7 +803,7 @@ ENCODING_PROFILES: dict[UID, list[ProfileType]] = {
         ("MONOCHROME2", 1, (0,), (8,), (8,)),
         ("MONOCHROME2", 1, (0,), (16,), (12,)),
     ],
-    JPEGLosslessP14: [  # 1.2.840.10008.1.2.4.57: Table 8.2.1-2 in PS3.5
+    JPEGLossless: [  # 1.2.840.10008.1.2.4.57: Table 8.2.1-2 in PS3.5
         ("MONOCHROME1", 1, (0, 1), (8, 16), range(1, 17)),
         ("MONOCHROME2", 1, (0, 1), (8, 16), range(1, 17)),
         ("PALETTE COLOR", 1, (0,), (8, 16), range(1, 17)),

--- a/src/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/src/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -51,7 +51,7 @@ DEPENDENCIES = {
 SUPPORTED_TRANSFER_SYNTAXES = [
     pydicom.uid.JPEGBaseline8Bit,
     pydicom.uid.JPEGExtended12Bit,
-    pydicom.uid.JPEGLosslessP14,
+    pydicom.uid.JPEGLossless,
     pydicom.uid.JPEGLosslessSV1,
     pydicom.uid.JPEGLSLossless,
     pydicom.uid.JPEGLSNearLossless,

--- a/src/pydicom/pixel_data_handlers/pylibjpeg_handler.py
+++ b/src/pydicom/pixel_data_handlers/pylibjpeg_handler.py
@@ -109,7 +109,7 @@ from pydicom.pixel_data_handlers.util import (
 from pydicom.uid import (
     JPEGBaseline8Bit,
     JPEGExtended12Bit,
-    JPEGLosslessP14,
+    JPEGLossless,
     JPEGLosslessSV1,
     JPEGLSLossless,
     JPEGLSNearLossless,
@@ -130,7 +130,7 @@ if HAVE_PYLIBJPEG:
 _LIBJPEG_SYNTAXES = [
     JPEGBaseline8Bit,
     JPEGExtended12Bit,
-    JPEGLosslessP14,
+    JPEGLossless,
     JPEGLosslessSV1,
     JPEGLSLossless,
     JPEGLSNearLossless,

--- a/src/pydicom/uid.py
+++ b/src/pydicom/uid.py
@@ -7,43 +7,12 @@ import random
 import re
 import sys
 import uuid
-import warnings
 from typing import Any
 
 from pydicom import config
 from pydicom._uid_dict import UID_dictionary
 from pydicom.config import disable_value_validation
 from pydicom.valuerep import STR_VR_REGEXES, validate_value
-
-_deprecations = {
-    "JPEGBaseline": "JPEGBaseline8Bit",
-    "JPEGExtended": "JPEGExtended12Bit",
-    "JPEGLossless": "JPEGLosslessSV1",
-    "JPEGLSLossy": "JPEGLSNearLossless",
-    "JPEG2000MultiComponentLossless": "JPEG2000MCLossless",
-    "JPEG2000MultiComponent": "JPEG2000MC",
-}
-
-
-def __getattr__(name: str) -> Any:
-    if name in _deprecations:
-        replacement = _deprecations[name]
-        if name == "JPEGLossless":
-            warnings.warn(
-                "In pydicom v3.0 the UID for 'JPEGLossless' will change "
-                "from '1.2.840.10008.1.2.4.70' to '1.2.840.10008.1.2.4.57' to "
-                f"match its UID keyword. Use '{replacement}' instead"
-            )
-        else:
-            warnings.warn(
-                f"The UID constant '{name}' is deprecated and will be removed "
-                f"in pydicom v3.0, use '{replacement}' instead",
-                DeprecationWarning,
-            )
-
-        return globals()[replacement]
-
-    raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
 class UID(str):
@@ -265,9 +234,9 @@ with disable_value_validation():
     """1.2.840.10008.1.2.4.50"""
     JPEGExtended12Bit = UID("1.2.840.10008.1.2.4.51")
     """1.2.840.10008.1.2.4.51"""
-    JPEGLosslessP14 = UID("1.2.840.10008.1.2.4.57")  # needs to be updated
+    JPEGLossless = UID("1.2.840.10008.1.2.4.57")
     """1.2.840.10008.1.2.4.57"""
-    JPEGLosslessSV1 = UID("1.2.840.10008.1.2.4.70")  # Old JPEGLossless
+    JPEGLosslessSV1 = UID("1.2.840.10008.1.2.4.70")
     """1.2.840.10008.1.2.4.70"""
     JPEGLSLossless = UID("1.2.840.10008.1.2.4.80")
     """1.2.840.10008.1.2.4.80"""
@@ -283,24 +252,44 @@ with disable_value_validation():
     """1.2.840.10008.1.2.4.93"""
     MPEG2MPML = UID("1.2.840.10008.1.2.4.100")
     """1.2.840.10008.1.2.4.100"""
+    MPEG2MPMLF = UID("1.2.840.10008.1.2.4.100.1")
+    """1.2.840.10008.1.2.4.100.1"""
     MPEG2MPHL = UID("1.2.840.10008.1.2.4.101")
     """1.2.840.10008.1.2.4.101"""
+    MPEG2MPHLF = UID("1.2.840.10008.1.2.4.101.1")
+    """1.2.840.10008.1.2.4.101.1"""
     MPEG4HP41 = UID("1.2.840.10008.1.2.4.102")
     """1.2.840.10008.1.2.4.102"""
+    MPEG4HP41F = UID("1.2.840.10008.1.2.4.102.1")
+    """1.2.840.10008.1.2.4.102.1"""
     MPEG4HP41BD = UID("1.2.840.10008.1.2.4.103")
     """1.2.840.10008.1.2.4.103"""
+    MPEG4HP41BDF = UID("1.2.840.10008.1.2.4.103.1")
+    """1.2.840.10008.1.2.4.103.1"""
     MPEG4HP422D = UID("1.2.840.10008.1.2.4.104")
     """1.2.840.10008.1.2.4.104"""
+    MPEG4HP422DF = UID("1.2.840.10008.1.2.4.104.1")
+    """1.2.840.10008.1.2.4.104.1"""
     MPEG4HP423D = UID("1.2.840.10008.1.2.4.105")
     """1.2.840.10008.1.2.4.105"""
+    MPEG4HP423DF = UID("1.2.840.10008.1.2.4.105.1")
+    """1.2.840.10008.1.2.4.105.1"""
     MPEG4HP42STEREO = UID("1.2.840.10008.1.2.4.106")
     """1.2.840.10008.1.2.4.106"""
+    MPEG4HP42STEREOF = UID("1.2.840.10008.1.2.4.106.1")
+    """1.2.840.10008.1.2.4.106.1"""
     HEVCMP51 = UID("1.2.840.10008.1.2.4.107")
     """1.2.840.10008.1.2.4.107"""
     HEVCM10P51 = UID("1.2.840.10008.1.2.4.108")
     """1.2.840.10008.1.2.4.108"""
     RLELossless = UID("1.2.840.10008.1.2.5")
     """1.2.840.10008.1.2.5"""
+    SMPTEST211020UncompressedProgressiveActiveVideo = UID("1.2.840.10008.1.2.7.1")
+    """1.2.840.10008.1.2.7.1"""
+    SMPTEST211020UncompressedInterlacedActiveVideo = UID("1.2.840.10008.1.2.7.2")
+    """1.2.840.10008.1.2.7.2"""
+    SMPTEST211030PCMDigitalAudio = UID("1.2.840.10008.1.2.7.3")
+    """1.2.840.10008.1.2.7.3"""
 
 AllTransferSyntaxes = [
     ImplicitVRLittleEndian,
@@ -309,7 +298,7 @@ AllTransferSyntaxes = [
     ExplicitVRBigEndian,
     JPEGBaseline8Bit,
     JPEGExtended12Bit,
-    JPEGLosslessP14,
+    JPEGLossless,
     JPEGLosslessSV1,
     JPEGLSLossless,
     JPEGLSNearLossless,
@@ -318,22 +307,32 @@ AllTransferSyntaxes = [
     JPEG2000MCLossless,
     JPEG2000MC,
     MPEG2MPML,
+    MPEG2MPMLF,
     MPEG2MPHL,
+    MPEG2MPHLF,
     MPEG4HP41,
+    MPEG4HP41F,
     MPEG4HP41BD,
+    MPEG4HP41BDF,
     MPEG4HP422D,
+    MPEG4HP422DF,
     MPEG4HP423D,
+    MPEG4HP423DF,
     MPEG4HP42STEREO,
+    MPEG4HP42STEREOF,
     HEVCMP51,
     HEVCM10P51,
     RLELossless,
+    SMPTEST211020UncompressedProgressiveActiveVideo,
+    SMPTEST211020UncompressedInterlacedActiveVideo,
+    SMPTEST211030PCMDigitalAudio,
 ]
 """All non-retired transfer syntaxes and *Explicit VR Big Endian*."""
 
 JPEGTransferSyntaxes = [
     JPEGBaseline8Bit,
     JPEGExtended12Bit,
-    JPEGLosslessP14,
+    JPEGLossless,
     JPEGLosslessSV1,
 ]
 """JPEG (ISO/IEC 10918-1) transfer syntaxes"""
@@ -346,12 +345,19 @@ JPEG2000TransferSyntaxes = [JPEG2000Lossless, JPEG2000, JPEG2000MCLossless, JPEG
 
 MPEGTransferSyntaxes = [
     MPEG2MPML,
+    MPEG2MPMLF,
     MPEG2MPHL,
+    MPEG2MPHLF,
     MPEG4HP41,
+    MPEG4HP41F,
     MPEG4HP41BD,
+    MPEG4HP41BDF,
     MPEG4HP422D,
+    MPEG4HP422DF,
     MPEG4HP423D,
+    MPEG4HP423DF,
     MPEG4HP42STEREO,
+    MPEG4HP42STEREOF,
     HEVCMP51,
     HEVCM10P51,
 ]
@@ -367,31 +373,6 @@ UncompressedTransferSyntaxes = [
     ExplicitVRBigEndian,
 ]
 """Uncompressed (native) transfer syntaxes."""
-
-# Deprecated
-if sys.version_info[:2] < (3, 7):
-    JPEGBaseline = JPEGBaseline8Bit
-    JPEGExtended = JPEGExtended12Bit
-    JPEGLossless = JPEGLosslessSV1
-    JPEGLSLossy = JPEGLSNearLossless
-    JPEG2000MultiComponentLossless = JPEG2000MCLossless
-    JPEG2000MultiComponent = JPEG2000MC
-
-JPEGLossyCompressedPixelTransferSyntaxes = [
-    JPEGBaseline8Bit,
-    JPEGExtended12Bit,
-]
-JPEGLSSupportedCompressedPixelTransferSyntaxes = JPEGLSTransferSyntaxes
-JPEG2000CompressedPixelTransferSyntaxes = JPEG2000TransferSyntaxes
-PILSupportedCompressedPixelTransferSyntaxes = [
-    JPEGBaseline8Bit,
-    JPEGLosslessP14,
-    JPEGExtended12Bit,
-    JPEG2000Lossless,
-    JPEG2000,
-]
-RLECompressedLosslessSyntaxes = RLETransferSyntaxes
-UncompressedPixelTransferSyntaxes = UncompressedTransferSyntaxes
 
 
 def generate_uid(

--- a/tests/test_handler_util.py
+++ b/tests/test_handler_util.py
@@ -40,7 +40,7 @@ from pydicom.pixel_data_handlers.util import (
 from pydicom.uid import (
     ExplicitVRLittleEndian,
     ImplicitVRLittleEndian,
-    UncompressedPixelTransferSyntaxes,
+    UncompressedTransferSyntaxes,
 )
 
 
@@ -859,7 +859,7 @@ class TestNumpy_ReshapePixelArray:
 
     def test_uncompressed_syntaxes(self):
         """Test that uncompressed syntaxes use the dataset planar conf."""
-        for uid in UncompressedPixelTransferSyntaxes:
+        for uid in UncompressedTransferSyntaxes:
             self.ds.file_meta.TransferSyntaxUID = uid
             self.ds.PlanarConfiguration = 0
             self.ds.NumberOfFrames = 1

--- a/tests/test_pylibjpeg.py
+++ b/tests/test_pylibjpeg.py
@@ -16,7 +16,7 @@ from pydicom.uid import (
     ImplicitVRLittleEndian,
     JPEGBaseline8Bit,
     JPEGExtended12Bit,
-    JPEGLosslessP14,
+    JPEGLossless,
     JPEGLosslessSV1,
     JPEGLSLossless,
     JPEGLSNearLossless,
@@ -65,7 +65,7 @@ TEST_RLE = TEST_HANDLER and HAVE_RLE  # Run RLE Lossless tests
 SUPPORTED_SYNTAXES = [
     JPEGBaseline8Bit,
     JPEGExtended12Bit,
-    JPEGLosslessP14,
+    JPEGLossless,
     JPEGLosslessSV1,
     JPEGLSLossless,
     JPEGLSNearLossless,

--- a/tests/test_uid.py
+++ b/tests/test_uid.py
@@ -16,53 +16,6 @@ def test_storage_sopclass_uids():
     assert CTImageStorage == pydicom.uid.CTImageStorage
 
 
-def test_jpeglossless_warning():
-    """Test warning when importing JPEGLossless for Python 3.7+."""
-    if sys.version_info[:2] < (3, 7):
-        from pydicom.uid import JPEGLossless
-
-        assert "1.2.840.10008.1.2.4.70" == JPEGLossless
-    else:
-        msg = (
-            r"In pydicom v3.0 the UID for 'JPEGLossless' will change "
-            r"from '1.2.840.10008.1.2.4.70' to '1.2.840.10008.1.2.4.57' to "
-            r"match its UID keyword. Use 'JPEGLosslessSV1' instead"
-        )
-        with pytest.warns(UserWarning, match=msg):
-            from pydicom.uid import JPEGLossless
-
-            assert "1.2.840.10008.1.2.4.70" == JPEGLossless
-
-
-def test_deprecation_warnings():
-    """Test deprecations warnings for other UIDs for Python 3.7+."""
-    _deprecations = {
-        "JPEGBaseline": ("1.2.840.10008.1.2.4.50", "JPEGBaseline8Bit"),
-        "JPEGExtended": ("1.2.840.10008.1.2.4.51", "JPEGExtended12Bit"),
-        "JPEGLSLossy": ("1.2.840.10008.1.2.4.81", "JPEGLSNearLossless"),
-        "JPEG2000MultiComponentLossless": (
-            "1.2.840.10008.1.2.4.92",
-            "JPEG2000MCLossless",
-        ),
-        "JPEG2000MultiComponent": ("1.2.840.10008.1.2.4.93", "JPEG2000MC"),
-    }
-
-    if sys.version_info[:2] < (3, 7):
-        for name, (value, replacement) in _deprecations.items():
-            uid = getattr(pydicom.uid, name)
-
-            assert value == uid
-    else:
-        for name, (value, replacement) in _deprecations.items():
-            msg = (
-                f"The UID constant '{name}' is deprecated and will be removed "
-                f"in pydicom v3.0, use '{replacement}' instead"
-            )
-            with pytest.warns(DeprecationWarning, match=msg):
-                uid = getattr(pydicom.uid, name)
-                assert value == uid
-
-
 class TestGenerateUID:
     def test_generate_uid(self):
         """Test UID generator"""


### PR DESCRIPTION
#### Describe the changes
* Removes UIDs and various List[UID] [deprecated in v2.1](https://pydicom.github.io/pydicom/stable/release_notes/index.html#id9)
* Changes the UID value for `JPEGLossless` to `1.2.840.10008.1.2.4.57` in line with [planned change](https://pydicom.github.io/pydicom/stable/release_notes/index.html#id9)
* Adds [various new MPEG and SMPTE UIDs](https://dicom.nema.org/medical/dicom/current/output/chtml/part06/chapter_A.html)

#### Tasks
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/493ed39e-fac6-472a-baab-505624beb7ce/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
