### PR TITLE
[MRG] Remove relational attributes from Dataset, Sequence and DataElement

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -55,7 +55,11 @@ Changes
   for 32-bit systems (:issue:`1743`)
 * The characters used by :func:`~pydicom.fileset.generate_filename` when
   `alphanumeric` is ``True`` has been reduced to [0-9][A-I,K-Z]
-* The ``Dataset.parent`` and ``Sequence.parent`` properties have been removed
+* The following properties have been removed:
+
+    * ``Dataset.parent`` and ``Dataset.parent_seq``
+    * ``Sequence.parent`` and ``Sequence.parent_dataset``
+    * ``DataElement.parent``
 * The ``overlay_data_handlers`` module has been removed, use the :mod:`~pydicom.overlays`
   module instead
 

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -232,7 +232,6 @@ class DataElement:
         self.file_tell = file_value_tell
         self.is_undefined_length = is_undefined_length
         self.private_creator: str | None = None
-        self.parent: Dataset | None = None
 
     def validate(self, value: Any) -> None:
         """Validate the current value against the DICOM standard.
@@ -551,18 +550,6 @@ class DataElement:
 
         self.validate(val)
         return val
-
-    def __deepcopy__(self, memo: dict[int, Any] | None) -> "DataElement":
-        cls = self.__class__
-        copied = cls.__new__(cls)
-        if memo:
-            memo[id(self)] = copied
-
-        # Fix for #1816: don't deepcopy the parent!
-        for key in (k for k in self.__dict__ if k != "parent"):
-            copied.__dict__[key] = copy.deepcopy(self.__dict__[key], memo)
-
-        return copied
 
     def __eq__(self, other: Any) -> Any:
         """Compare `self` and `other` for equality.

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2293,6 +2293,9 @@ class Dataset:
             if not isinstance(elem.value, pydicom.Sequence):
                 elem.value = pydicom.Sequence(elem.value)  # type: ignore
 
+            # Update the `_pixel_rep` attribute when nested sequences
+            #   containing RawDataElements are being added to a different
+            #   dataset
             self._set_pixel_representation(cast(DataElement, elem))
 
     def _set_pixel_representation(self, elem: DataElement) -> None:
@@ -2318,12 +2321,12 @@ class Dataset:
         for item in elem.value:
             if TAG_PIXREP in item._dict:
                 pr = item._dict[TAG_PIXREP].value
-                if pr is None and hasattr(self, "_pixel_rep"):
-                    item._pixel_rep = self._pixel_rep
-                else:
+                if pr is not None:
                     item._pixel_rep = (
                         int(b"\x01" in pr) if isinstance(pr, bytes) else pr
                     )
+                elif hasattr(self, "_pixel_rep"):
+                    item._pixel_rep = self._pixel_rep
             elif hasattr(self, "_pixel_rep"):
                 item._pixel_rep = self._pixel_rep
 

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -1011,6 +1011,7 @@ class Dataset:
 
                 def _set_pixel_rep(ds: "Dataset") -> None:
                     """Set the `Dataset._pixel_rep` attribute, if possible."""
+                    # `TAG_PIXREP` is (0028,0103) *Pixel Representation*
                     if TAG_PIXREP not in ds._dict:
                         return
 
@@ -1024,14 +1025,13 @@ class Dataset:
                 # Note that the value of `_pixel_rep` gets updated as we move
                 #   down the tree - the value used to correct ambiguous
                 #   elements will be from the closest dataset to that element
-                # `TAG_PIXREP` is (0028,0103) *Pixel Representation*
                 _set_pixel_rep(self)
 
                 for item in self[tag].value:
-                    if TAG_PIXREP not in item._dict and hasattr(self, "_pixel_rep"):
-                        item._pixel_rep = self._pixel_rep
-                    else:
+                    if TAG_PIXREP in item._dict:
                         _set_pixel_rep(item)
+                    elif hasattr(self, "_pixel_rep"):
+                        item._pixel_rep = self._pixel_rep
 
             # If the Element has an ambiguous VR, try to correct it
             if self[tag].VR in AMBIGUOUS_VR:

