### PR TITLE
[MRG] Reduce theoretical maximum size of file-sets to support 32-bit systems

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -50,11 +50,10 @@ Changes
 * Removed the `_storage_sopclass_uids` module, import UIDs from the `uid` module
   instead
 * The theoretical maximum number of instances supported by
-  :class:`~pydicom.fileset.FileSet` has been reduced to 308915776 to ensure support
+  :class:`~pydicom.fileset.FileSet` has been reduced to 1838265625 to ensure support
   for 32-bit systems (:issue:`1743`)
-* The `alphanumeric` keyword argument for :func:`~pydicom.fileset.generate_filename`
-  has been changed to `use_alpha` and the characters used for filenames changed
-  to use [A-Z] accordingly
+* The characters used by :func:`~pydicom.fileset.generate_filename` when
+  `alphanumeric` is ``True`` has been reduced to [0-9][A-I,K-Z]
 
 Enhancements
 ------------

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -49,6 +49,11 @@ Changes
   :attr:`~pydicom.encoders.RLELosslessEncoder` instead.
 * Removed the `_storage_sopclass_uids` module, import UIDs from the `uid` module
   instead
+* The theoretical maximum number of instances supported by
+  :class:`~pydicom.fileset.FileSet` has been reduced to 308915776
+* The `alphanumeric` keyword argument for :func:`~pydicom.fileset.generate_filename`
+  has been change dto `use_alpha` and the characters used for filenames changed
+  to use [A-Z] accordingly to ensure support for 32-bit systems (:issue:`1743`) .
 
 Enhancements
 ------------

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -50,10 +50,11 @@ Changes
 * Removed the `_storage_sopclass_uids` module, import UIDs from the `uid` module
   instead
 * The theoretical maximum number of instances supported by
-  :class:`~pydicom.fileset.FileSet` has been reduced to 308915776
+  :class:`~pydicom.fileset.FileSet` has been reduced to 308915776 to ensure support
+  for 32-bit systems (:issue:`1743`)
 * The `alphanumeric` keyword argument for :func:`~pydicom.fileset.generate_filename`
-  has been change dto `use_alpha` and the characters used for filenames changed
-  to use [A-Z] accordingly to ensure support for 32-bit systems (:issue:`1743`) .
+  has been changed to `use_alpha` and the characters used for filenames changed
+  to use [A-Z] accordingly
 
 Enhancements
 ------------

