### PR TITLE
[MRG] `IOError` → `OSError`

### DIFF
--- a/pydicom/filebase.py
+++ b/pydicom/filebase.py
@@ -184,15 +184,15 @@ class DicomFileLike(DicomIO):
 
     def no_write(self, bytes_read: bytes) -> int:
         """Used for file-like objects where no write is available"""
-        raise IOError("This DicomFileLike object has no write() method")
+        raise OSError("This DicomFileLike object has no write() method")
 
     def no_read(self, size: int = -1) -> bytes:
         """Used for file-like objects where no read is available"""
-        raise IOError("This DicomFileLike object has no read() method")
+        raise OSError("This DicomFileLike object has no read() method")
 
     def no_seek(self, offset: int, whence: int = 0) -> int:
         """Used for file-like objects where no seek is available"""
-        raise IOError("This DicomFileLike object has no seek() method")
+        raise OSError("This DicomFileLike object has no seek() method")
 
     def __enter__(self) -> "DicomFileLike":
         return self

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -513,7 +513,7 @@ def read_sequence_item(
         bytes_read = fp.read(8)
         group, element, length = unpack(tag_length_format, bytes_read)
     except BaseException:
-        raise IOError(
+        raise OSError(
             f"No tag to read at file position {fp.tell() + offset:X}"
         )
 
@@ -1144,9 +1144,9 @@ def read_deferred_data_element(
 
     Raises
     ------
-    IOError
+    OSError
         If `filename_or_obj` is ``None``.
-    IOError
+    OSError
         If `filename_or_obj` is a filename and the corresponding file does
         not exist.
     ValueError
@@ -1155,7 +1155,7 @@ def read_deferred_data_element(
     logger.debug("Reading deferred element %r" % str(raw_data_elem.tag))
     # If it wasn't read from a file, then return an error
     if filename_or_obj is None:
-        raise IOError(
+        raise OSError(
             "Deferred read -- original filename not stored. Cannot re-open"
         )
 
@@ -1163,7 +1163,7 @@ def read_deferred_data_element(
     is_filename = isinstance(filename_or_obj, str)
     if isinstance(filename_or_obj, str):
         if not os.path.exists(filename_or_obj):
-            raise IOError(
+            raise OSError(
                 f"Deferred read -- original file {filename_or_obj} is missing"
             )
 

--- a/pydicom/tests/test_filebase.py
+++ b/pydicom/tests/test_filebase.py
@@ -226,15 +226,15 @@ class TestDicomFileLike:
                 pass
 
         fp = DicomFileLike(IntPlus)
-        with pytest.raises(IOError,
+        with pytest.raises(OSError,
                            match=r"This DicomFileLike object has no write\(\) "
                                  r"method"):
             fp.write(b'')
-        with pytest.raises(IOError,
+        with pytest.raises(OSError,
                            match=r"This DicomFileLike object has no read\(\) "
                                  r"method"):
             fp.parent_read(b'')
-        with pytest.raises(IOError,
+        with pytest.raises(OSError,
                            match=r"This DicomFileLike object has no seek\(\) "
                                  r"method"):
             fp.seek(0, 1)

--- a/pydicom/tests/test_filereader.py
+++ b/pydicom/tests/test_filereader.py
@@ -1499,7 +1499,7 @@ class TestDeferredRead:
         """Deferred read raises error if file no longer exists."""
         ds = dcmread(self.testfile_name, defer_size=2000)
         os.remove(self.testfile_name)
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             ds.PixelData
 
     def test_values_identical(self):

--- a/pydicom/tests/test_filewriter.py
+++ b/pydicom/tests/test_filewriter.py
@@ -2356,12 +2356,12 @@ class TestWriteNumbers:
         assert fp.getvalue() == b'\x01\x00'
 
     def test_exception(self):
-        """Test exceptions raise IOError"""
+        """Test exceptions raise OSError"""
         fp = DicomBytesIO()
         fp.is_little_endian = True
         elem = DataElement(0x00100010, 'US', b'\x00')
         fmt = 'H'
-        with pytest.raises(IOError,
+        with pytest.raises(OSError,
                            match=r"for data_element:\n\(0010, 0010\)"):
             write_numbers(fp, elem, fmt)
 

--- a/pydicom/tests/test_unicode.py
+++ b/pydicom/tests/test_unicode.py
@@ -26,5 +26,5 @@ class TestUnicodeFilenames:
         except UnicodeEncodeError:
             self.fail("UnicodeEncodeError generated for unicode name")
         # ignore file doesn't exist error
-        except IOError:
+        except OSError:
             pass


### PR DESCRIPTION
From [Built-in Exceptions](https://docs.python.org/3/library/exceptions.html#concrete-exceptions):
> The following exceptions are kept for compatibility with previous versions; starting from Python 3.3, they are aliases of [`OSError`](https://docs.python.org/3/library/exceptions.html#OSError).
> 
> _exception_ **`EnvironmentError`**
> 
> _exception_ **`IOError`**
> 
> _exception_ **`WindowsError`**

<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
- [ ] No warnings during build
- [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
