### PR TITLE
[WIP] Remove Dataset.parent and change Dataset.file_meta

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -56,6 +56,8 @@ Changes
 * The characters used by :func:`~pydicom.fileset.generate_filename` when
   `alphanumeric` is ``True`` has been reduced to [0-9][A-I,K-Z]
 * The ``Dataset.parent`` and ``Sequence.parent`` properties have been removed
+* :attr:`~pydicom.dataset.Dataset.file_meta` must now be set using a
+  :class:`~pydicom.dataset.FileMetaDataset` instance
 
 Enhancements
 ------------

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -56,8 +56,7 @@ Changes
 * The characters used by :func:`~pydicom.fileset.generate_filename` when
   `alphanumeric` is ``True`` has been reduced to [0-9][A-I,K-Z]
 * The ``Dataset.parent`` and ``Sequence.parent`` properties have been removed
-* :attr:`~pydicom.dataset.FileDataset.file_meta` must now be set using a
-  :class:`~pydicom.dataset.FileMetaDataset` instance
+
 
 Enhancements
 ------------

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -55,6 +55,7 @@ Changes
   for 32-bit systems (:issue:`1743`)
 * The characters used by :func:`~pydicom.fileset.generate_filename` when
   `alphanumeric` is ``True`` has been reduced to [0-9][A-I,K-Z]
+* The ``Dataset.parent`` and ``Sequence.parent`` properties have been removed
 
 Enhancements
 ------------

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -56,7 +56,7 @@ Changes
 * The characters used by :func:`~pydicom.fileset.generate_filename` when
   `alphanumeric` is ``True`` has been reduced to [0-9][A-I,K-Z]
 * The ``Dataset.parent`` and ``Sequence.parent`` properties have been removed
-* :attr:`~pydicom.dataset.Dataset.file_meta` must now be set using a
+* :attr:`~pydicom.dataset.FileDataset.file_meta` must now be set using a
   :class:`~pydicom.dataset.FileMetaDataset` instance
 
 Enhancements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ pixeldata = [
     "pylibjpeg[openjpeg]",
     "pylibjpeg[rle]",
     "python-gdcm"
-]        
+]
 
 # Consider libjpeg-turbo (BSD-like license) when 12-bit available
 # https://github.com/libjpeg-turbo/libjpeg-turbo/issues/199
@@ -135,19 +135,13 @@ max-statements = 106
 [tool.mypy]
 python_version = "3.10"
 files = "src/"
-exclude = ["src/pydicom/benchmarks/", "src/pydicom/pixel_data_handlers/pillow_handler.py"]
+exclude = ["src/pydicom/benchmarks/"]
 show_error_codes = true
-warn_redundant_casts = false
-warn_unused_ignores = false
+warn_redundant_casts = true
+warn_unused_ignores = true
 warn_return_any = true
 warn_unreachable = false
 ignore_missing_imports = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-
-[[tool.mypy.overrides]]
-# 2023-06: mypy complains for a line in this file if ignore used or not.
-# Override unused ignores for that one file
-module = "pydicom.encoders.base"
-warn_unused_ignores = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,3 +145,9 @@ ignore_missing_imports = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
+
+[[tool.mypy.overrides]]
+# 2023-06: mypy complains for a line in this file if ignore used or not.
+# Override unused ignores for that one file
+module = "pydicom.encoders.base"
+warn_unused_ignores = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,10 +135,10 @@ max-statements = 106
 [tool.mypy]
 python_version = "3.10"
 files = "src/"
-exclude = ["src/pydicom/benchmarks/"]
+exclude = ["src/pydicom/benchmarks/", "src/pydicom/pixel_data_handlers/pillow_handler.py"]
 show_error_codes = true
-warn_redundant_casts = true
-warn_unused_ignores = true
+warn_redundant_casts = false
+warn_unused_ignores = false
 warn_return_any = true
 warn_unreachable = false
 ignore_missing_imports = true

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -456,40 +456,6 @@ class Dataset:
         if value != self._parent_seq:
             self._parent_seq = weakref.ref(value)
 
