### PR TITLE
[MRG] Fix PermissionErrors when running data manager tests on a read-only filesystem

### DIFF
--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -122,7 +122,9 @@ class TestGetData:
             assert palbase in x
 
 
-@pytest.mark.skipif(not EXT_PYDICOM or not IS_WRITEABLE, reason="pydicom-data not installed or RO")
+@pytest.mark.skipif(
+    not EXT_PYDICOM or not IS_WRITEABLE, reason="pydicom-data not installed or RO"
+)
 class TestExternalDataSource:
     """Tests for the external data sources."""
 

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -6,6 +6,7 @@ import os
 from os.path import basename
 from pathlib import Path
 import shutil
+from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -24,9 +25,16 @@ from pydicom.data import download
 from pydicom.data.download import get_data_dir, calculate_file_hash, get_cached_filehash
 
 
-EXT_PYDICOM = False
-if "pydicom-data" in external_data_sources():
-    EXT_PYDICOM = True
+EXT_PYDICOM = "pydicom-data" in external_data_sources()
+if EXT_PYDICOM:
+    DATA_SRC = external_data_sources()["pydicom-data"].data_path
+    try:
+        with open(SRC / "test", "wb") as f:
+            pass
+        os.remove(SRC / "test")
+        IS_WRITEABLE = True
+    except Exception as exc:
+        IS_WRITEABLE = False
 
 
 @pytest.fixture
@@ -114,7 +122,7 @@ class TestGetData:
             assert palbase in x
 
 
-@pytest.mark.skipif(not EXT_PYDICOM, reason="pydicom-data not installed")
+@pytest.mark.skipif(not EXT_PYDICOM or not IS_WRITEABLE, reason="pydicom-data not installed or RO")
 class TestExternalDataSource:
     """Tests for the external data sources."""
 
@@ -122,14 +130,15 @@ class TestExternalDataSource:
         self.dpath = external_data_sources()["pydicom-data"].data_path
 
         # Backup the 693_UNCI.dcm file
-        p = self.dpath / "693_UNCI.dcm"
-        shutil.copy(p, self.dpath / "PYTEST_BACKUP")
+        self.src = self.dpath / "693_UNCI.dcm"
+        self.tdir = TemporaryDirectory()
+        self.dst = Path(self.tdir.name) / "PYTEST_BACKUP"
+        shutil.copy(self.src, self.dst)
 
     def teardown_method(self):
         # Restore the backed-up file
-        p = self.dpath / "693_UNCI.dcm"
-        shutil.copy(self.dpath / "PYTEST_BACKUP", p)
-        os.remove(self.dpath / "PYTEST_BACKUP")
+        shutil.copy(self.dst, self.src)
+
 
         if "mylib" in external_data_sources():
             del external_data_sources()["mylib"]

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -29,9 +29,9 @@ EXT_PYDICOM = "pydicom-data" in external_data_sources()
 if EXT_PYDICOM:
     DATA_SRC = external_data_sources()["pydicom-data"].data_path
     try:
-        with open(SRC / "test", "wb") as f:
+        with open(DATA_SRC / "test", "wb") as f:
             pass
-        os.remove(SRC / "test")
+        os.remove(DATA_SRC / "test")
         IS_WRITEABLE = True
     except Exception as exc:
         IS_WRITEABLE = False
@@ -131,14 +131,14 @@ class TestExternalDataSource:
 
         # Backup the 693_UNCI.dcm file
         self.src = self.dpath / "693_UNCI.dcm"
-        self.tdir = TemporaryDirectory()
+        self.tdir = TemporaryDirectory(ignore_cleanup_errors=True)
         self.dst = Path(self.tdir.name) / "PYTEST_BACKUP"
         shutil.copy(self.src, self.dst)
 
     def teardown_method(self):
         # Restore the backed-up file
         shutil.copy(self.dst, self.src)
-
+        self.tdir.cleanup()
 
         if "mylib" in external_data_sources():
             del external_data_sources()["mylib"]


### PR DESCRIPTION
#### Describe the changes
* Closes #1697, check to see if can write to the pydicom-data data directory before running the tests that require write-access.

I tested these locally by making `DATA_SRC` read-only and checking that the tests were skipped.

#### Tasks
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
