### PR TITLE
[MRG] Use Pillow draft method instead of setting tile and mode directly

### DIFF
--- a/src/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/src/pydicom/pixel_data_handlers/pillow_handler.py
@@ -130,22 +130,9 @@ def _decompress_single_frame(
     if (
         transfer_syntax in PillowJPEGTransferSyntaxes
         and photometric_interpretation == "RGB"
+        and "adobe_transform" not in image.info
     ):
-        if "adobe_transform" not in image.info:
-            color_mode = "YCbCr"
-            image.tile = [
-                (
-                    "jpeg",
-                    image.tile[0][1],
-                    image.tile[0][2],
-                    (color_mode, ""),
-                )
-            ]
-            # Pillow 10.1+ made Image.mode read-only
-            if hasattr(image, "_mode"):
-                image._mode = color_mode
-            else:
-                image.mode = color_mode
+        image.draft("YCbCr", image.size)
     return image
 
 

--- a/src/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/src/pydicom/pixel_data_handlers/pillow_handler.py
@@ -146,8 +146,6 @@ def _decompress_single_frame(
                 image._mode = color_mode
             else:
                 image.mode = color_mode
-
-            image.rawmode = color_mode
     return image
 
 


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
The latest version of Pillow has prevented `_mode` from being set - https://pillow.readthedocs.io/en/stable/releasenotes/10.1.0.html#setting-image-mode

I noticed that https://github.com/pydicom/pydicom/pull/1908 responded to this by setting the internal `_mode` attribute instead.
I wondered if there was a better way to perform the task, rather than interacting further with Pillow's internals, and I found that [`draft()`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.draft) did the trick, simplifying the code considerably and switching to only using Pillow's public API.

#### Tasks
- [x] Fix or feature added

`tests/test_pillow_pixel_data.py::TestPillowHandler_JPEG::test_array` continues to pass with this new version.
It's not immediately apparent to me how to check coverage, but given that I'm not introducing new functionality, it should remain unchanged.