-    @property
-    def parent(self) -> "weakref.ReferenceType[Dataset] | None":
-        """Return a weak reference to the parent Sequence's
-        parent Dataset.
-
-        .. deprecated:: 2.4
-        """
-        if config._use_future:
-            raise AttributeError("Future: Dataset.parent is removed in v3.x")
-        else:
-            warnings.warn(
-                "Dataset.parent will be removed in pydicom 3.0", DeprecationWarning
-            )
-
-            parent_ref = self.parent_seq
-            if parent_ref is None:
-                return None
-
-            return cast("Sequence", parent_ref()).parent_dataset
-
-    @parent.setter
-    def parent(self, value: "Dataset") -> None:
-        """Set the parent :class:`~pydicom.sequence.Sequence`
-
-        .. deprecated:: 2.4
-        """
-        if config._use_future:
-            raise AttributeError("Future: Dataset.parent is removed in v3.x")
-        else:
-            warnings.warn(
-                "Dataset.parent will be removed in pydicom 3.0", DeprecationWarning
-            )
-        self._parent = weakref.ref(value)
-
     def __deepcopy__(self, memo: dict[int, Any] | None) -> "Dataset":
         cls = self.__class__
         copied = cls.__new__(cls)
@@ -2232,19 +2198,9 @@ class Dataset:
 
     def _set_file_meta(self, value: Optional["Dataset"]) -> None:
         if value is not None and not isinstance(value, FileMetaDataset):
-            if config._use_future:
-                raise TypeError(
-                    "Pydicom Future: Dataset.file_meta must be an instance "
-                    "of FileMetaDataset"
-                )
+            raise TypeError("'Dataset.file_meta' must be a 'FileMetaDataset' instance")
 
-            FileMetaDataset.validate(value)
-            warnings.warn(
-                "Starting in pydicom 3.0, Dataset.file_meta must be a "
-                "FileMetaDataset class instance",
-                DeprecationWarning,
-            )
-
+        FileMetaDataset.validate(value)
         self.__dict__["file_meta"] = value
 
     def __setitem__(self, key: "slice | TagType", elem: _DatasetValue) -> None:

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2196,11 +2196,18 @@ class Dataset:
             # XXX note if user misspells a dicom data_element - no error!!!
             object.__setattr__(self, name, value)
 
-    def _set_file_meta(self, value: Optional["FileMetaDataset"]) -> None:
-        if value is not None and not isinstance(value, Dataset):
-            raise TypeError("'Dataset.file_meta' must be a 'FileMetaDataset' instance")
+    def _set_file_meta(self, value: Optional["Dataset"]) -> None:
+        """Set the Dataset's File Meta Information attribute."""
+        if value is None:
+            self.__dict__["file_meta"] = value
+            return
 
-        if isinstance(value, Dataset):
+        if not isinstance(value, Dataset):
+            cls_name = self.__class__.__name__
+            raise TypeError(f"'{cls_name}.file_meta' must be a 'FileMetaDataset' instance")
+
+        if not isinstance(value, FileMetaDataset):
+            # Also validates for only group 2 elements
             value = FileMetaDataset(value)
 
         self.__dict__["file_meta"] = value

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2196,7 +2196,7 @@ class Dataset:
             # XXX note if user misspells a dicom data_element - no error!!!
             object.__setattr__(self, name, value)
 
-    def _set_file_meta(self, value: Optional["Dataset"]) -> None:
+    def _set_file_meta(self, value: Optional["FileMetaDataset"]) -> None:
         if value is not None and not isinstance(value, FileMetaDataset):
             raise TypeError("'Dataset.file_meta' must be a 'FileMetaDataset' instance")
 

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2196,11 +2196,13 @@ class Dataset:
             # XXX note if user misspells a dicom data_element - no error!!!
             object.__setattr__(self, name, value)
 
-    def _set_file_meta(self, value: Optional["FileMetaDataset"]) -> None:
+    def _set_file_meta(self, value: Optional["Dataset"]) -> None:
         if value is not None and not isinstance(value, FileMetaDataset):
             raise TypeError("'Dataset.file_meta' must be a 'FileMetaDataset' instance")
 
