### PR TITLE
[MRG] Change DataElement.VM to return 1 for SQ

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -64,6 +64,8 @@ Changes
   generated using :func:`~secrets.randbelow` when `entropy_srcs` isn't used, and
   the maximum allowed length of the `prefix` has been changed to 54 characters
   (:issue:`1773`)
+* :attr:`~pydicom.dataelem.DataElement.VM` always returns ``1`` for **SQ**
+  elements (:issue:`1481`)
 
 
 Enhancements

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -452,15 +452,26 @@ class DataElement:
 
     @property
     def VM(self) -> int:
-        """Return the value multiplicity of the element as :class:`int`."""
+        """Return the value multiplicity of the element as :class:`int`.
+
+        .. versionchanged:: 3.0
+
+            **SQ** elements now always return a VM of ``1``.
+        """
+        if self.VR == VR_.SQ:
+            return 1
+
         if self.value is None:
             return 0
+
         if isinstance(self.value, str | bytes | PersonName):
             return 1 if self.value else 0
+
         try:
             iter(self.value)
         except TypeError:
             return 1
+
         return len(self.value)
 
     @property
@@ -469,6 +480,9 @@ class DataElement:
 
         .. versionadded:: 1.4
         """
+        if self.VR == VR_.SQ:
+            return not bool(self.value)
+
         return self.VM == 0
 
     @property

--- a/tests/test_dataelem.py
+++ b/tests/test_dataelem.py
@@ -544,7 +544,6 @@ class TestDataElement:
         ds.AcquisitionContextSequence = []
         elem = ds["AcquisitionContextSequence"]
         assert bool(elem.value) is False
-        assert 0 == elem.VM
         assert elem.value == []
 
         fp = DicomBytesIO()
@@ -553,7 +552,6 @@ class TestDataElement:
         filewriter.write_dataset(fp, ds)
         ds_read = dcmread(fp, force=True)
         elem = ds_read["AcquisitionContextSequence"]
-        assert 0 == elem.VM
         assert elem.value == []
 
     def test_is_private(self):
@@ -562,6 +560,26 @@ class TestDataElement:
         assert elem.is_private
         elem = DataElement(0x00080010, "UN", None)
         assert not elem.is_private
+
+    def test_is_empty_sequence(self):
+        """Test DataElement.is_empty for SQ."""
+        elem = DataElement(0x300A00B0, "SQ", [])
+        assert elem.VR == "SQ"
+        assert len(elem.value) == 0
+        assert elem.is_empty
+        elem.value = [Dataset()]
+        assert len(elem.value) == 1
+        assert not elem.is_empty
+
+    def test_vm_sequence(self):
+        """Test DataElement.VM for SQ."""
+        elem = DataElement(0x300A00B0, "SQ", [])
+        assert elem.VR == "SQ"
+        assert len(elem.value) == 0
+        assert elem.VM == 1
+        elem.value = [Dataset(), Dataset()]
+        assert len(elem.value) == 2
+        assert elem.VM == 1
 
 
 class TestRawDataElement:


### PR DESCRIPTION
#### Describe the changes
* `DataElement.VM` changed to always return 1 for SQ
* Closes #1481

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
