### PR TITLE
[MRG] Refactor MultiValue and MultiString

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -72,7 +72,12 @@ Changes
   elements (:issue:`1481`)
 * DICOM dictionary updated to 2023d
 * :class:`~pydicom.sequence.Sequence` is no longer a subclass of
-  :class:`~pydicom.multivalue.MultiValue`
+  :class:`~pydicom.multivalue.MultiValue` (:issue:`1395`)
+* :class:`~pydicom.multivalue.MultiValue` no longer accepts a ``validation_mode``
+  optional argument
+* ``valuerep.MultiString`` has been moved and renamed to
+  :func:`values.multi_string <pydicom.values.multi_string` and no longer accepts
+  a ``validation_mode`` optional argument
 
 
 Enhancements

--- a/src/pydicom/cli/show.py
+++ b/src/pydicom/cli/show.py
@@ -105,16 +105,14 @@ def quiet_rtplan(ds: Dataset) -> str | None:
                 gantry = cp.get("GantryAngle")
                 bld = cp.get("BeamLimitingDeviceAngle")
                 couch = cp.get("PatientSupportAngle")
-                line += (
-                    f" energy {energy} gantry {gantry}, coll {bld}, " f"couch {couch}"
-                )
+                line += f" energy {energy} gantry {gantry}, coll {bld}, couch {couch}"
 
         wedges = beam.get("NumberOfWedges")
         comps = beam.get("NumberOfCompensators")
         boli = beam.get("NumberOfBoli")
         blocks = beam.get("NumberOfBlocks")
 
-        line += f" ({wedges} wedges, {comps} comps, {boli} boli," f" {blocks} blocks)"
+        line += f" ({wedges} wedges, {comps} comps, {boli} boli, {blocks} blocks)"
 
         lines.append(line)
 