-        FileMetaDataset.validate(value)
+        if value is not None:
+            FileMetaDataset.validate(value)
+
         self.__dict__["file_meta"] = value
 
     def __setitem__(self, key: "slice | TagType", elem: _DatasetValue) -> None:

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2204,7 +2204,9 @@ class Dataset:
 
         if not isinstance(value, Dataset):
             cls_name = self.__class__.__name__
-            raise TypeError(f"'{cls_name}.file_meta' must be a 'FileMetaDataset' instance")
+            raise TypeError(
+                f"'{cls_name}.file_meta' must be a 'FileMetaDataset' instance"
+            )
 
         if not isinstance(value, FileMetaDataset):
             # Also validates for only group 2 elements

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2196,12 +2196,12 @@ class Dataset:
             # XXX note if user misspells a dicom data_element - no error!!!
             object.__setattr__(self, name, value)
 
-    def _set_file_meta(self, value: Optional["Dataset"]) -> None:
-        if value is not None and not isinstance(value, FileMetaDataset):
+    def _set_file_meta(self, value: Optional["FileMetaDataset"]) -> None:
+        if value is not None and not isinstance(value, Dataset):
             raise TypeError("'Dataset.file_meta' must be a 'FileMetaDataset' instance")
 
-        if value is not None:
-            FileMetaDataset.validate(value)
+        if isinstance(value, Dataset):
+            value = FileMetaDataset(value)
 
         self.__dict__["file_meta"] = value
 
@@ -2905,10 +2905,12 @@ class FileMetaDataset(Dataset):
                 f"Argument must be a dict or Dataset, not {type(init_value)}"
             )
 
-        non_group2 = [Tag(tag) for tag in init_value.keys() if Tag(tag).group != 2]
+        non_group2 = [str(Tag(tag)) for tag in init_value.keys() if Tag(tag).group != 2]
         if non_group2:
