### PR TITLE
[MRG] Added convenience method Dataset.add_private to add a private tag

### DIFF
--- a/doc/old/private_data_elements.rst
+++ b/doc/old/private_data_elements.rst
@@ -113,10 +113,9 @@ with block object::
     >>> 0x01 in block
     False
 
-Since pydicom 3.0, there is also a convenience method to add a private tag without the need
-of creating a private block first::
+Since pydicom 3.0, there is also a convenience method to add a private tag without creating a private block first::
 
-    >>> block = ds.add_private("My company 001", 0x000B, 0x01, "my value", VR.SH)
+    >>> block = ds.add_new_private("My company 001", 0x000B, 0x01, "my value", VR.SH)
     >>> ds
     ...
     (000b, 0010) Private Creator                     LO: 'My company 001'

--- a/doc/old/private_data_elements.rst
+++ b/doc/old/private_data_elements.rst
@@ -113,6 +113,18 @@ with block object::
     >>> 0x01 in block
     False
 
+Since pydicom 3.0, there is also a convenience method to add a private tag without the need
+of creating a private block first::
+
+    >>> block = ds.add_private("My company 001", 0x000B, 0x01, "my value", VR.SH)
+    >>> ds
+    ...
+    (000b, 0010) Private Creator                     LO: 'My company 001'
+    (000b, 1001) Private tag data                    SH: 'my value'
+    ...
+
+Note that for known private tags you don't need to provide the VR in this function.
+
 Removing All Private Data Elements
 -----------------------------------------------
 

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -76,7 +76,7 @@ Enhancements
     * :attr:`~pydicom.uid.SMPTEST211020UncompressedProgressiveActiveVideo`
     * :attr:`~pydicom.uid.SMPTEST211020UncompressedInterlacedActiveVideo`
     * :attr:`~pydicom.uid.SMPTEST211030PCMDigitalAudio`
-* Added convenience method :meth:`~pydicom.dataset.Dataset.add_private` to add a private tag
+* Added convenience method :meth:`~pydicom.dataset.Dataset.add_new_private` to add a private tag
 
 Fixes
 -----

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -76,6 +76,7 @@ Enhancements
     * :attr:`~pydicom.uid.SMPTEST211020UncompressedProgressiveActiveVideo`
     * :attr:`~pydicom.uid.SMPTEST211020UncompressedInterlacedActiveVideo`
     * :attr:`~pydicom.uid.SMPTEST211030PCMDigitalAudio`
+* Added convenience method :meth:`~pydicom.dataset.Dataset.add_private` to add a private tag
 
 Fixes
 -----

