### PR TITLE
[MRG] Fix Pillow raising AttributeError due to Image.mode being read-only

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -81,6 +81,7 @@ Fixes
   when the J2K stream disagrees with the dataset and
   :attr:`~pydicom.config.APPLY_J2K_CORRECTIONS` is `True` (:issue:`1689`)
 * Fixed pydicom codify error when relative path did not exist
+* Fixed pixel data handler for Pillow 10.1 raising an AttributeError (:issue:`1907`)
 
 Pydicom Internals
 -----------------

--- a/src/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/src/pydicom/pixel_data_handlers/pillow_handler.py
@@ -142,7 +142,7 @@ def _decompress_single_frame(
                 )
             ]
             # Pillow 10.1+ made Image.mode read-only
-            if hasattr(image, '_mode'):
+            if hasattr(image, "_mode"):
                 image._mode = color_mode
             else:
                 image.mode = colour_mode

--- a/src/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/src/pydicom/pixel_data_handlers/pillow_handler.py
@@ -141,7 +141,12 @@ def _decompress_single_frame(
                     (color_mode, ""),
                 )
             ]
-            image._mode = color_mode
+            # Pillow 10.1+ made Image.mode read-only
+            if hasattr(image, '_mode'):
+                image._mode = color_mode
+            else:
+                image.mode = colour_mode
+
             image.rawmode = color_mode
     return image
 

--- a/src/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/src/pydicom/pixel_data_handlers/pillow_handler.py
@@ -141,7 +141,7 @@ def _decompress_single_frame(
                     (color_mode, ""),
                 )
             ]
-            image.mode = color_mode
+            image._mode = color_mode
             image.rawmode = color_mode
     return image
 

--- a/src/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/src/pydicom/pixel_data_handlers/pillow_handler.py
@@ -145,7 +145,7 @@ def _decompress_single_frame(
             if hasattr(image, "_mode"):
                 image._mode = color_mode
             else:
-                image.mode = colour_mode
+                image.mode = color_mode
 
             image.rawmode = color_mode
     return image


### PR DESCRIPTION
#### Describe the changes

[Pillow 10.1 changed](https://github.com/python-pillow/Pillow/pull/7307) the `Image.mode` property to be read-only, with [Image._mode intended to be read-write](https://github.com/python-pillow/Pillow/pull/7271#issuecomment-1666593551).

Closes #1907

#### Tasks
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