-            msg = "Attempted to set non-group 2 elements: {}"
-            raise ValueError(msg.format(non_group2))
+            raise ValueError(
+                "File meta datasets may only contain group 2 elements but the "
+                f"following elements are present: {', '.join(non_group2)}"
+            )
 
     def __setitem__(self, key: "slice | TagType", value: _DatasetValue) -> None:
         """Override parent class to only allow setting of group 2 elements.

--- a/src/pydicom/encoders/base.py
+++ b/src/pydicom/encoders/base.py
@@ -639,7 +639,7 @@ class Encoder:
         if byteorder == ">":
             arr = arr.astype(dtype.newbyteorder("<"))
 
-        return cast(bytes, arr.tobytes()) # type: ignore[redundant-cast]
+        return cast(bytes, arr.tobytes())  # type: ignore[redundant-cast]
 
     def _process(
         self,

--- a/src/pydicom/encoders/base.py
+++ b/src/pydicom/encoders/base.py
@@ -639,7 +639,7 @@ class Encoder:
         if byteorder == ">":
             arr = arr.astype(dtype.newbyteorder("<"))
 
-        return cast(bytes, arr.tobytes())  #  type: ignore
+        return arr.tobytes()
 
     def _process(
         self,

--- a/src/pydicom/encoders/base.py
+++ b/src/pydicom/encoders/base.py
@@ -639,7 +639,7 @@ class Encoder:
         if byteorder == ">":
             arr = arr.astype(dtype.newbyteorder("<"))
 
-        return arr.tobytes()
+        return cast(bytes, arr.tobytes()) # type: ignore[redundant-cast]
 
     def _process(
         self,

--- a/src/pydicom/encoders/base.py
+++ b/src/pydicom/encoders/base.py
@@ -639,7 +639,7 @@ class Encoder:
         if byteorder == ">":
             arr = arr.astype(dtype.newbyteorder("<"))
 
-        return cast(bytes, arr.tobytes()) # type:ignore[redundant-cast]
+        return cast(bytes, arr.tobytes())  # type:ignore[redundant-cast]
 
     def _process(
         self,

--- a/src/pydicom/encoders/base.py
+++ b/src/pydicom/encoders/base.py
@@ -639,7 +639,7 @@ class Encoder:
         if byteorder == ">":
             arr = arr.astype(dtype.newbyteorder("<"))
 
-        return cast(bytes, arr.tobytes())  # type: ignore[redundant-cast]
+        return cast(bytes, arr.tobytes()) # type:ignore[redundant-cast]
 
     def _process(
         self,

--- a/src/pydicom/encoders/base.py
+++ b/src/pydicom/encoders/base.py
@@ -639,7 +639,7 @@ class Encoder:
         if byteorder == ">":
             arr = arr.astype(dtype.newbyteorder("<"))
 
-        return cast(bytes, arr.tobytes())  #  type:ignore[redundant-cast]
+        return cast(bytes, arr.tobytes())  #  type: ignore
 
     def _process(
         self,

--- a/src/pydicom/sequence.py
+++ b/src/pydicom/sequence.py
@@ -126,34 +126,6 @@ class Sequence(MultiValue[Dataset]):
         if value != self._parent_dataset:
             self._parent_dataset = weakref.ref(value)
 
-    @property
-    def parent(self) -> "weakref.ReferenceType[Dataset] | None":
-        """Return a weak reference to the parent Dataset
-
-        .. deprecated:: 2.4
-        """
-        if config._use_future:
-            raise AttributeError("Future: Sequence.parent is removed in v3.x")
-        else:
-            warnings.warn(
-                "Sequence.parent will be removed in pydicom 3.0", DeprecationWarning
-            )
-            return self.parent_dataset
-
-    @parent.setter
-    def parent(self, value: "Dataset") -> None:
-        """Set the parent :class:`~pydicom.dataset.Dataset`
-
-        .. deprecated:: 2.4
-        """
-        if config._use_future:
-            raise AttributeError("Future: Sequence.parent is removed in v3.x")
-        else:
-            warnings.warn(
-                "Sequence.parent will be removed in pydicom 3.0", DeprecationWarning
-            )
-            self.parent_dataset = value  # type:ignore
-
     @overload  # type: ignore[override]
     def __setitem__(self, idx: int, val: Dataset) -> None:
         pass  # pragma: no cover

--- a/src/pydicom/util/codify.py
+++ b/src/pydicom/util/codify.py
@@ -187,7 +187,9 @@ def code_sequence(
         var_names = deque()
 
     def unique_name(name: str) -> str:
-        name_count = var_names.count(name) - 1
+        name_count = (
+            cast(deque, var_names).count(name) - 1
+        )  # type:ignore[redundant-cast]
         return name if name_count == 0 else name + f"_{name_count}"
 
     lines = []

--- a/src/pydicom/util/codify.py
+++ b/src/pydicom/util/codify.py
@@ -187,9 +187,7 @@ def code_sequence(
         var_names = deque()
 
     def unique_name(name: str) -> str:
-        name_count = (
-            cast(deque, var_names).count(name) - 1
-        )  # type:ignore[redundant-cast]
+        name_count = var_names.count(name) - 1
         return name if name_count == 0 else name + f"_{name_count}"
 
     lines = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -132,12 +132,6 @@ class TestFuture:
         importlib.reload(config)
         assert not config._use_future
 
-    def test_file_meta_class(self, future_setter):
-        """FileMetaDataset required type in pydicom future behavior"""
-        ds = Dataset()
-        with pytest.raises(TypeError):
-            ds.file_meta = Dataset()
-
     def test_invalid_keyword_raise(self, future_setter):
         ds = Dataset()
         with pytest.raises(ValueError):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1747,15 +1747,12 @@ class TestDatasetElements:
         assert "4.5.6" == self.ds.file_meta.MediaStorageSOPInstanceUID
         self.ds.fix_meta_info(enforce_standard=True)
 
-        with pytest.warns(DeprecationWarning):
-            self.ds.file_meta = Dataset()  # not FileMetaDataset
-        self.ds.file_meta.PatientID = "PatientID"
+        self.ds.file_meta = FileMetaDataset()
         with pytest.raises(
             ValueError,
-            match=r"Only File Meta Information Group "
-            r"\(0002,eeee\) elements must be present .*",
+            match=r"Only group 2 data elements are allowed in a FileMetaDataset",
         ):
-            self.ds.fix_meta_info(enforce_standard=True)
+            self.ds.file_meta.PatientID = "PatientID"
 
     def test_validate_and_correct_file_meta(self):
         file_meta = FileMetaDataset()
@@ -2045,10 +2042,11 @@ class TestDatasetOverlayArray:
 
 
 class TestFileMeta:
-    def test_deprecation_warning(self):
+    def test_type_exception(self):
         """Assigning ds.file_meta warns if not FileMetaDataset instance"""
         ds = Dataset()
-        with pytest.warns(DeprecationWarning):
+        msg = "'Dataset.file_meta' must be a 'FileMetaDataset' instance"
+        with pytest.raises(TypeError, match=msg):
             ds.file_meta = Dataset()  # not FileMetaDataset
 
     def test_assign_file_meta(self):
@@ -2063,15 +2061,13 @@ class TestFileMeta:
         ds.file_meta = FileMetaDataset()
 
         # Can assign non-empty file_meta
-        ds_meta = Dataset()  # not FileMetaDataset
+        ds_meta = FileMetaDataset()
         ds_meta.TransferSyntaxUID = "1.2"
-        with pytest.warns(DeprecationWarning):
-            ds.file_meta = ds_meta
+        ds.file_meta = ds_meta
 
         # Error on assigning file meta if any non-group 2
-        ds_meta.PatientName = "x"
         with pytest.raises(ValueError):
-            ds.file_meta = ds_meta
+            ds_meta.PatientName = "x"
 
     def test_init_file_meta(self):
         """Check instantiation of FileMetaDataset"""

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2047,7 +2047,7 @@ class TestFileMeta:
         ds = Dataset()
         msg = "'Dataset.file_meta' must be a 'FileMetaDataset' instance"
         with pytest.raises(TypeError, match=msg):
-            ds.file_meta = list()  # not FileMetaDataset
+            ds.file_meta = list()
 
     def test_assign_file_meta(self):
         """Test can only set group 2 elements in File Meta"""

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2047,7 +2047,7 @@ class TestFileMeta:
         ds = Dataset()
         msg = "'Dataset.file_meta' must be a 'FileMetaDataset' instance"
         with pytest.raises(TypeError, match=msg):
-            ds.file_meta = Dataset()  # not FileMetaDataset
+            ds.file_meta = list()  # not FileMetaDataset
 
     def test_assign_file_meta(self):
         """Test can only set group 2 elements in File Meta"""
@@ -2068,6 +2068,26 @@ class TestFileMeta:
         # Error on assigning file meta if any non-group 2
         with pytest.raises(ValueError):
             ds_meta.PatientName = "x"
+
+    def test_file_meta_conversion(self):
+        """Test conversion to FileMetaDataset from Dataset."""
+        ds = Dataset()
+        meta = Dataset()
+        meta.TransferSyntaxUID = "1.2"
+        ds.file_meta = meta
+        assert isinstance(ds.file_meta, FileMetaDataset)
+        assert ds.file_meta.TransferSyntaxUID == "1.2"
+
+        ds.file_meta = None
+        meta.PatientID = "12345678"
+        msg = (
+            r"File meta datasets may only contain group 2 elements but the "
+            r"following elements are present: \(0010,0020\)"
+        )
+        with pytest.raises(ValueError, match=msg):
+            ds.file_meta = meta
+
+        assert ds.file_meta is None
 
     def test_init_file_meta(self):
         """Check instantiation of FileMetaDataset"""


### PR DESCRIPTION
#### Describe the changes
Missed a couple of deprecations...

* Remove deprecated `Dataset.parent` and `Sequence.parent` properties
* Convert `Dataset` to `FileMetaDataset` when setting `Dataset.file_meta`, this seemed better to me than just forcing the `FileMetaDataset` requirement

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/70ff343b-02e6-470e-b797-750b250571ca/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
