### PR TITLE
[MRG] Fix VR enum returning invalid value with f-strings

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -81,6 +81,7 @@ Fixes
   when the J2K stream disagrees with the dataset and
   :attr:`~pydicom.config.APPLY_J2K_CORRECTIONS` is `True` (:issue:`1689`)
 * Fixed pydicom codify error when relative path did not exist
+* Fixed the VR enum sometimes returning invalid values for Python 3.11+ (:issue:`1874`)
 
 Pydicom Internals
 -----------------

--- a/src/pydicom/valuerep.py
+++ b/src/pydicom/valuerep.py
@@ -481,6 +481,9 @@ class VR(str, Enum):
     US_OW = "US or OW"
     OB_OW = "OB or OW"
 
+    def __str__(self) -> str:
+        return str.__str__(self)
+
 
 # Standard VRs from Table 6.2-1 in Part 5
 STANDARD_VR = {

--- a/tests/test_valuerep.py
+++ b/tests/test_valuerep.py
@@ -1630,6 +1630,7 @@ class TestVR:
         assert isinstance(VR.AE, str)
         assert VR.AE == "AE"
         assert VR.US_SS_OW == "US or SS or OW"
+        assert f"{VR.AE}" == "AE"
 
     def test_all_present(self):
         """Test all VRs are configured"""


### PR DESCRIPTION
#### Describe the changes
Python 3.11 changed the behaviour of f-strings when used with Enums + a str mixin.

Closes #1874

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
