### PR TITLE
[MRG] Raise ValueError if get_testdata_file is called with absolute path

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -58,6 +58,8 @@ Changes
 * The ``Dataset.parent`` and ``Sequence.parent`` properties have been removed
 * The ``overlay_data_handlers`` module has been removed, use the :mod:`~pydicom.overlays`
   module instead
+* :func:`~pydicom.data_manager.get_testdata_file` and :func:`~pydicom.data_manager.get_testdata_files`
+  now raise ``ValueError`` if called with an absolute path or pattern
 
 
 Enhancements
@@ -84,7 +86,7 @@ Fixes
 -----
 * Fixed the GDCM and pylibjpeg handlers changing the *Pixel Representation* value to 0
   when the J2K stream disagrees with the dataset and
-  :attr:`~pydicom.config.APPLY_J2K_CORRECTIONS` is `True` (:issue:`1689`)
+  :attr:`~pydicom.config.APPLY_J2K_CORRECTIONS` is ``True`` (:issue:`1689`)
 * Fixed pydicom codify error when relative path did not exist
 * Fixed the VR enum sometimes returning invalid values for Python 3.11+ (:issue:`1874`)
 * Fixed pixel data handler for Pillow 10.1 raising an AttributeError (:issue:`1907`)

--- a/src/pydicom/cli/main.py
+++ b/src/pydicom/cli/main.py
@@ -129,7 +129,7 @@ def filespec_parser(filespec: str) -> list[tuple[Dataset, Any]]:
     # Get the pydicom test filename even without prefix, in case user forgot it
     try:
         pydicom_filename = cast(str, get_testdata_file(filename))
-    except NotImplementedError:  # will get this if absolute path passed
+    except ValueError:  # will get this if absolute path passed
         pydicom_filename = ""
 
     # Check if filename is in charset files

--- a/src/pydicom/data/data_manager.py
+++ b/src/pydicom/data/data_manager.py
@@ -289,7 +289,7 @@ def get_testdata_file(
     download: bool = True,
 ) -> "str | Dataset | None":
     """Return an absolute path to the first matching dataset with filename
-    `name`.
+    `name` that is found in a local or external pydicom datastore.
 
     .. versionadded:: 1.4
 
@@ -326,7 +326,18 @@ def get_testdata_file(
     str, pydicom.dataset.Dataset or None
         The absolute path of the file if found, the dataset itself if `read` is
         ``True``, or ``None`` if the file is not found.
+
+    Raises
+    ______
+    ValueError
+        If `name` is an absolute path.
     """
+    if os.path.isabs(name):
+        raise ValueError(
+            f"'get_testdata_file' does not support absolute paths, as it only works"
+            f" with internal pydicom test data - did you mean 'dcmread(\"{name}\")'?"
+        )
+
     path = _get_testdata_file(name=name, download=download)
     if read and path is not None:
         from pydicom.filereader import dcmread
@@ -387,7 +398,17 @@ def get_testdata_files(pattern: str = "**/*") -> list[str]:
     -------
     list of str
         A list of absolute paths to matching files.
+
+    Raises
+    ______
+    ValueError
+        If `pattern` matches an absolute path.
     """
+    if os.path.isabs(pattern):
+        raise ValueError(
+            f"'get_testdata_files' does not support absolute paths, as it only works"
+            f" with internal pydicom test data."
+        )
     data_path = Path(DATA_ROOT) / "test_files"
 
     files = get_files(base=data_path, pattern=pattern, dtype=DataTypes.DATASET)

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -113,6 +113,23 @@ class TestGetData:
         for x in palettes:
             assert palbase in x
 
+    def test_no_absolute_path_in_get_testdata_file(self):
+        msg = (
+            "'get_testdata_file' does not support absolute paths, "
+            "as it only works with internal pydicom test data - "
+            rf"did you mean 'dcmread\(\"/foo/bar.dcm\"\)'?"
+        )
+        with pytest.raises(ValueError, match=msg):
+            get_testdata_file("/foo/bar.dcm")
+
+    def test_no_absolute_path_in_get_testdata_files(self):
+        msg = (
+            "'get_testdata_files' does not support absolute paths, as it only works "
+            "with internal pydicom test data."
+        )
+        with pytest.raises(ValueError, match=msg):
+            get_testdata_files("/foo/*.dcm")
+
 
 @pytest.mark.skipif(not EXT_PYDICOM, reason="pydicom-data not installed")
 class TestExternalDataSource:


### PR DESCRIPTION
- same for get_testdata_file called with absolute file pattern

As discussed in #1918 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [x] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
