### PR TITLE
[MRG] Change FileInstance to use a random UUID when adding to a FileSet

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -86,6 +86,9 @@ Fixes
 * Fixed pydicom codify error when relative path did not exist
 * Fixed the VR enum sometimes returning invalid values for Python 3.11+ (:issue:`1874`)
 * Fixed pixel data handler for Pillow 10.1 raising an AttributeError (:issue:`1907`)
+* Fixed a possible security issue with :class:`~pydicom.fileset.FileInstance` instances
+  being able to escape the temporary directory when being added to a
+  :class:`~pydicom.fileset.FileSet` (:issue:`1922`)
 
 Pydicom Internals
 -----------------

--- a/doc/tutorials/filesets.rst
+++ b/doc/tutorials/filesets.rst
@@ -321,7 +321,7 @@ accessed and loaded:
     >>> instance.for_addition
     True
     >>> instance.path
-    '/tmp/tmp0aalrzir/1.3.6.1.4.1.5962.1.1.1.1.1.20040119072730.12322'
+    '/tmp/tmp0aalrzir/86e6b75b-b764-46af-bec3-51698a8366f2'
     >>> type(instance.load())
     <class 'pydicom.dataset.FileDataset'>
 

--- a/src/pydicom/fileset.py
+++ b/src/pydicom/fileset.py
@@ -9,6 +9,7 @@ import re
 import shutil
 from tempfile import TemporaryDirectory
 from typing import Optional, Union, Any, cast
+import uuid
 import warnings
 
 from pydicom.charset import default_encoding
@@ -719,6 +720,7 @@ class FileInstance:
             add: bool
             remove: bool
 
+        self._uuid = uuid.uuid4()
         self._flags = Flags()
         self._apply_stage("x")
         self._stage_path: Path | None = None
@@ -746,7 +748,7 @@ class FileInstance:
                 self._stage_path = None
             else:
                 self._flags.add = True
-                self._stage_path = self.file_set._stage["path"] / self.SOPInstanceUID
+                self._stage_path = self.file_set._stage["path"] / f"{self._uuid}"
 
         elif flag == "-":
             # add + remove = no change

--- a/tests/test_fileset.py
+++ b/tests/test_fileset.py
@@ -881,9 +881,7 @@ class TestFileInstance:
         instance = fs._instances[0]
         assert instance.is_staged
         assert instance.for_addition
-        assert (Path(fs._stage["path"]) / Path(instance.SOPInstanceUID)) == Path(
-            instance.path
-        )
+        assert Path(fs._stage["path"]) / f"{instance._uuid}" == Path(instance.path)
         assert isinstance(instance.path, str)
 
     def test_path_move(self, dicomdir):


### PR DESCRIPTION
#### Describe the changes
Closes #1922, use a random UUID as the filename when adding a `FileInstance` to a `FileSet`

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