--- a/src/pydicom/filereader.py
+++ b/src/pydicom/filereader.py
@@ -888,8 +888,6 @@ def read_partial(
     dataset.update(command_set)
 
     # (0002,0002) Media Storage SOP Class UID
-    elem = file_meta.get(0x00020002, None)
-    sop_class = elem.value.name if (elem and elem.VM == 1) else ""
     ds = FileDataset(
         fileobj,
         dataset,

--- a/src/pydicom/filereader.py
+++ b/src/pydicom/filereader.py
@@ -886,8 +886,6 @@ def read_partial(
 
     # Add the command set elements to the dataset (if any)
     dataset.update(command_set)
-
-    # (0002,0002) Media Storage SOP Class UID
     ds = FileDataset(
         fileobj,
         dataset,

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -217,6 +217,10 @@ def correct_ambiguous_vr_element(
     If the VR is corrected and is 'US' or 'SS' then the value will be updated
     using the :func:`~pydicom.values.convert_numbers` function.
 
+    .. versionchanged:: 3.0
+
+        The `ancestors` keyword argument was added.
+
     Parameters
     ----------
     elem : dataelem.DataElement
@@ -267,6 +271,10 @@ def correct_ambiguous_vr(
 
     If the VR is corrected and is 'US' or 'SS' then the value will be updated
     using the :func:`~pydicom.values.convert_numbers` function.
+
+    .. versionchanged:: 3.0
+
+        The `ancestors` keyword argument was added.
 
     Parameters
     ----------

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -89,7 +89,7 @@ _OVERLAY_DATA_TAGS = {x << 16 | 0x3000 for x in range(0x6000, 0x601F, 2)}
 
 def _correct_ambiguous_vr_element(
     elem: DataElement,
-    ancestors: list["Dataset"],
+    ancestors: list[Dataset],
     is_little_endian: bool,
 ) -> DataElement:
     """Implementation for `correct_ambiguous_vr_element`.
@@ -126,15 +126,17 @@ def _correct_ambiguous_vr_element(
         #   https://github.com/pydicom/pydicom/pull/298
         # PixelRepresentation is usually set in the root dataset
 
-        # This list of ancestor datasets is most useful when writing, o duringr
+        # This list of ancestor datasets is most useful when writing, or during
         #   reading if the element is on the same level as pixel representation
         anc_ds: list[Dataset] = [x for x in ancestors if "PixelRepresentation" in x]
         # This list is useful during reading if the element isn't on the same
         #   level as pixel representation
-        anc_pr: list[int] = [x._pixel_rep for x in ancestors if hasattr(x, "_pixel_rep")]
+        anc_pr: list[int] = [
+            x._pixel_rep for x in ancestors if hasattr(x, "_pixel_rep")
+        ]
 
         if anc_ds:
-            pixel_rep = anc_ds[0].PixelRepresentation
+            pixel_rep = cast(int, anc_ds[0].PixelRepresentation)
         elif anc_pr:
             pixel_rep = anc_pr[0]
         else:
@@ -202,9 +204,9 @@ def _correct_ambiguous_vr_element(
 
 def correct_ambiguous_vr_element(
     elem: DataElement,
-    ds: "Dataset",
+    ds: Dataset,
     is_little_endian: bool,
-    ancestors: list["Dataset"] | None = None,
+    ancestors: list[Dataset] | None = None,
 ) -> DataElement:
     """Attempt to correct the ambiguous VR element `elem`.
 
@@ -253,10 +255,10 @@ def correct_ambiguous_vr_element(
 
 
 def correct_ambiguous_vr(
-    ds: "Dataset",
+    ds: Dataset,
     is_little_endian: bool,
-    ancestors: list["Dataset"] | None = None,
-) -> "Dataset":
+    ancestors: list[Dataset] | None = None,
+) -> Dataset:
     """Iterate through `ds` correcting ambiguous VR elements (if possible).
 
     When it's not possible to correct the VR, the element will be returned
@@ -289,7 +291,7 @@ def correct_ambiguous_vr(
         If a tag is missing in `ds` that is required to resolve the ambiguity.
     """
     # Construct the tree if `ds` is the root level dataset
-    #tree = Tree(ds) if tree is None else tree
+    # tree = Tree(ds) if tree is None else tree
     ancestors = [ds] if ancestors is None else ancestors
 
     # Iterate through the elements

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -128,7 +128,9 @@ def _correct_ambiguous_vr_element(
 
         # This list of ancestor datasets is most useful when writing, or during
         #   reading if the element is on the same level as pixel representation
-        anc_ds: list[Dataset] = [x for x in ancestors if "PixelRepresentation" in x]
+        anc_ds = [
+            x for x in ancestors if getattr(x, "PixelRepresentation", None) is not None
+        ]
         # This list is useful during reading if the element isn't on the same
         #   level as pixel representation
         anc_pr: list[int] = [

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -41,6 +41,7 @@ if have_numpy:
     import numpy
 
 
+# Ambiguous VR Correction
 # (0018,9810) Zero Velocity Pixel Value
 # (0022,1452) Mapped Pixel Value
 # (0028,0104)/(0028,0105) Smallest/Largest Valid Pixel Value
@@ -53,7 +54,7 @@ if have_numpy:
 # (0028,3002) LUT Descriptor
 # (0040,9216)/(0040,9211) Real World Value First/Last Value Mapped
 # (0060,3004)/(0060,3006) Histogram First/Last Bin Value
-_us_ss_tags = {
+_AMBIGUOUS_US_SS_TAGS = {
     0x00189810,
     0x00221452,
     0x00280104,
@@ -80,18 +81,23 @@ _us_ss_tags = {
 # (5400,0112) Channel Maximum Value
 # (5400,100A) Waveform Padding Data
 # (5400,1010) Waveform Data
-_ob_ow_tags = {0x54000110, 0x54000112, 0x5400100A, 0x54001010}
+_AMBIGUOUS_OB_OW_TAGS = {0x54000110, 0x54000112, 0x5400100A, 0x54001010}
 
 # (60xx,3000) Overlay Data
-_overlay_data_tags = {x << 16 | 0x3000 for x in range(0x6000, 0x601F, 2)}
+_OVERLAY_DATA_TAGS = {x << 16 | 0x3000 for x in range(0x6000, 0x601F, 2)}
 
 
 def _correct_ambiguous_vr_element(
-    elem: DataElement, ds: Dataset, is_little_endian: bool
+    elem: DataElement,
+    ancestors: list["Dataset"],
+    is_little_endian: bool,
 ) -> DataElement:
     """Implementation for `correct_ambiguous_vr_element`.
     See `correct_ambiguous_vr_element` for description.
     """
+    # The zeroth dataset is the nearest, the last is the root dataset
+    ds = ancestors[0]
+
     # 'OB or OW': 7fe0,0010 PixelData
     if elem.tag == 0x7FE00010:
         # Compressed Pixel Data
@@ -114,31 +120,36 @@ def _correct_ambiguous_vr_element(
             elem.VR = VR.OW if cast(int, ds.BitsAllocated) > 8 else VR.OB
 
     # 'US or SS' and dependent on PixelRepresentation
-    elif elem.tag in _us_ss_tags:
+    elif elem.tag in _AMBIGUOUS_US_SS_TAGS:
         # US if PixelRepresentation value is 0x0000, else SS
         #   For references, see the list at
         #   https://github.com/pydicom/pydicom/pull/298
         # PixelRepresentation is usually set in the root dataset
-        while (
-            "PixelRepresentation" not in ds
-            and ds.parent_seq is not None
-            and ds.parent_seq().parent_dataset is not None  # type: ignore[union-attr]
-            and ds.parent_seq().parent_dataset()  # type: ignore
-        ):
-            # Make weakrefs into strong refs (locally here) by calling () them
-            ds = ds.parent_seq().parent_dataset()  # type: ignore
-        # if no pixel data is present, none if these tags is used,
-        # so we can just ignore a missing PixelRepresentation in this case
-        if (
-            "PixelRepresentation" not in ds
-            and "PixelData" not in ds
-            or ds.PixelRepresentation == 0
-        ):
-            elem.VR = VR.US
-            byte_type = "H"
+
+        # This list of ancestor datasets is most useful when writing, o duringr
+        #   reading if the element is on the same level as pixel representation
+        anc_ds: list[Dataset] = [x for x in ancestors if "PixelRepresentation" in x]
+        # This list is useful during reading if the element isn't on the same
+        #   level as pixel representation
+        anc_pr: list[int] = [x._pixel_rep for x in ancestors if hasattr(x, "_pixel_rep")]
+
+        if anc_ds:
+            pixel_rep = anc_ds[0].PixelRepresentation
+        elif anc_pr:
+            pixel_rep = anc_pr[0]
         else:
-            elem.VR = VR.SS
-            byte_type = "h"
+            # if no pixel data is present, none if these tags is used,
+            # so we can just ignore a missing PixelRepresentation in this case
+            pixel_rep = 1
+            if (
+                "PixelRepresentation" not in ds
+                and "PixelData" not in ds
+                or ds.PixelRepresentation == 0
+            ):
+                pixel_rep = 0
+
+        elem.VR = VR.US if pixel_rep == 0 else VR.SS
+        byte_type = "H" if pixel_rep == 0 else "h"
 
         if elem.VM == 0:
             return elem
@@ -151,7 +162,7 @@ def _correct_ambiguous_vr_element(
             )
 
     # 'OB or OW' and dependent on WaveformBitsAllocated
-    elif elem.tag in _ob_ow_tags:
+    elif elem.tag in _AMBIGUOUS_OB_OW_TAGS:
         # If WaveformBitsAllocated is > 8 then OW, otherwise may be
         #   OB or OW.
         #   See PS3.3 C.10.9.1.
@@ -181,7 +192,7 @@ def _correct_ambiguous_vr_element(
             elem.VR = VR.OW
 
     # 'OB or OW': 60xx,3000 OverlayData and dependent on Transfer Syntax
-    elif elem.tag in _overlay_data_tags:
+    elif elem.tag in _OVERLAY_DATA_TAGS:
         # Implicit VR must be OW, explicit VR may be OB or OW
         #   as per PS3.5 Section 8.1.2 and Annex A
         elem.VR = VR.OW
@@ -190,7 +201,10 @@ def _correct_ambiguous_vr_element(
 
 
 def correct_ambiguous_vr_element(
-    elem: DataElement, ds: Dataset, is_little_endian: bool
+    elem: DataElement,
+    ds: "Dataset",
+    is_little_endian: bool,
+    ancestors: list["Dataset"] | None = None,
 ) -> DataElement:
     """Attempt to correct the ambiguous VR element `elem`.
 
@@ -209,12 +223,19 @@ def correct_ambiguous_vr_element(
         The dataset containing `elem`.
     is_little_endian : bool
         The byte ordering of the values in the dataset.
+    ancestors : list[pydicom.dataset.Dataset] | None
+        A list of the ancestor datasets to look through when trying to find
+        the relevant element value to use in VR correction. Should be ordered
+        from closest to furthest. If ``None`` then will build itself
+        automatically starting at `ds` (default).
 
     Returns
     -------
     dataelem.DataElement
         The corrected element
     """
+    ancestors = [ds] if ancestors is None else ancestors
+
     if elem.VR in AMBIGUOUS_VR:
         # convert raw data elements before handling them
         if isinstance(elem, RawDataElement):
@@ -222,16 +243,20 @@ def correct_ambiguous_vr_element(
             ds.__setitem__(elem.tag, elem)
 
         try:
-            _correct_ambiguous_vr_element(elem, ds, is_little_endian)
+            _correct_ambiguous_vr_element(elem, ancestors, is_little_endian)
         except AttributeError as e:
             raise AttributeError(
-                f"Failed to resolve ambiguous VR for tag {elem.tag}: " + str(e)
+                f"Failed to resolve ambiguous VR for tag {elem.tag}: {str(e)}"
             )
 
     return elem
 
 
-def correct_ambiguous_vr(ds: Dataset, is_little_endian: bool) -> Dataset:
+def correct_ambiguous_vr(
+    ds: "Dataset",
+    is_little_endian: bool,
+    ancestors: list["Dataset"] | None = None,
+) -> "Dataset":
     """Iterate through `ds` correcting ambiguous VR elements (if possible).
 
     When it's not possible to correct the VR, the element will be returned
@@ -247,6 +272,11 @@ def correct_ambiguous_vr(ds: Dataset, is_little_endian: bool) -> Dataset:
         The dataset containing ambiguous VR elements.
     is_little_endian : bool
         The byte ordering of the values in the dataset.
+    ancestors : list[pydicom.dataset.Dataset] | None
+        A list of the ancestor datasets to look through when trying to find
+        the relevant element value to use in VR correction. Should be ordered
+        from closest to furthest. If ``None`` then will build itself
+        automatically starting at `ds` (default).
 
     Returns
     -------
@@ -258,15 +288,22 @@ def correct_ambiguous_vr(ds: Dataset, is_little_endian: bool) -> Dataset:
     AttributeError
         If a tag is missing in `ds` that is required to resolve the ambiguity.
     """
+    # Construct the tree if `ds` is the root level dataset
+    #tree = Tree(ds) if tree is None else tree
+    ancestors = [ds] if ancestors is None else ancestors
+
     # Iterate through the elements
     for elem in ds:
         # raw data element sequences can be written as they are, because we
         # have ensured that the transfer syntax has not changed at this point
         if elem.VR == VR.SQ:
-            for item in cast(MutableSequence[Dataset], elem.value):
-                correct_ambiguous_vr(item, is_little_endian)
+            for item in cast(MutableSequence["Dataset"], elem.value):
+                ancestors.insert(0, item)
+                correct_ambiguous_vr(item, is_little_endian, ancestors)
         elif elem.VR in AMBIGUOUS_VR:
-            correct_ambiguous_vr_element(elem, ds, is_little_endian)
+            correct_ambiguous_vr_element(elem, ds, is_little_endian, ancestors)
+
+    del ancestors[0]
     return ds
 
 

--- a/src/pydicom/tag.py
+++ b/src/pydicom/tag.py
@@ -260,3 +260,8 @@ ItemDelimiterTag = TupleTag((0xFFFE, 0xE00D))
 
 # end of Sequence of undefined length
 SequenceDelimiterTag = TupleTag((0xFFFE, 0xE0DD))
+
+# (0028,0103) *Pixel Representation*
+TAG_PIXREP = BaseTag(0x00280103)
+# (0008,0005) *Specific Character Set*
+TAG_CHARSET = BaseTag(0x00080005)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1756,6 +1756,7 @@ class TestDataset:
         assert ds.BeamSequence == []
         assert ds._pixel_rep == 1
 
+
 class TestDatasetElements:
     """Test valid assignments of data elements"""
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1756,6 +1756,11 @@ class TestDataset:
         assert ds.BeamSequence == []
         assert ds._pixel_rep == 1
 
+        ds = Dataset()
+        ds.PixelRepresentation = 0
+        ds._set_pixel_representation(ds["PixelRepresentation"])
+        assert ds._pixel_rep == 0
+
 
 class TestDatasetElements:
     """Test valid assignments of data elements"""

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1841,13 +1841,11 @@ class TestFileDataset:
 
     def test_pickle_data_elements(self):
         ds = pydicom.dcmread(self.test_file)
-        assert ds.OtherPatientIDsSequence.parent_dataset == weakref.ref(ds)
         for e in ds:
             # make sure all data elements have been loaded
             pass
         s = pickle.dumps({"ds": ds})
         ds1 = pickle.loads(s)["ds"]
-        assert ds1.OtherPatientIDsSequence.parent_dataset == weakref.ref(ds)
         assert ds == ds1
 
     def test_pickle_nested_sequence(self):
@@ -2012,17 +2010,12 @@ class TestFileDataset:
         """Regression test for #1816"""
         ds = Dataset()
         ds.BeamSequence = []
-        elem = ds["BeamSequence"]
-        assert elem.parent is ds
 
         ds2 = Dataset()
         ds2.update(ds)
-        elem = ds2["BeamSequence"]
-        assert elem.parent is ds2
 
         ds3 = copy.deepcopy(ds2)
-        elem = ds3["BeamSequence"]
-        assert elem.parent is ds3
+        assert ds3 == ds
 
 
 class TestDatasetOverlayArray:
@@ -2225,12 +2218,6 @@ class TestFileMeta:
         assert ds_copy.BeamSequence[1].Manufacturer == "Linac and Sons, co."
         if copy_method == copy.deepcopy:
             assert id(ds_copy.BeamSequence[0]) != id(ds.BeamSequence[0])
-
-            # dereference weakrefs and check are pointing to correct objects
-            assert ds.BeamSequence is ds.BeamSequence[0].parent_seq()
-            assert ds is ds.BeamSequence.parent_dataset()
-            assert ds_copy.BeamSequence is ds_copy.BeamSequence[0].parent_seq()
-            assert ds_copy is ds_copy.BeamSequence.parent_dataset()
         else:
             # shallow copy
             assert id(ds_copy.BeamSequence[0]) == id(ds.BeamSequence[0])

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1717,6 +1717,44 @@ class TestDataset:
         with pytest.raises(ValueError, match=msg):
             ds["invalid"] = ds["PatientName"]
 
+    def test_values(self):
+        """Test Dataset.values()."""
+        ds = Dataset()
+        ds.PatientName = "Foo"
+        ds.BeamSequence = [Dataset()]
+        ds.BeamSequence[0].PatientID = "Bar"
+
+        values = list(ds.values())
+        assert values[0] == ds["PatientName"]
+        assert values[1] == ds["BeamSequence"]
+        assert len(values) == 2
+
+    def test_pixel_rep(self):
+        """Tests for Dataset._pixel_rep"""
+        ds = Dataset()
+        ds.PixelRepresentation = None
+        ds.BeamSequence = []
+
+        ds.is_implicit_VR = True
+        ds.is_little_endian = True
+        fp = io.BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        assert not hasattr(ds, "_pixel_rep")
+        assert ds.PixelRepresentation is None
+        assert ds.BeamSequence == []
+        # Attribute not set if Pixel Representation is None
+        assert not hasattr(ds, "_pixel_rep")
+
+        ds = dcmread(fp, force=True)
+        ds.PixelRepresentation = 0
+        assert ds.BeamSequence == []
+        assert ds._pixel_rep == 0
+
+        ds = dcmread(fp, force=True)
+        ds.PixelRepresentation = 1
+        assert ds.BeamSequence == []
+        assert ds._pixel_rep == 1
 
 class TestDatasetElements:
     """Test valid assignments of data elements"""

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -1058,6 +1058,7 @@ class TestCorrectAmbiguousVR:
         ds = Dataset()
         ds.PixelRepresentation = pixel_repr
         ds.ModalityLUTSequence = [Dataset()]
+        #ds.ModalityLUTSequence[0].PixelRepresentation = 0
         ds.ModalityLUTSequence[0].LUTDescriptor = [0, 0, 16]
         ds.ModalityLUTSequence[0].LUTExplanation = None
         ds.ModalityLUTSequence[0].ModalityLUTType = "US"  # US = unspecified

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -1289,7 +1289,7 @@ class TestCorrectAmbiguousVR:
         assert "US" == item[0x00283002].VR
 
     def test_pixel_repr_none_in_further_implicit(self):
-        """Test a pixel representation of None in a nearer dataset."""
+        """Test a pixel representation of None in a further dataset."""
         ds = self.dataset_with_modality_lut_sequence(None)
         ds.ModalityLUTSequence[0].PixelRepresentation = 0
         ds.is_implicit_VR = True

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -1058,7 +1058,6 @@ class TestCorrectAmbiguousVR:
         ds = Dataset()
         ds.PixelRepresentation = pixel_repr
         ds.ModalityLUTSequence = [Dataset()]
-        #ds.ModalityLUTSequence[0].PixelRepresentation = 0
         ds.ModalityLUTSequence[0].LUTDescriptor = [0, 0, 16]
         ds.ModalityLUTSequence[0].LUTExplanation = None
         ds.ModalityLUTSequence[0].ModalityLUTType = "US"  # US = unspecified
@@ -1134,6 +1133,21 @@ class TestCorrectAmbiguousVR:
 
         ds = self.dataset_with_modality_lut_sequence(pixel_repr=1)
         ds.is_implicit_VR = True
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        assert "SS" == ds[0x00283000][0][0x00283002].VR
+
+    def test_ambiguous_element_sequence_implicit_nearest(self):
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=0)
+        ds.is_implicit_VR = True
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        assert "US" == ds[0x00283000][0][0x00283002].VR
+
+        # Uses the nearer element to set the VR
+        ds.ModalityLUTSequence[0].PixelRepresentation = 1
         fp = BytesIO()
         ds.save_as(fp, write_like_original=True)
         ds = dcmread(fp, force=True)

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -6,6 +6,7 @@ from datetime import date, datetime, time, timedelta, timezone
 from io import BytesIO
 import os
 from pathlib import Path
+import pickle
 from platform import python_implementation
 
 from struct import unpack
@@ -1139,19 +1140,168 @@ class TestCorrectAmbiguousVR:
         assert "SS" == ds[0x00283000][0][0x00283002].VR
 
     def test_ambiguous_element_sequence_implicit_nearest(self):
+        """Test that the nearest dataset with pixel rep to the ambiguous
+        element is used for correction.
+        """
         ds = self.dataset_with_modality_lut_sequence(pixel_repr=0)
         ds.is_implicit_VR = True
-        fp = BytesIO()
-        ds.save_as(fp, write_like_original=True)
-        ds = dcmread(fp, force=True)
-        assert "US" == ds[0x00283000][0][0x00283002].VR
-
-        # Uses the nearer element to set the VR
         ds.ModalityLUTSequence[0].PixelRepresentation = 1
         fp = BytesIO()
         ds.save_as(fp, write_like_original=True)
         ds = dcmread(fp, force=True)
         assert "SS" == ds[0x00283000][0][0x00283002].VR
+
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=1)
+        ds.is_implicit_VR = True
+        ds.ModalityLUTSequence[0].PixelRepresentation = 0
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        assert "US" == ds[0x00283000][0][0x00283002].VR
+
+    def test_ambiguous_element_sequence_explicit_nearest(self):
+        """Test that the nearest dataset with pixel rep to the ambiguous
+        element is used for correction.
+        """
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=0)
+        ds.is_implicit_VR = False
+        ds.ModalityLUTSequence[0].PixelRepresentation = 1
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        assert "SS" == ds[0x00283000][0][0x00283002].VR
+
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=1)
+        ds.is_implicit_VR = False
+        ds.ModalityLUTSequence[0].PixelRepresentation = 0
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        assert "US" == ds[0x00283000][0][0x00283002].VR
+
+    def test_pickle_deepcopy_implicit(self):
+        """Test we can correct VR after pickling and deepcopy."""
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=0)
+        ds.is_implicit_VR = True
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        ds.filename = None
+
+        ds2 = deepcopy(ds)
+
+        s = pickle.dumps({"ds": ds})
+        ds = pickle.loads(s)["ds"]
+
+        assert "US" == ds[0x00283000][0][0x00283002].VR
+        assert "US" == ds2[0x00283000][0][0x00283002].VR
+
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=1)
+        ds.is_implicit_VR = True
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        ds.filename = None
+
+        ds2 = deepcopy(ds)
+
+        s = pickle.dumps({"ds": ds})
+        ds = pickle.loads(s)["ds"]
+
+        assert "SS" == ds[0x00283000][0][0x00283002].VR
+        assert "SS" == ds2[0x00283000][0][0x00283002].VR
+
+    def test_pickle_deepcopy_explicit(self):
+        """Test we can correct VR after pickling and deepcopy."""
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=0)
+        ds.is_implicit_VR = False
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        ds.filename = None
+
+        ds2 = deepcopy(ds)
+
+        s = pickle.dumps({"ds": ds})
+        ds = pickle.loads(s)["ds"]
+
+        assert "US" == ds[0x00283000][0][0x00283002].VR
+        assert "US" == ds2[0x00283000][0][0x00283002].VR
+
+        ds = self.dataset_with_modality_lut_sequence(pixel_repr=1)
+        ds.is_implicit_VR = False
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+        ds.filename = None
+
+        ds2 = deepcopy(ds)
+
+        s = pickle.dumps({"ds": ds})
+        ds = pickle.loads(s)["ds"]
+
+        assert "SS" == ds[0x00283000][0][0x00283002].VR
+        assert "SS" == ds2[0x00283000][0][0x00283002].VR
+
+    def test_parent_change_implicit(self):
+        """Test ambiguous VR correction when parent is changed."""
+        ds = Dataset()
+        ds.PixelRepresentation = 0
+        ds.BeamSequence = [Dataset()]
+        # Nesting Modality LUT Sequence to avoid raw -> elem conversion
+        seq = ds.BeamSequence[0]
+        seq.ModalityLUTSequence = [Dataset()]
+        seq.ModalityLUTSequence[0].LUTDescriptor = [0, 0, 16]
+        seq.ModalityLUTSequence[0].LUTExplanation = None
+        seq.ModalityLUTSequence[0].ModalityLUTType = "US"  # US = unspecified
+        seq.ModalityLUTSequence[0].LUTData = b"\x0000\x149a\x1f1c\xc2637"
+        ds.is_little_endian = True
+        ds.is_implicit_VR = True
+
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+
+        ds1 = dcmread(ct_name)
+        ds1.PixelRepresentation = 1
+        ds1.BeamSequence = ds.BeamSequence
+        assert ds1._pixel_rep == 1
+        assert ds1["BeamSequence"][0]._pixel_rep == 1
+        assert isinstance(ds1.BeamSequence[0]._dict[0x00283000], RawDataElement)
+
+        modality_seq = ds1.BeamSequence[0].ModalityLUTSequence
+        assert modality_seq[0]._pixel_rep == 1
+        assert "SS" == ds1.BeamSequence[0][0x00283000][0][0x00283002].VR
+
+    def test_pixel_repr_none_in_nearer_implicit(self):
+        """Test a pixel representation of None in a nearer dataset."""
+        ds = self.dataset_with_modality_lut_sequence(0)
+        ds.ModalityLUTSequence[0].PixelRepresentation = None
+        ds.is_implicit_VR = True
+
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+
+        item = ds.ModalityLUTSequence[0]
+        assert ds._pixel_rep == 0
+        assert item._pixel_rep == 0
+        assert "US" == item[0x00283002].VR
+
+    def test_pixel_repr_none_in_further_implicit(self):
+        """Test a pixel representation of None in a nearer dataset."""
+        ds = self.dataset_with_modality_lut_sequence(None)
+        ds.ModalityLUTSequence[0].PixelRepresentation = 0
+        ds.is_implicit_VR = True
+
+        fp = BytesIO()
+        ds.save_as(fp, write_like_original=True)
+        ds = dcmread(fp, force=True)
+
+        item = ds.ModalityLUTSequence[0]
+        assert not hasattr(ds, "_pixel_rep")
+        assert item._pixel_rep == 0
+        assert "US" == item[0x00283002].VR
 
 
 class TestCorrectAmbiguousVRElement:

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -98,14 +98,10 @@ class TestSequence:
         parent.PatientName = "Parent"
 
         seq = Sequence()
-        seq.parent_dataset = parent
-        assert isinstance(seq.parent_dataset, weakref.ReferenceType)
         seq.append(ds_a)
         seq.append(ds_c)
         seq.insert(1, ds_b)
         assert 3 == len(seq)
-        for ds in seq:
-            assert isinstance(ds.parent_seq, weakref.ReferenceType)
 
         seq[1] = ds_e
         assert ds_e == seq[1]
@@ -114,8 +110,6 @@ class TestSequence:
         assert [ds_a, ds_d, ds_e, ds_c] == seq
         seq[1:2] = [ds_c, ds_e]
         assert [ds_a, ds_c, ds_e, ds_e, ds_c] == seq
-        for ds in seq:
-            assert isinstance(ds.parent_seq, weakref.ReferenceType)
 
         msg = r"Can only assign an iterable of 'Dataset'"
         with pytest.raises(TypeError, match=msg):
@@ -138,8 +132,6 @@ class TestSequence:
         parent.PatientName = "Parent"
 
         seq = Sequence()
-        seq.parent_dataset = parent
-        assert isinstance(seq.parent_dataset, weakref.ReferenceType)
         seq.extend([ds_a, ds_b, ds_c])
         assert [ds_a, ds_b, ds_c] == seq
 
@@ -150,8 +142,6 @@ class TestSequence:
 
         seq.extend([ds_d, ds_e])
         assert [ds_a, ds_b, ds_c, ds_d, ds_e] == seq
-        for ds in seq:
-            assert isinstance(ds.parent_seq, weakref.ReferenceType)
 
     def test_iadd(self):
         """Test Sequence() += [Dataset()]."""
@@ -170,8 +160,6 @@ class TestSequence:
         parent.PatientName = "Parent"
 
         seq = Sequence()
-        seq.parent_dataset = parent
-        assert isinstance(seq.parent_dataset, weakref.ReferenceType)
         seq += [ds_a, ds_b, ds_c]
         assert [ds_a, ds_b, ds_c] == seq
 
@@ -182,9 +170,6 @@ class TestSequence:
 
         seq += [ds_d, ds_e]
         assert [ds_a, ds_b, ds_c, ds_d, ds_e] == seq
-
-        for ds in seq:
-            assert isinstance(ds.parent_seq, weakref.ReferenceType)
 
     def test_deepcopy_sequence_subclass(self):
         """Regression test for #1813."""


### PR DESCRIPTION
#### Describe the changes
* Removes the `Dataset.parent_seq`, `Sequence.parent_dataset` and `DataElement.parent` attributes.
* Removes the pickle `__getstate__` and `__setstate__` overrides in `Dataset` and `Sequence`
* Removes the `__deepcopy__` overrides in `Dataset`, `Sequence` and `DataElement`
* Adds `Dataset._pixel_rep` attribute and `Dataset._set_pixel_representation` method to replace the removed functionality for ambiguous VR correction
* Adds an `ancestors` parameter to the ambiguous VR functions to replace the removed functionality

Closes #1843 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/356a0fbf-705f-4bba-9a2a-7a0b026ae2d9/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