--- a/src/pydicom/fileset.py
+++ b/src/pydicom/fileset.py
@@ -80,11 +80,11 @@ def generate_filename(
     Maximum number of File IDs is:
 
     * Numeric: (10 ** (8 - `prefix`)) - `start`
-    * Alpha: (35 ** (8 - `prefix`)) - `start`
+    * Alphanumeric: (35 ** (8 - `prefix`)) - `start`
 
     .. versionchanged:: 3.0
 
-       The characters used when `alphanumeric` is ``True`` has been reduced to
+       The characters used when `alphanumeric` is ``True`` have been reduced to
        [0-9][A-I,K-Z]
 
     Parameters

--- a/src/pydicom/fileset.py
+++ b/src/pydicom/fileset.py
@@ -80,7 +80,7 @@ def generate_filename(
     Maximum number of File IDs is:
 
     * Numeric: (10 ** (8 - `prefix`)) - `start`
-    * Alpha: (26 ** (8 - `prefix`)) - `start`
+    * Alpha: (35 ** (8 - `prefix`)) - `start`
 
     .. versionchanged:: 3.0
 

--- a/src/pydicom/fileset.py
+++ b/src/pydicom/fileset.py
@@ -72,8 +72,6 @@ _LOWER_OFFSET = "OffsetOfReferencedLowerLevelDirectoryEntity"
 _LAST_OFFSET = "OffsetOfTheLastDirectoryRecordOfTheRootDirectoryEntity"
 
 
-
-
 def generate_filename(
     prefix: str = "", start: int = 0, use_alpha: bool = False
 ) -> Iterator[str]:

--- a/src/pydicom/fileset.py
+++ b/src/pydicom/fileset.py
@@ -1,6 +1,7 @@
 # Copyright 2008-2020 pydicom authors. See LICENSE file for details.
 """DICOM File-set handling."""
 
+from collections.abc import Iterator, Iterable, Callable
 import copy
 import os
 from pathlib import Path
@@ -8,7 +9,6 @@ import re
 import shutil
 from tempfile import TemporaryDirectory
 from typing import Optional, Union, Any, cast
-from collections.abc import Iterator, Iterable, Callable
 import warnings
 
 from pydicom.charset import default_encoding
@@ -72,15 +72,22 @@ _LOWER_OFFSET = "OffsetOfReferencedLowerLevelDirectoryEntity"
 _LAST_OFFSET = "OffsetOfTheLastDirectoryRecordOfTheRootDirectoryEntity"
 
 
+
+
 def generate_filename(
-    prefix: str = "", start: int = 0, alphanumeric: bool = False
+    prefix: str = "", start: int = 0, use_alpha: bool = False
 ) -> Iterator[str]:
     """Yield File IDs for a File-set.
 
     Maximum number of File IDs is:
 
     * Numeric: (10 ** (8 - `prefix`)) - `start`
-    * Alphanumeric: (36 ** (8 - `prefix`)) - `start`
+    * Alpha: (26 ** (8 - `prefix`)) - `start`
+
+    .. versionchanged:: 3.0
+
+       `alphanumeric` has been changed to `use_alpha` and the characters
+       used when `use_alpha` is ``True`` has been reduced to [A-Z]
 
     Parameters
     ----------
@@ -89,9 +96,9 @@ def generate_filename(
     start : int, optional
         The starting index to use for the suffixes, (default ``0``).
         i.e. if you want to start at ``'00010'`` then `start` should be ``10``.
-    alphanumeric : bool, optional
+    use_alpha : bool, optional
         If ``False`` (default) then only generate suffixes using the characters
-        [0-9], otherwise use [0-9][A-Z].
+        [0-9], otherwise use [A-Z].
 
     Yields
     ------
@@ -103,10 +110,8 @@ def generate_filename(
     if len(prefix) > 7:
         raise ValueError("The 'prefix' must be less than 8 characters long")
 
-    chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    if not alphanumeric:
-        chars = chars[:10]
-
+    chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" if use_alpha else "0123456789"
+    padding = "A" if use_alpha else "0"
     idx = start
     b = len(chars)
     length = 8 - len(prefix)
@@ -117,7 +122,7 @@ def generate_filename(
             suffix += chars[n % b]
             n //= b
 
-        yield f"{prefix}{suffix[::-1]:>0{length}}"
+        yield f"{prefix}{suffix[::-1]:{padding}>{length}}"
         idx += 1
 
 
@@ -245,10 +250,11 @@ class RecordNode(Iterable["RecordNode"]):
         if self.record_type == "PRIVATE":
             prefix = f"{prefix}{self.depth}"
 
-        chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        if not self.file_set._use_alphanumeric:
-            chars = chars[:10]
+        chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        if not self.file_set._use_alpha:
+            chars = "0123456789"
 
+        padding = "A" if self.file_set._use_alpha else "0"
         suffix = ""
         n = self.index
         b = len(chars)
@@ -256,7 +262,7 @@ class RecordNode(Iterable["RecordNode"]):
             suffix += chars[n % b]
             n //= b
 
-        idx = f"{suffix[::-1]:>0{8 - len(prefix)}}"
+        idx = f"{suffix[::-1]:{padding}>{8 - len(prefix)}}"
 
         return f"{prefix}{idx}"
 
@@ -973,8 +979,8 @@ class FileSet:
         self._ds = Dataset()
         # The File-set's managed SOP Instances as list of FileInstance
         self._instances: list[FileInstance] = []
-        # Use alphanumeric or numeric File IDs
-        self._use_alphanumeric = False
+        # Use alpha or numeric File IDs
+        self._use_alpha = False
 
         # The File-set ID
         self._id: str | None = None
@@ -1240,11 +1246,12 @@ class FileSet:
             raise ValueError("Cannot copy the File-set as the 'path' is unchanged")
 
         if len(self) > 10**6:
-            self._use_alphanumeric = True
-        if len(self) > 36**6:
+            self._use_alpha = True
+
+        if len(self) > 26**6:
             raise NotImplementedError(
                 "pydicom doesn't support writing File-sets with more than "
-                "2176782336 managed instances"
+                "308915776 managed instances"
             )
 
         # Removals are detached from the tree
@@ -2079,11 +2086,12 @@ class FileSet:
 
         # Worst case scenario if all instances in one directory
         if len(self) > 10**6:
-            self._use_alphanumeric = True
-        if len(self) > 36**6:
+            self._use_alpha = True
+
+        if len(self) > 26**6:
             raise NotImplementedError(
                 "pydicom doesn't support writing File-sets with more than "
-                "2176782336 managed instances"
+                "308915776 managed instances on 32-bit systems"
             )
 
         # Remove the removals - must be first because the File IDs will be

--- a/src/pydicom/fileset.py
+++ b/src/pydicom/fileset.py
@@ -2089,7 +2089,7 @@ class FileSet:
         if len(self) > 26**6:
             raise NotImplementedError(
                 "pydicom doesn't support writing File-sets with more than "
-                "308915776 managed instances on 32-bit systems"
+                "308915776 managed instances"
             )
 
         # Remove the removals - must be first because the File IDs will be

--- a/tests/test_fileset.py
+++ b/tests/test_fileset.py
@@ -399,7 +399,7 @@ class TestGenerateFilename:
 
     def test_numeric(self):
         """Test generating numeric suffixes."""
-        gen = generate_filename(start=0, alphanumeric=False)
+        gen = generate_filename(start=0, use_alpha=False)
         assert "00000000" == next(gen)
         assert "00000001" == next(gen)
         assert "00000002" == next(gen)
@@ -416,58 +416,44 @@ class TestGenerateFilename:
         """Test prefix for numeric filenames."""
         for ii in range(1, 8):
             prefix = "A" * ii
-            gen = generate_filename(prefix="A" * ii, start=0, alphanumeric=False)
+            gen = generate_filename(prefix="A" * ii, start=0, use_alpha=False)
             assert prefix + "0" * (8 - ii) == next(gen)
 
     def test_numeric_start(self):
         """Test start point with numeric suffixes."""
-        gen = generate_filename(start=10, alphanumeric=False)
+        gen = generate_filename(start=10, use_alpha=False)
         assert "00000010" == next(gen)
         assert "00000011" == next(gen)
         assert "00000012" == next(gen)
 
-    def test_alphanumeric(self):
-        """Test generating alphanumeric suffixes."""
-        gen = generate_filename(start=0, alphanumeric=True)
-        assert "00000000" == next(gen)
-        assert "00000001" == next(gen)
-        assert "00000002" == next(gen)
-        assert "00000003" == next(gen)
-        assert "00000004" == next(gen)
-        assert "00000005" == next(gen)
-        assert "00000006" == next(gen)
-        assert "00000007" == next(gen)
-        assert "00000008" == next(gen)
-        assert "00000009" == next(gen)
-        assert "0000000A" == next(gen)
-        for ii in range(24):
+    def test_alpha(self):
+        """Test generating alpha suffixes."""
+        gen = generate_filename(start=0, use_alpha=True)
+        assert "AAAAAAAA" == next(gen)
+        assert "AAAAAAAB" == next(gen)
+        assert "AAAAAAAC" == next(gen)
+        assert "AAAAAAAD" == next(gen)
+        for ii in range(21):
             next(gen)
-        assert "0000000Z" == next(gen)
-        assert "00000010" == next(gen)
+        assert "AAAAAAAZ" == next(gen)
+        assert "AAAAAABA" == next(gen)
 
-    def test_alphanumeric_prefix(self):
+    def test_alpha_prefix(self):
         """Test length of the suffixes."""
         for ii in range(1, 8):
-            prefix = "A" * ii
-            gen = generate_filename(prefix="A" * ii, start=0, alphanumeric=True)
-            assert prefix + "0" * (8 - ii) == next(gen)
-            assert prefix + "0" * (7 - ii) + "1" == next(gen)
-            assert prefix + "0" * (7 - ii) + "2" == next(gen)
-            assert prefix + "0" * (7 - ii) + "3" == next(gen)
-            assert prefix + "0" * (7 - ii) + "4" == next(gen)
-            assert prefix + "0" * (7 - ii) + "5" == next(gen)
-            assert prefix + "0" * (7 - ii) + "6" == next(gen)
-            assert prefix + "0" * (7 - ii) + "7" == next(gen)
-            assert prefix + "0" * (7 - ii) + "8" == next(gen)
-            assert prefix + "0" * (7 - ii) + "9" == next(gen)
-            assert prefix + "0" * (7 - ii) + "A" == next(gen)
+            prefix = "2" * ii
+            gen = generate_filename(prefix="2" * ii, start=0, use_alpha=True)
+            assert prefix + "A" * (8 - ii) == next(gen)
+            assert prefix + "A" * (7 - ii) + "B" == next(gen)
+            assert prefix + "A" * (7 - ii) + "C" == next(gen)
+            assert prefix + "A" * (7 - ii) + "D" == next(gen)
 
-    def test_alphanumeric_start(self):
-        """Test start point with alphanumeric suffixes."""
-        gen = generate_filename(start=10, alphanumeric=True)
-        assert "0000000A" == next(gen)
-        assert "0000000B" == next(gen)
-        assert "0000000C" == next(gen)
+    def test_alpha_start(self):
+        """Test start point with alpha suffixes."""
+        gen = generate_filename(start=10, use_alpha=True)
+        assert "AAAAAAAK" == next(gen)
+        assert "AAAAAAAL" == next(gen)
+        assert "AAAAAAAM" == next(gen)
 
     def test_long_prefix_raises(self):
         """Test too long a prefix."""
@@ -2241,18 +2227,18 @@ class TestFileSet_Modify:
         assert 10**6 + 1 == len(fs)
         ds, paths = write_fs(fs)
         instance = fs._instances[-1]
-        # Was written with alphanumeric File IDs
-        assert "IM00001D" in instance.path
+        # Was written with alpha File IDs
+        assert "IMAAAABX" in instance.path
 
         def my_len(self):
-            return 36**6 + 1
+            return 26**6 + 1
 
         FileSet.__len__ = my_len
         fs = FileSet(ds)
-        assert 36**6 + 1 == len(fs)
+        assert 26**6 + 1 == len(fs)
         msg = (
             r"pydicom doesn't support writing File-sets with more than "
-            r"2176782336 managed instances"
+            r"308915776 managed instances"
         )
         with pytest.raises(NotImplementedError, match=msg):
             fs.write()
@@ -2574,17 +2560,17 @@ class TestFileSet_Copy:
         fs, ds, paths = copy_fs(fs, tdir.name)
         instance = fs._instances[-1]
         # Was written with alphanumeric File IDs
-        assert "IM00001D" in instance.path
+        assert "IMAAAABX" in instance.path
 
         def my_len(self):
-            return 36**6 + 1
+            return 26**6 + 1
 
         FileSet.__len__ = my_len
         fs = FileSet(tiny)
-        assert 36**6 + 1 == len(fs)
+        assert 26**6 + 1 == len(fs)
         msg = (
             r"pydicom doesn't support writing File-sets with more than "
-            r"2176782336 managed instances"
+            r"308915776 managed instances"
         )
         with pytest.raises(NotImplementedError, match=msg):
             fs.copy(tdir.name)

--- a/tests/test_fileset.py
+++ b/tests/test_fileset.py
@@ -399,7 +399,7 @@ class TestGenerateFilename:
 
     def test_numeric(self):
         """Test generating numeric suffixes."""
-        gen = generate_filename(start=0, use_alpha=False)
+        gen = generate_filename(start=0, alphanumeric=False)
         assert "00000000" == next(gen)
         assert "00000001" == next(gen)
         assert "00000002" == next(gen)
@@ -416,44 +416,58 @@ class TestGenerateFilename:
         """Test prefix for numeric filenames."""
         for ii in range(1, 8):
             prefix = "A" * ii
-            gen = generate_filename(prefix="A" * ii, start=0, use_alpha=False)
+            gen = generate_filename(prefix="A" * ii, start=0, alphanumeric=False)
             assert prefix + "0" * (8 - ii) == next(gen)
 
     def test_numeric_start(self):
         """Test start point with numeric suffixes."""
-        gen = generate_filename(start=10, use_alpha=False)
+        gen = generate_filename(start=10, alphanumeric=False)
         assert "00000010" == next(gen)
         assert "00000011" == next(gen)
         assert "00000012" == next(gen)
 
-    def test_alpha(self):
-        """Test generating alpha suffixes."""
-        gen = generate_filename(start=0, use_alpha=True)
-        assert "AAAAAAAA" == next(gen)
-        assert "AAAAAAAB" == next(gen)
-        assert "AAAAAAAC" == next(gen)
-        assert "AAAAAAAD" == next(gen)
-        for ii in range(21):
+    def test_alphanumeric(self):
+        """Test generating alphanumeric suffixes."""
+        gen = generate_filename(start=0, alphanumeric=True)
+        assert "00000000" == next(gen)
+        assert "00000001" == next(gen)
+        assert "00000002" == next(gen)
+        assert "00000003" == next(gen)
+        assert "00000004" == next(gen)
+        assert "00000005" == next(gen)
+        assert "00000006" == next(gen)
+        assert "00000007" == next(gen)
+        assert "00000008" == next(gen)
+        assert "00000009" == next(gen)
+        assert "0000000A" == next(gen)
+        for ii in range(23):
             next(gen)
-        assert "AAAAAAAZ" == next(gen)
-        assert "AAAAAABA" == next(gen)
+        assert "0000000Z" == next(gen)
+        assert "00000010" == next(gen)
 
-    def test_alpha_prefix(self):
+    def test_alphanumeric_prefix(self):
         """Test length of the suffixes."""
         for ii in range(1, 8):
-            prefix = "2" * ii
-            gen = generate_filename(prefix="2" * ii, start=0, use_alpha=True)
-            assert prefix + "A" * (8 - ii) == next(gen)
-            assert prefix + "A" * (7 - ii) + "B" == next(gen)
-            assert prefix + "A" * (7 - ii) + "C" == next(gen)
-            assert prefix + "A" * (7 - ii) + "D" == next(gen)
+            prefix = "A" * ii
+            gen = generate_filename(prefix="A" * ii, start=0, alphanumeric=True)
+            assert prefix + "0" * (8 - ii) == next(gen)
+            assert prefix + "0" * (7 - ii) + "1" == next(gen)
+            assert prefix + "0" * (7 - ii) + "2" == next(gen)
+            assert prefix + "0" * (7 - ii) + "3" == next(gen)
+            assert prefix + "0" * (7 - ii) + "4" == next(gen)
+            assert prefix + "0" * (7 - ii) + "5" == next(gen)
+            assert prefix + "0" * (7 - ii) + "6" == next(gen)
+            assert prefix + "0" * (7 - ii) + "7" == next(gen)
+            assert prefix + "0" * (7 - ii) + "8" == next(gen)
+            assert prefix + "0" * (7 - ii) + "9" == next(gen)
+            assert prefix + "0" * (7 - ii) + "A" == next(gen)
 
-    def test_alpha_start(self):
-        """Test start point with alpha suffixes."""
-        gen = generate_filename(start=10, use_alpha=True)
-        assert "AAAAAAAK" == next(gen)
-        assert "AAAAAAAL" == next(gen)
-        assert "AAAAAAAM" == next(gen)
+    def test_alphanumeric_start(self):
+        """Test start point with alphanumeric suffixes."""
+        gen = generate_filename(start=10, alphanumeric=True)
+        assert "0000000A" == next(gen)
+        assert "0000000B" == next(gen)
+        assert "0000000C" == next(gen)
 
     def test_long_prefix_raises(self):
         """Test too long a prefix."""
@@ -2228,17 +2242,17 @@ class TestFileSet_Modify:
         ds, paths = write_fs(fs)
         instance = fs._instances[-1]
         # Was written with alpha File IDs
-        assert "IMAAAABX" in instance.path
+        assert "IM00001E" in instance.path
 
         def my_len(self):
-            return 26**6 + 1
+            return 35**6 + 1
 
         FileSet.__len__ = my_len
         fs = FileSet(ds)
-        assert 26**6 + 1 == len(fs)
+        assert 35**6 + 1 == len(fs)
         msg = (
             r"pydicom doesn't support writing File-sets with more than "
-            r"308915776 managed instances"
+            r"1838265625 managed instances"
         )
         with pytest.raises(NotImplementedError, match=msg):
             fs.write()
@@ -2560,17 +2574,17 @@ class TestFileSet_Copy:
         fs, ds, paths = copy_fs(fs, tdir.name)
         instance = fs._instances[-1]
         # Was written with alphanumeric File IDs
-        assert "IMAAAABX" in instance.path
+        assert "IM00001E" in instance.path
 
         def my_len(self):
-            return 26**6 + 1
+            return 35**6 + 1
 
         FileSet.__len__ = my_len
         fs = FileSet(tiny)
-        assert 26**6 + 1 == len(fs)
+        assert 35**6 + 1 == len(fs)
         msg = (
             r"pydicom doesn't support writing File-sets with more than "
-            r"308915776 managed instances"
+            r"1838265625 managed instances"
         )
         with pytest.raises(NotImplementedError, match=msg):
             fs.copy(tdir.name)

--- a/tests/test_fileset.py
+++ b/tests/test_fileset.py
@@ -2241,7 +2241,7 @@ class TestFileSet_Modify:
         assert 10**6 + 1 == len(fs)
         ds, paths = write_fs(fs)
         instance = fs._instances[-1]
-        # Was written with alpha File IDs
+        # Was written with alphanumeric File IDs
         assert "IM00001E" in instance.path
 
         def my_len(self):


### PR DESCRIPTION
#### Describe the changes
* Reduces the available characters for `fileset.generate_fileset()` from [0-9,A-Z] to [0-9,A-I,K-Z]
* Changes the theoretical maximum number of instances supported by `FileSet` to 35^6 (down from 36^6) to better support 32-bit systems (closes #1743)

Technically I don't need to change `generate_fileset()` but thought it would be good for it to be consistent with the FileSet file ID naming scheme.

#### Tasks
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/34bd944b-438d-4c00-b1f5-732d85b86b44/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
