### PR TITLE
[MRG] Improvements for generate_uid()

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -58,6 +58,10 @@ Changes
 * The ``Dataset.parent`` and ``Sequence.parent`` properties have been removed
 * The ``overlay_data_handlers`` module has been removed, use the :mod:`~pydicom.overlays`
   module instead
+* :func:`~pydicom.uid.generate_uid` has been changed to use a random suffix
+  generated using :func:`~secrets.randbelow` when `entropy_srcs` isn't used, and
+  the maximum allowed length of the `prefix` has been changed to 54 characters
+  (:issue:`1773`)
 
 
 Enhancements

--- a/src/pydicom/uid.py
+++ b/src/pydicom/uid.py
@@ -400,19 +400,16 @@ def generate_uid(
     ----------
     prefix : str or None, optional
         The UID prefix to use when creating the UID. Default is the *pydicom*
-        root UID ``'1.2.826.0.1.3680043.8.498.'``. If `prefix` is ``None then
+        root UID ``'1.2.826.0.1.3680043.8.498.'``. If `prefix` is ``None`` then
         a prefix of ``'2.25.'`` will be used with the integer form of a UUID
-        generated using the :func:`uuid.uuid4` algorithm. Because the UUID
-        suffix can be at most 39 characters, a `prefix` longer than 25
-        characters starts to increase the probability that the returned UID
-        will not be unique.
+        generated using the :func:`uuid.uuid4` algorithm.
     entropy_srcs : list of str, optional
         If `prefix` is used then the `prefix` will be appended with a
         SHA512 hash of the supplied :class:`list` which means the result is
         deterministic and should make the original data unrecoverable. If
         `entropy_srcs` isn't used then a random number from
         :func:`secrets.randbelow` will be appended to the `prefix`. If `prefix`
-        is not used then `entropy_srcs` has no effect.
+        is ``None`` then `entropy_srcs` has no effect.
 
     Returns
     -------
@@ -460,7 +457,7 @@ def generate_uid(
         )
 
     if entropy_srcs is None:
-        maximum = int("9" * (64 - len(prefix))) + 1
+        maximum = int(f"1{'0' * (64 - len(prefix))}")
         # randbelow is in [0, maximum)
         # {prefix}.0, and {prefix}0 are both valid
         return UID(f"{prefix}{secrets.randbelow(maximum)}"[:64])

--- a/src/pydicom/uid.py
+++ b/src/pydicom/uid.py
@@ -457,7 +457,7 @@ def generate_uid(
         )
 
     if entropy_srcs is None:
-        maximum = int(f"1{'0' * (64 - len(prefix))}")
+        maximum = 10 ** (64 - len(prefix))
         # randbelow is in [0, maximum)
         # {prefix}.0, and {prefix}0 are both valid
         return UID(f"{prefix}{secrets.randbelow(maximum)}"[:64])

--- a/src/pydicom/uid.py
+++ b/src/pydicom/uid.py
@@ -437,9 +437,9 @@ def generate_uid(
     References
     ----------
 
-    * DICOM Standard, Part 5, :dcm:`Chapters 9`<part05/chapter_9.html>` and
+    * DICOM Standard, Part 5, :dcm:`Chapters 9<part05/chapter_9.html>` and
       :dcm:`Annex B<part05/chapter_B.html>`
-    * ISO/IEC 9834-8/`ITU-T X.667<https://www.itu.int/rec/T-REC-X.667-201210-I/en>`_
+    * ISO/IEC 9834-8 (`ITU-T X.667<https://www.itu.int/rec/T-REC-X.667-201210-I/en>`_)
     """
     if prefix is None:
         # UUID -> as 128-bit int -> max 39 characters long

--- a/src/pydicom/uid.py
+++ b/src/pydicom/uid.py
@@ -439,7 +439,7 @@ def generate_uid(
 
     * DICOM Standard, Part 5, :dcm:`Chapters 9<part05/chapter_9.html>` and
       :dcm:`Annex B<part05/chapter_B.html>`
-    * ISO/IEC 9834-8 (`ITU-T X.667<https://www.itu.int/rec/T-REC-X.667-201210-I/en>`_)
+    * ISO/IEC 9834-8/`ITU-T X.667 <https://www.itu.int/rec/T-REC-X.667-201210-I/en>`_
     """
     if prefix is None:
         # UUID -> as 128-bit int -> max 39 characters long

--- a/tests/test_uid.py
+++ b/tests/test_uid.py
@@ -36,7 +36,7 @@ class TestGenerateUID:
 
         # Test invalid UID prefixes
         for invalid_prefix in (
-            ("1" * 63) + ".",
+            ("1" * 54) + ".",
             "",
             ".",
             "1",
@@ -54,7 +54,7 @@ class TestGenerateUID:
             "1.",
             "1.23.",
             "1.0.23.",
-            ("1" * 62) + ".",
+            ("1" * 53) + ".",
             "1.2.3.444444.",
         ):
             uid = generate_uid(prefix=valid_prefix)


### PR DESCRIPTION
#### Describe the changes
* Use a uniformly distributed random integer from [randbelow](https://docs.python.org/3/library/secrets.html#secrets.randbelow) as a suffix when `entropy_srcs` is not used
* Reduce the maximum character limit of `prefix` to 54 (down from 63)
* Closes #1773

```python
>>> from pydicom.uid import generate_uid
>>> import collections
>>> collections.Counter(generate_uid()[26] for _ in range(100000))
Counter({'7': 11330, '6': 11153, '8': 11130, '3': 11130, '5': 11124, '9': 11091, '1': 11072, '2': 11009, '4': 10961})
```

I didn't use `uuid4()` for this case because it only supplies [~122-bits of entropy](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)), which is roughly enough for 39 characters. Since we potentially need up to 64 characters I used `randbelow()` to generate random integers up to the length remaining after subtracting for the prefix.

The "2.25." UIDs are [specified by the DICOM Standard to use UUIDs](https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_B.2.html) so they stay as-is.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working - not really sure what test(s) to add
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/c75db2b3-613b-4aac-8482-5f38a7e5730a/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