--- a/src/pydicom/data/data_manager.py
+++ b/src/pydicom/data/data_manager.py
@@ -174,7 +174,7 @@ def fetch_data_files() -> None:
 
     if error:
         raise RuntimeError(
-            "An error occurred downloading the following files: " f"{', '.join(error)}"
+            f"An error occurred downloading the following files: {', '.join(error)}"
         )
 
 

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -292,7 +292,7 @@ class DataElement:
             return cls(tag=tag, value=elem_value, VR=vr)
         except Exception as exc:
             raise ValueError(
-                f"Data element '{tag}' could not be loaded from JSON: " f"{elem_value}"
+                f"Data element '{tag}' could not be loaded from JSON: {elem_value}"
             ) from exc
 
     def to_json_dict(
@@ -522,13 +522,13 @@ class DataElement:
             return Sequence(val)
 
         # if the value is a list, convert each element
-        try:
-            val.append
-        except AttributeError:  # not a list
+        if not hasattr(val, "append"):
             return self._convert(val)
+
         if len(val) == 1:
             return self._convert(val[0])
-        return MultiValue(self._convert, val, validation_mode=self.validation_mode)
+
+        return MultiValue(self._convert, val)
 
     def _convert(self, val: Any) -> Any:
         """Convert `val` to an appropriate type for the element's VR."""
@@ -538,6 +538,7 @@ class DataElement:
             val = val.decode()
 
         if self.VR == VR_.IS:
+            print(val, self.validation_mode)
             return pydicom.valuerep.IS(val, self.validation_mode)
 
         if self.VR == VR_.DA and config.datetime_conversion:

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -538,7 +538,6 @@ class DataElement:
             val = val.decode()
 
         if self.VR == VR_.IS:
-            print(val, self.validation_mode)
             return pydicom.valuerep.IS(val, self.validation_mode)
 
         if self.VR == VR_.DA and config.datetime_conversion:

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -1579,7 +1579,7 @@ class Dataset:
                 missing = [dd for dd in hh_deps if have_package(dd) is None]
                 # Package names
                 names = [hh_deps[name][1] for name in missing]
-                pkg_msg.append(f"{hh.HANDLER_NAME} " f"(req. {', '.join(names)})")
+                pkg_msg.append(f"{hh.HANDLER_NAME} (req. {', '.join(names)})")
 
             raise RuntimeError(msg + ", ".join(pkg_msg))
 
@@ -1889,7 +1889,7 @@ class Dataset:
                 missing = [dd for dd in hh_deps if have_package(dd) is None]
                 # Package names
                 names = [hh_deps[name][1] for name in missing]
-                pkg_msg.append(f"{hh.HANDLER_NAME} " f"(req. {', '.join(names)})")
+                pkg_msg.append(f"{hh.HANDLER_NAME} (req. {', '.join(names)})")
 
             raise RuntimeError(msg + ", ".join(pkg_msg))
 
@@ -2274,7 +2274,7 @@ class Dataset:
 
         if key != elem_tag:
             raise ValueError(
-                f"The key '{key}' doesn't match the 'DataElement' tag " f"'{elem_tag}'"
+                f"The key '{key}' doesn't match the 'DataElement' tag '{elem_tag}'"
             )
 
         if elem_tag.is_private:

--- a/src/pydicom/encoders/base.py
+++ b/src/pydicom/encoders/base.py
@@ -685,7 +685,7 @@ class Encoder:
         all_plugins = list(self._unavailable.keys()) + list(self._available.keys())
         if plugin and plugin not in all_plugins:
             raise ValueError(
-                f"No plugin named '{plugin}' has been added to the " f"'{self.name}'"
+                f"No plugin named '{plugin}' has been added to the '{self.name}'"
             )
 
         if plugin and plugin in self._unavailable:

--- a/src/pydicom/filereader.py
+++ b/src/pydicom/filereader.py
@@ -1125,7 +1125,7 @@ def read_deferred_data_element(
         fp.close()
     if elem.VR != raw_data_elem.VR:
         raise ValueError(
-            f"Deferred read VR {elem.VR} does not match original " f"{raw_data_elem.VR}"
+            f"Deferred read VR {elem.VR} does not match original {raw_data_elem.VR}"
         )
 
     if elem.tag != raw_data_elem.tag:

--- a/src/pydicom/multival.py
+++ b/src/pydicom/multival.py
@@ -6,8 +6,6 @@ or any list of items that must all be the same type.
 from typing import overload, Any, cast, TypeVar
 from collections.abc import Iterable, Callable, MutableSequence, Iterator
 
-from pydicom import config
-
 
 T = TypeVar("T")
 Self = TypeVar("Self", bound="ConstrainedList")
@@ -126,7 +124,6 @@ class MultiValue(ConstrainedList):
         self,
         type_constructor: Callable[[Any], T],
         iterable: Iterable[Any],
-        validation_mode: int | None = None,
     ) -> None:
         """Create a new :class:`MultiValue` from an iterable and ensure each
         item in the :class:`MultiValue` has the same type.
@@ -145,24 +142,10 @@ class MultiValue(ConstrainedList):
             the :class:`MultiValue`.
         """
         self._constructor = type_constructor
-        self._valmode = config.settings.reading_validation_mode
-        if validation_mode is not None:
-            self._valmode = validation_mode
 
         super().__init__(iterable)
 
-    def _validate(self, item: Any) -> T:  # type: ignore[type-var]
-        from pydicom.valuerep import DSfloat, DSdecimal, IS
-
-        if self._constructor in (DSfloat, DSdecimal, IS):
-            if item == "":
-                return cast(T, item)
-
-            return self._constructor(  # type: ignore[call-arg]
-                item,
-                validation_mode=self._valmode,
-            )
-
+    def _validate(self, item: Any | T) -> T:
         return self._constructor(item)
 
     def sort(self, *args: Any, **kwargs: Any) -> None:

--- a/src/pydicom/sr/codedict.py
+++ b/src/pydicom/sr/codedict.py
@@ -99,7 +99,7 @@ class _CID_Dict:
                 # See CID 12300 for example
                 codes = ", ".join([f"'{v[0]}'" for v in _matches])
                 raise AttributeError(
-                    f"'{name}' has multiple code matches in CID {self.cid}: " f"{codes}"
+                    f"'{name}' has multiple code matches in CID {self.cid}: {codes}"
                 )
 
             code, val = _matches[0]

--- a/src/pydicom/valuerep.py
+++ b/src/pydicom/valuerep.py
@@ -1362,7 +1362,6 @@ class IS(int):
             newval = ISfloat(val, validation_mode)
 
         # Checks in case underlying int is >32 bits, DICOM does not allow this
-        print(newval, newval < 2**31, validation_mode == config.RAISE)
         if not -(2**31) <= newval < 2**31 and validation_mode == config.RAISE:
             raise OverflowError(
                 "Elements with a VR of IS must have a value between -2**31 "

--- a/src/pydicom/values.py
+++ b/src/pydicom/values.py
@@ -42,7 +42,7 @@ from pydicom.valuerep import PersonName
 _T = TypeVar("_T")
 
 
-def MultiString(
+def multi_string(
     val: str, valtype: Callable[[str], _T] | None = None
 ) -> _T | MutableSequence[_T]:
     """Split a string by delimiters if there are any
@@ -272,7 +272,7 @@ def convert_DS_string(
 
         return value
 
-    return MultiString(num_string.strip(), valtype=pydicom.valuerep.DSclass)
+    return multi_string(num_string.strip(), valtype=pydicom.valuerep.DSclass)
 
 
 def _DT_from_str(value: str) -> DT:
@@ -372,7 +372,7 @@ def convert_IS_string(
 
         return cast("numpy.ndarray", value)
 
-    return MultiString(num_string, valtype=pydicom.valuerep.IS)
+    return multi_string(num_string, valtype=pydicom.valuerep.IS)
 
 
 def convert_numbers(
@@ -523,7 +523,7 @@ def convert_string(
     str or MultiValue of str
         The decoded value(s).
     """
-    return MultiString(byte_string.decode(default_encoding))
+    return multi_string(byte_string.decode(default_encoding))
 
 
 def convert_text(
@@ -690,7 +690,7 @@ def convert_UI(
     """
     # Convert to str and remove any trailing nulls or spaces
     value = byte_string.decode(default_encoding)
-    return MultiString(value.rstrip("\0 "), pydicom.uid.UID)
+    return multi_string(value.rstrip("\0 "), pydicom.uid.UID)
 
 
 def convert_UN(

--- a/src/pydicom/values.py
+++ b/src/pydicom/values.py
@@ -126,7 +126,7 @@ def convert_ATvalue(
     # length > 4
     if length % 4 != 0:
         logger.warning(
-            "Expected length to be multiple of 4 for VR 'AT', " f"got length {length}"
+            f"Expected length to be multiple of 4 for VR 'AT', got length {length}"
         )
         length -= length % 4
     return MultiValue(
@@ -529,9 +529,7 @@ def convert_text(
     as_strings = [handle_value(value) for value in values]
     if len(as_strings) == 1:
         return as_strings[0]
-    return MultiValue(
-        str, as_strings, validation_mode=config.settings.reading_validation_mode
-    )
+    return MultiValue(str, as_strings)
 
 
 def convert_single_string(

--- a/tests/test_multival.py
+++ b/tests/test_multival.py
@@ -5,7 +5,7 @@ import pytest
 
 from pydicom import config
 from pydicom.multival import MultiValue, ConstrainedList
-from pydicom.valuerep import DS, DSfloat, DSdecimal, IS
+from pydicom.valuerep import DS, DSfloat, DSdecimal, IS, ISfloat
 from copy import deepcopy
 
 import sys
@@ -15,13 +15,13 @@ python_version = sys.version_info
 
 class TestMultiValue:
     def testMultiDS(self):
-        """MultiValue: Multi-valued data elements can be created........"""
+        """MultiValue: Multi-valued data elements can be created"""
         multival = MultiValue(DS, ["11.1", "22.2", "33.3"])
         for val in multival:
             assert isinstance(val, DSfloat | DSdecimal)
 
     def testEmptyElements(self):
-        """MultiValue: Empty number string elements are not converted..."""
+        """MultiValue: Empty number string elements are not converted"""
         multival = MultiValue(DSfloat, ["1.0", ""])
         assert 1.0 == multival[0]
         assert "" == multival[1]
@@ -36,14 +36,8 @@ class TestMultiValue:
         assert not multival
         assert 0 == len(multival)
 
-    def testLimits(self):
-        """MultiValue: Raise error if any item outside DICOM limits...."""
-        with pytest.raises(OverflowError):
-            MultiValue(IS, [1, -(2**31) - 1], validation_mode=config.RAISE)
-        # Overflow error not raised for IS out of DICOM valid range
-
     def testAppend(self):
-        """MultiValue: Append of item converts it to required type..."""
+        """MultiValue: Append of item converts it to required type"""
         multival = MultiValue(IS, [1, 5, 10])
         multival.append("5")
         assert isinstance(multival[-1], IS)
@@ -57,7 +51,7 @@ class TestMultiValue:
         assert 7 == multival[1]
 
     def testDeleteIndex(self):
-        """MultiValue: Deleting item at index behaves as expected..."""
+        """MultiValue: Deleting item at index behaves as expected"""
         multival = MultiValue(IS, [1, 5, 10])
         del multival[1]
         assert 2 == len(multival)
@@ -160,7 +154,7 @@ class TestMultiValue:
         assert [1, 7, 8, 2, 3] == mv
 
     def test_iadd(self):
-        """Test += [T, ...]"""
+        """Test += [T, .]"""
         multival = MultiValue(IS, [1, 5, 10])
         multival += ["7", 42]
         assert isinstance(multival[-2], IS)
@@ -170,6 +164,20 @@ class TestMultiValue:
         msg = "An iterable is required"
         with pytest.raises(TypeError, match=msg):
             multival += None
+
+    def test_IS_str(self):
+        """Test IS works OK with empty str"""
+        multival = MultiValue(ISfloat, [1, 2, "", 3, 4])
+        assert multival == [1, 2, "", 3, 4]
+        multival = MultiValue(IS, [1, 2, "", 3, 4])
+        assert multival == [1, 2, "", 3, 4]
+
+    def test_DS_str(self):
+        """Test DS works OK with empty str"""
+        multival = MultiValue(DSfloat, [1, 2, "", 3, 4])
+        assert multival == [1, 2, "", 3, 4]
+        multival = MultiValue(DSdecimal, [1, 2, "", 3, 4])
+        assert multival == [1, 2, "", 3, 4]
 
 
 def test_constrained_list_raises():

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -16,7 +16,7 @@ from pydicom.values import (
     convert_single_string,
     convert_AE_string,
     convert_PN,
-    MultiString,
+    multi_string,
 )
 from pydicom.valuerep import VR
 
@@ -285,20 +285,20 @@ def test_all_converters():
 
 
 def test_multistring():
-    """Tests for MultiString"""
+    """Tests for multi_string"""
     # Test stripping trailing nulls and spaces
-    value = MultiString("abjoaisj\\afsdfa\\aasdf \x00  \x00\x00   ")
+    value = multi_string("abjoaisj\\afsdfa\\aasdf \x00  \x00\x00   ")
     assert value == ["abjoaisj", "afsdfa", "aasdf"]
-    value = MultiString("abjoaisj\\afsdfa\\\x00 \x00  \x00\x00   ")
+    value = multi_string("abjoaisj\\afsdfa\\\x00 \x00  \x00\x00   ")
     assert value == ["abjoaisj", "afsdfa", ""]
-    value = MultiString("  \x00abjoaisj \\ afsdfa\\\x00 \x00  \x00\x00   ")
+    value = multi_string("  \x00abjoaisj \\ afsdfa\\\x00 \x00  \x00\x00   ")
     assert value == ["  \x00abjoaisj ", " afsdfa", ""]
     # Test default constructor
     assert isinstance(value[0], str)
     # Test supplied constructor
-    value = MultiString("1.2.3.4\\5.6.7.8", UID)
+    value = multi_string("1.2.3.4\\5.6.7.8", UID)
     assert value == ["1.2.3.4", "5.6.7.8"]
     assert all(isinstance(x, UID) for x in value)
     # Test single item
-    value = MultiString("aasdf \x00  \x00\x00   ")
+    value = multi_string("aasdf \x00  \x00\x00   ")
     assert value == "aasdf"


### PR DESCRIPTION
#### Describe the changes
* Refactor `MultiValue` to remove `validation_mode` and `DSfloat`, `DSdecimal`, `ISfloat` special behaviour
* Rename `MultiString` to `multi_string`, refactor to remove `validation_mode`, simplify it and move to `values` where it's actually used
  *  Used [here](https://github.com/pydicom/pydicom/blob/b54036985c6ef38b92da201234ff7c1d0abbe678/src/pydicom/values.py#L245), [here](https://github.com/pydicom/pydicom/blob/b54036985c6ef38b92da201234ff7c1d0abbe678/src/pydicom/values.py#L345), [here](https://github.com/pydicom/pydicom/blob/b54036985c6ef38b92da201234ff7c1d0abbe678/src/pydicom/values.py#L496), [here](https://github.com/pydicom/pydicom/blob/b54036985c6ef38b92da201234ff7c1d0abbe678/src/pydicom/values.py#L665) (none pass `validation_mode` arg)
* Change `ISfloat("")` to return `""` in line with the other class constructors

##### Benchmark
```python
import time
from pydicom.dataelem import DataElement

elem = DataElement(0x00100010, "PN", "Foo")

for value in ("Foo", ["Foo"], ["Foo", "Foo"]):
    start = time.perf_counter()
    for _ in range(1000000):
        elem.value = value

    print(f"{time.perf_counter() - start:.2f} s")
```
```
main
VM 1: 4.04 s
VM 1 (list): 3.68 s
VM 2: 10.38 s

dev-multivalue
VM 1: 3.49 s  # due to changing away from exception
VM 1 (list): 3.67 s
VM 2: 7.93 s  # due to refactor of MultiValue
```

The only real change is that creating a `MultiValue` directly with `DSfloat`, `DSdecimal` and `ISfloat` no longer gets validated, but the same thing is already true for all other VR types (and `MultiValue` is usually used through `DataElement`).

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
