### PR TITLE
[MRG] Fix deepcopy after Dataset.update()

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -91,6 +91,8 @@ Fixes
 * Fixed a possible security issue with :class:`~pydicom.fileset.FileInstance` instances
   being able to escape the temporary directory when being added to a
   :class:`~pydicom.fileset.FileSet` (:issue:`1922`)
+* Fixed an ``AttributeError`` when running :meth:`~copy.deepcopy` after
+  :meth:`pydicom.dataset.Dataset.update<Dataset.update>` (:issue:`1816`)
 
 Pydicom Internals
 -----------------

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -91,8 +91,8 @@ Fixes
 * Fixed a possible security issue with :class:`~pydicom.fileset.FileInstance` instances
   being able to escape the temporary directory when being added to a
   :class:`~pydicom.fileset.FileSet` (:issue:`1922`)
-* Fixed an ``AttributeError`` when running :meth:`~copy.deepcopy` after
-  :meth:`pydicom.dataset.Dataset.update<Dataset.update>` (:issue:`1816`)
+* Fixed an ``AttributeError`` when running :py:func:`~copy.deepcopy` after
+  :meth:`Dataset.update<pydicom.dataset.Dataset.update>` (:issue:`1816`)
 
 Pydicom Internals
 -----------------

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -559,7 +559,7 @@ class DataElement:
             memo[id(self)] = copied
 
         # Fix for #1816: don't deepcopy the parent!
-        for key in (k for k in self.__dict__ if k not in ("parent")):
+        for key in (k for k in self.__dict__ if k != "parent"):
             copied.__dict__[key] = copy.deepcopy(self.__dict__[key], memo)
 
         return copied

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -202,9 +202,6 @@ class DataElement:
             Defines if values are validated and how validation errors are
             handled.
         """
-        # Missing: _value, file_tell, is_undefined_length, parent,
-        #   private_creator, tag, validation_mode, VR
-
         if validation_mode is None:
             validation_mode = config.settings.reading_validation_mode
 

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -562,8 +562,6 @@ class DataElement:
         for key in (k for k in self.__dict__ if k not in ("parent")):
             copied.__dict__[key] = copy.deepcopy(self.__dict__[key], memo)
 
-        copied.parent = self.parent
-
         return copied
 
     def __eq__(self, other: Any) -> Any:

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2415,7 +2415,7 @@ class Dataset:
             else:
                 self[Tag(cast(int, key))] = value
                 if getattr(value, "parent", None):
-                    value.parent = self  # ignore[union-attr]
+                    value.parent = self  # type: ignore[union-attr]
 
     def iterall(self) -> Iterator[DataElement]:
         """Iterate through the :class:`Dataset`, yielding all the elements.

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2414,7 +2414,7 @@ class Dataset:
                 setattr(self, key, value)
             else:
                 self[Tag(cast(int, key))] = value
-                if value.parent:
+                if getattr(value, "parent", None):
                     value.parent = self
 
     def iterall(self) -> Iterator[DataElement]:

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2414,7 +2414,7 @@ class Dataset:
                 setattr(self, key, value)
             else:
                 self[Tag(cast(int, key))] = value
-                if getattr(value, "parent", None):
+                if getattr(value, "parent", None):  # ignore[union-attr]
                     value.parent = self
 
     def iterall(self) -> Iterator[DataElement]:

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -467,6 +467,8 @@ class Dataset:
         for elem in copied:  # DICOM elements
             if elem.VR == VR_.SQ:
                 elem.value.parent_dataset = copied  # setter does weakref
+                elem.parent = copied
+
         return copied
 
     def __enter__(self) -> "Dataset":
@@ -2412,6 +2414,8 @@ class Dataset:
                 setattr(self, key, value)
             else:
                 self[Tag(cast(int, key))] = value
+                if value.parent:
+                    value.parent = self
 
     def iterall(self) -> Iterator[DataElement]:
         """Iterate through the :class:`Dataset`, yielding all the elements.

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2414,8 +2414,8 @@ class Dataset:
                 setattr(self, key, value)
             else:
                 self[Tag(cast(int, key))] = value
-                if getattr(value, "parent", None):  # ignore[union-attr]
-                    value.parent = self
+                if getattr(value, "parent", None):
+                    value.parent = self  # ignore[union-attr]
 
     def iterall(self) -> Iterator[DataElement]:
         """Iterate through the :class:`Dataset`, yielding all the elements.

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2012,10 +2012,17 @@ class TestFileDataset:
         """Regression test for #1816"""
         ds = Dataset()
         ds.BeamSequence = []
+        elem = ds["BeamSequence"]
+        assert elem.parent is ds
 
         ds2 = Dataset()
         ds2.update(ds)
-        copy.deepcopy(ds2)
+        elem = ds2["BeamSequence"]
+        assert elem.parent is ds2
+
+        ds3 = copy.deepcopy(ds2)
+        elem = ds3["BeamSequence"]
+        assert elem.parent is ds3
 
 
 class TestDatasetOverlayArray:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2008,6 +2008,15 @@ class TestFileDataset:
         ds2 = copy.deepcopy(my_dataset_subclass)
         assert ds2.__class__ is MyDatasetSubclass
 
+    def test_deepcopy_after_update(self):
+        """Regression test for #1816"""
+        ds = Dataset()
+        ds.BeamSequence = []
+
+        ds2 = Dataset()
+        ds2.update(ds)
+        copy.deepcopy(ds2)
+
 
 class TestDatasetOverlayArray:
     """Tests for Dataset.overlay_array()."""


### PR DESCRIPTION
#### Describe the changes
Closes #1816, fixes `deepcopy` after `Dataset.update()`

Issue caused by the deepcopy of sequence elements trying to run on `DataElement.parent` (which then goes back down to try to `deepcopy` the incompletely copied sequence `DataElement`).

I also fixed `Dataset.update()` not updating the parent dataset for the updated SQ elements.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/f3fc3115-1b62-40c2-a025-ec406c9b8bab/artifacts/0/doc/_build/html/release_notes/index.html)
- [x] Unit tests passing and overall coverage the same or better