--- a/src/pydicom/datadict.py
+++ b/src/pydicom/datadict.py
@@ -543,7 +543,7 @@ def get_private_entry(tag: TagType, private_creator: str) -> tuple[str, str, str
         private_dict = private_dictionaries[private_creator]
     except KeyError as exc:
         raise KeyError(
-            f"Private creator '{private_creator}' not in the private " "dictionary"
+            f"Private creator '{private_creator}' not in the private dictionary"
         ) from exc
     except TypeError as exc:
         msg = (

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -518,7 +518,7 @@ class Dataset:
         """
         self.add(DataElement(tag, VR, value))
 
-    def add_private(
+    def add_new_private(
         self,
         private_creator: str,
         group: int,

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -15,28 +15,14 @@ Dataset (dict subclass)
             contains its own DataElements, and so on in a recursive manner.
 """
 import copy
-from bisect import bisect_left
-from contextlib import nullcontext
 import io
-from importlib.util import find_spec as have_package
-from itertools import takewhile
 import json
 import os
 import os.path
 import re
-from types import TracebackType
-from typing import (
-    Optional,
-    TypeAlias,
-    Union,
-    Any,
-    cast,
-    BinaryIO,
-    AnyStr,
-    TypeVar,
-    overload,
-    TYPE_CHECKING,
-)
+import warnings
+import weakref
+from bisect import bisect_left
 from collections.abc import (
     ValuesView,
     Iterator,
@@ -45,8 +31,21 @@ from collections.abc import (
     MutableMapping,
     Set,
 )
-import warnings
-import weakref
+from contextlib import nullcontext
+from importlib.util import find_spec as have_package
+from itertools import takewhile
+from types import TracebackType
+from typing import (
+    Optional,
+    TypeAlias,
+    Any,
+    AnyStr,
+    cast,
+    BinaryIO,
+    TypeVar,
+    overload,
+    TYPE_CHECKING,
+)
 
 from pydicom.filebase import DicomFileLike
 
@@ -65,6 +64,7 @@ from pydicom.datadict import (
     tag_for_keyword,
     keyword_for_tag,
     repeater_has_keyword,
+    get_private_entry,
 )
 from pydicom.dataelem import DataElement, DataElement_from_raw, RawDataElement
 from pydicom.encaps import encapsulate, encapsulate_extended
@@ -517,6 +517,51 @@ class Dataset:
               :class:`Dataset`
         """
         self.add(DataElement(tag, VR, value))
+
+    def add_private(
+        self,
+        private_creator: str,
+        group: int,
+        element_offset: int,
+        value: Any,
+        vr: str | None = None,
+    ) -> None:
+        """Create a new private element and add it to the :class:`Dataset`.
+
+        Parameters
+        ----------
+        private_creator : str
+            The private creator string related to the new tag.
+        group : int
+            The group ID (0x0009 - 0xFFFF) for the private tag.
+            Must be an odd number.
+        element_offset : int
+            The tag offset, e.g. the lower byte of the tag element of the
+            private tag (0x00 - 0xFF). The higher byte is defined by the location
+            of the private creator tag.
+        value : Any
+            The value of the data element. One of the following:
+
+            * a single string or number
+            * a :class:`list` or :class:`tuple` with all strings or all numbers
+            * a multi-value string with backslash separator
+            * for a sequence element, an empty :class:`list` or ``list`` of
+              :class:`Dataset`
+        vr : str | None
+            The two-letter DICOM value representation, or ``None``.
+            If set to ``None``, it is taken from the private tag dictionary.
+
+        Raises
+        ------
+        ValueError
+            If `group` doesn't belong to a private tag or `private_creator` is empty.
+        KeyError
+            If `vr` is ``None`` and the tag is not found in the private tag dictionary.
+        """
+        block = self.private_block(group, private_creator, create=True)
+        if vr is None:
+            vr = get_private_entry((group, element_offset), private_creator)[0]
+        block.add_new(element_offset, vr, value)
 
     def __array__(self) -> "numpy.ndarray":
         """Support accessing the dataset from a numpy array."""

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -10,6 +10,8 @@ import weakref
 from platform import python_implementation
 
 import pytest
+
+from pydicom.datadict import add_private_dict_entry
 from .test_helpers import assert_no_warning
 
 try:
@@ -39,7 +41,7 @@ from pydicom.uid import (
     ExplicitVRLittleEndian,
     MediaStorageDirectoryStorage,
 )
-from pydicom.valuerep import DS
+from pydicom.valuerep import DS, VR
 
 
 class BadRepr:
@@ -1053,6 +1055,39 @@ class TestDataset:
             ds.get_private_item(0x0009, 0x02, "Creator 1.0")
         item = ds.get_private_item(0x0009, 0x02, "Creator 2.0")
         assert 2 == item.value
+
+    def test_add_unknown_private_tag(self):
+        ds = Dataset()
+        with pytest.raises(ValueError, match="Tag must be private"):
+            ds.add_private("Creator 1.0", 0x0010, 0x01, "VALUE", VR.SH)
+        with pytest.raises(ValueError, match="Private creator must have a value"):
+            ds.add_private("", 0x0011, 0x01, "VALUE", VR.SH)
+        with pytest.raises(
+            KeyError,
+            match="Private creator 'Creator 1.0' not in the private dictionary",
+        ):
+            ds.add_private("Creator 1.0", 0x0011, 0x01, "VALUE")
+
+        ds.add_private("Creator 1.0", 0x0011, 0x01, "VALUE", VR.SH)
+        item = ds.get_private_item(0x0011, 0x01, "Creator 1.0")
+        assert item.value == "VALUE"
+        assert item.private_creator == "Creator 1.0"
+        assert item.VR == VR.SH
+
+    def test_add_known_private_tag(self):
+        ds = Dataset()
+        ds.add_private("GEMS_GENIE_1", 0x0009, 0x10, "Test Study")
+        item = ds.get_private_item(0x0009, 0x10, "GEMS_GENIE_1")
+        assert item.value == "Test Study"
+        assert item.private_creator == "GEMS_GENIE_1"
+        assert item.VR == VR.LO
+
+        add_private_dict_entry("Creator 1.0", 0x00110001, VR.SH, "Some Value")
+        ds.add_private("Creator 1.0", 0x0011, 0x01, "VALUE")
+        item = ds.get_private_item(0x0011, 0x01, "Creator 1.0")
+        assert item.value == "VALUE"
+        assert item.private_creator == "Creator 1.0"
+        assert item.VR == VR.SH
 
     def test_private_block(self):
         ds = Dataset()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1059,16 +1059,16 @@ class TestDataset:
     def test_add_unknown_private_tag(self):
         ds = Dataset()
         with pytest.raises(ValueError, match="Tag must be private"):
-            ds.add_private("Creator 1.0", 0x0010, 0x01, "VALUE", VR.SH)
+            ds.add_new_private("Creator 1.0", 0x0010, 0x01, "VALUE", VR.SH)
         with pytest.raises(ValueError, match="Private creator must have a value"):
-            ds.add_private("", 0x0011, 0x01, "VALUE", VR.SH)
+            ds.add_new_private("", 0x0011, 0x01, "VALUE", VR.SH)
         with pytest.raises(
             KeyError,
             match="Private creator 'Creator 1.0' not in the private dictionary",
         ):
-            ds.add_private("Creator 1.0", 0x0011, 0x01, "VALUE")
+            ds.add_new_private("Creator 1.0", 0x0011, 0x01, "VALUE")
 
-        ds.add_private("Creator 1.0", 0x0011, 0x01, "VALUE", VR.SH)
+        ds.add_new_private("Creator 1.0", 0x0011, 0x01, "VALUE", VR.SH)
         item = ds.get_private_item(0x0011, 0x01, "Creator 1.0")
         assert item.value == "VALUE"
         assert item.private_creator == "Creator 1.0"
@@ -1076,14 +1076,14 @@ class TestDataset:
 
     def test_add_known_private_tag(self):
         ds = Dataset()
-        ds.add_private("GEMS_GENIE_1", 0x0009, 0x10, "Test Study")
+        ds.add_new_private("GEMS_GENIE_1", 0x0009, 0x10, "Test Study")
         item = ds.get_private_item(0x0009, 0x10, "GEMS_GENIE_1")
         assert item.value == "Test Study"
         assert item.private_creator == "GEMS_GENIE_1"
         assert item.VR == VR.LO
 
         add_private_dict_entry("Creator 1.0", 0x00110001, VR.SH, "Some Value")
-        ds.add_private("Creator 1.0", 0x0011, 0x01, "VALUE")
+        ds.add_new_private("Creator 1.0", 0x0011, 0x01, "VALUE")
         item = ds.get_private_item(0x0011, 0x01, "Creator 1.0")
         assert item.value == "VALUE"
         assert item.private_creator == "Creator 1.0"


### PR DESCRIPTION
- complements the existing get_private_item
- for known tags, providing the VR is optional

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [x] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
