### PR TITLE
[MRG] Refactor filebase

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -49,6 +49,9 @@ Changes
   use :func:`~pydicom.filewriter.write_dataset` instead.
 * The :attr:`~pydicom.dataset.FileDataset.file_meta` elements are no longer
   modified when writing
+* :class:`~pydicom.filebase.DicomIO` now requires a readable or writeable buffer
+  during initialisation and :class:`~pydicom.filebase.DicomBytesIO` directly
+  inherits from it.
 
 Removals
 ~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ ignore_missing_imports = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
+disable_error_code = ["method-assign"]
 
 [[tool.mypy.overrides]]
 # 2023-06: mypy complains for a line in this file if ignore used or not.

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -64,7 +64,7 @@ from pydicom.datadict import (
 )
 from pydicom.dataelem import DataElement, DataElement_from_raw, RawDataElement
 from pydicom.encaps import encapsulate, encapsulate_extended
-from pydicom.filebase import WriteableBuffer
+from pydicom.filebase import ReadableBuffer, WriteableBuffer
 from pydicom.fileutil import path_from_pathlike, PathType
 from pydicom.misc import warn_and_log
 from pydicom.pixel_data_handlers.util import (
@@ -2975,7 +2975,7 @@ class FileDataset(Dataset):
 
     def __init__(
         self,
-        filename_or_obj: PathType | BinaryIO,
+        filename_or_obj: PathType | BinaryIO | ReadableBuffer,
         dataset: _DatasetType,
         preamble: bytes | None = None,
         file_meta: Optional["FileMetaDataset"] = None,
@@ -2986,9 +2986,12 @@ class FileDataset(Dataset):
 
         Parameters
         ----------
-        filename_or_obj : str or PathLike or BytesIO or None
-            Full path and filename to the file, memory buffer object, or
-            ``None`` if is a :class:`io.BytesIO`.
+        filename_or_obj : str, PathLike, file-like or readable buffer
+
+            * :class:`str` or path: the full path to the dataset file
+            * file-like: a file-like object in "rb" mode
+            * readable buffer: an object with ``read()``, ``tell()`` and
+            ``seek()`` methods such as :class:`io.BytesIO`.
         dataset : Dataset or dict
             Some form of dictionary, usually a :class:`Dataset` returned from
             :func:`~pydicom.filereader.dcmread`.
@@ -3025,22 +3028,22 @@ class FileDataset(Dataset):
         self.filename: PathType | BinaryIO = ""
 
         if isinstance(filename_or_obj, str):
+            # Path to the dataset file
             filename = filename_or_obj
             self.fileobj_type = open
         elif isinstance(filename_or_obj, io.BufferedReader):
+            # File-like in "rb" mode such as open(..., "rb")
             filename = filename_or_obj.name
             # This is the appropriate constructor for io.BufferedReader
             self.fileobj_type = open
         else:
-            # use __class__ python <2.7?;
-            # https://docs.python.org/3/reference/datamodel.html
-            self.fileobj_type = filename_or_obj.__class__
+            # Readable buffer with read(), seek() and tell() methods
+            self.fileobj_type = type(filename_or_obj)
             if hasattr(filename_or_obj, "name"):
                 filename = filename_or_obj.name
             elif hasattr(filename_or_obj, "filename"):
                 filename = filename_or_obj.filename
             else:
-                # e.g. came from BytesIO or something file-like
                 self.filename = filename_or_obj
 
         self.timestamp = None

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -44,8 +44,6 @@ from typing import (
     overload,
 )
 
-from pydicom.filebase import DicomFileLike
-
 try:
     import numpy
 except ImportError:
@@ -66,6 +64,7 @@ from pydicom.datadict import (
 )
 from pydicom.dataelem import DataElement, DataElement_from_raw, RawDataElement
 from pydicom.encaps import encapsulate, encapsulate_extended
+from pydicom.filebase import WriteableBuffer
 from pydicom.fileutil import path_from_pathlike, PathType
 from pydicom.misc import warn_and_log
 from pydicom.pixel_data_handlers.util import (
@@ -2312,7 +2311,7 @@ class Dataset:
 
     def save_as(
         self,
-        filename: "str | os.PathLike[AnyStr] | BinaryIO",
+        filename: str | os.PathLike[AnyStr] | BinaryIO | WriteableBuffer,
         /,
         __write_like_original: bool | None = None,
         *,
@@ -2353,7 +2352,9 @@ class Dataset:
         Parameters
         ----------
         filename : str | PathLike | BinaryIO
-            The path, file-like or buffer to write the encoded dataset to.
+            The path, file-like or writeable buffer to write the encoded
+            dataset to. If using a buffer it must have ``write()``, ``seek()``
+            and ``tell()`` methods.
         write_like_original : bool, optional
             If ``True`` (default) then write the dataset as-is, otherwise
             ensure that the dataset is written in the DICOM File Format or
@@ -2974,7 +2975,7 @@ class FileDataset(Dataset):
 
     def __init__(
         self,
-        filename_or_obj: PathType | BinaryIO | DicomFileLike,
+        filename_or_obj: PathType | BinaryIO,
         dataset: _DatasetType,
         preamble: bytes | None = None,
         file_meta: Optional["FileMetaDataset"] = None,

--- a/src/pydicom/fileutil.py
+++ b/src/pydicom/fileutil.py
@@ -7,7 +7,7 @@ from typing import BinaryIO, cast
 from pydicom.misc import size_in_bytes
 from pydicom.tag import TupleTag, Tag, SequenceDelimiterTag, ItemTag, BaseTag
 from pydicom.datadict import dictionary_description
-from pydicom.filebase import DicomFileLike
+from pydicom.filebase import ReadableBuffer, WriteableBuffer
 
 from pydicom.config import logger
 
@@ -420,7 +420,7 @@ def length_of_undefined_length(
 
 
 def path_from_pathlike(
-    file_object: PathType | BinaryIO | DicomFileLike,
+    file_object: PathType | BinaryIO | ReadableBuffer | WriteableBuffer,
 ) -> str | BinaryIO:
     """Returns the path if `file_object` is a path-like object, otherwise the
     original `file_object`.

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -11,7 +11,7 @@ from pydicom import config
 from pydicom.charset import default_encoding, convert_encodings, encode_string
 from pydicom.dataelem import DataElement_from_raw, DataElement, RawDataElement
 from pydicom.dataset import Dataset, validate_file_meta, FileMetaDataset
-from pydicom.filebase import DicomFile, DicomFileLike, DicomBytesIO, DicomIO
+from pydicom.filebase import DicomFile, DicomBytesIO, DicomIO, WriteableBuffer
 from pydicom.fileutil import path_from_pathlike, PathType
 from pydicom.misc import warn_and_log
 from pydicom.multival import MultiValue
@@ -722,7 +722,10 @@ def write_dataset(
     # TODO: Update in v4.0
     # In order of encoding priority
 
-    fp_encoding: EncodingType = (fp.is_implicit_VR, fp.is_little_endian)
+    fp_encoding: EncodingType = (
+        getattr(fp, "_implicit_vr", None),
+        getattr(fp, "_little_endian", None),
+    )
     ds_encoding: EncodingType = (None, None)
     if not config._use_future:
         ds_encoding = (dataset.is_implicit_VR, dataset.is_little_endian)
@@ -1054,7 +1057,7 @@ def _determine_encoding(
 
 
 def dcmwrite(
-    filename: PathType | BinaryIO | DicomFileLike,
+    filename: PathType | BinaryIO | WriteableBuffer,
     dataset: Dataset,
     /,
     __write_like_original: bool | None = None,
@@ -1066,7 +1069,7 @@ def dcmwrite(
     **kwargs: Any,
 ) -> None:
     """Write `dataset` to `filename`, which can be a path, a file-like or a
-    buffer.
+    writeable buffer.
 
     .. versionchanged:: 3.0
 
@@ -1162,8 +1165,10 @@ def dcmwrite(
 
     Parameters
     ----------
-    filename : str or PathLike or file-like
-        File path, file-like or buffer to write the encoded `dataset` to.
+    filename : str, PathLike, file-like or writeable buffer
+        File path, file-like or writeable buffer to write the encoded `dataset`
+        to. If using a writeable buffer it must have ``write()``, ``seek()``
+        and ``tell()`` methods.
     dataset : pydicom.dataset.FileDataset
         The dataset to be encoded.
     write_like_original : bool, optional
@@ -1259,7 +1264,7 @@ def dcmwrite(
     cls_name = dataset.__class__.__name__
 
     # Check for disallowed tags
-    bad_tags = [x >> 16 for x in dataset._dict if x >> 16 in (0, 2)]
+    bad_tags = [group for x in dataset._dict if (group := x >> 16) in (0, 2)]
     if bad_tags:
         if 0 in bad_tags:
             raise ValueError(
@@ -1357,17 +1362,22 @@ def dcmwrite(
     # Open file if not already a file object
     filename = path_from_pathlike(filename)
     if isinstance(filename, str):
-        fp = DicomFile(filename, "wb")
+        # A path-like to be written to
+        fp: DicomIO = DicomFile(filename, "wb")
         # caller provided a file name; we own the file handle
         caller_owns_file = False
+    elif isinstance(filename, DicomIO):
+        # A wrapped writeable buffer, don't wrap it again
+        fp = filename
     else:
+        # Anything else
         try:
-            fp = DicomFileLike(filename)
-        except AttributeError:
+            fp = DicomIO(filename)
+        except AttributeError as exc:
             raise TypeError(
-                "dcmwrite: Expected a file path or a file-like, "
+                "dcmwrite: Expected a file path, file-like or writeable buffer, "
                 f"but got {type(filename).__name__}"
-            )
+            ) from exc
 
     # Set the encoding of the buffer/file-like
     fp.is_implicit_VR, fp.is_little_endian = encoding
@@ -1391,9 +1401,7 @@ def dcmwrite(
 
             # Compress the encoded data and write to file
             compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
-            deflated = bytearray(
-                compressor.compress(buffer.parent.getvalue())  # type: ignore[union-attr]
-            )
+            deflated = bytearray(compressor.compress(buffer.getvalue()))
             deflated += compressor.flush()
             fp.write(deflated)
             if len(deflated) % 2:

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -1264,7 +1264,7 @@ def dcmwrite(
     cls_name = dataset.__class__.__name__
 
     # Check for disallowed tags
-    bad_tags = [group for x in dataset._dict if (group := x >> 16) in (0, 2)]
+    bad_tags = [x >> 16 for x in dataset._dict if x >> 16 in (0, 2)]
     if bad_tags:
         if 0 in bad_tags:
             raise ValueError(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -115,8 +115,6 @@ class TestDataset:
         ds2.BeamSequence[0].BeamNumber = "2"
         assert ds2 != ds1
 
-        fp.close()
-
     def test_attribute_error_in_property_correct_debug(self):
         """Test AttributeError in property raises correctly."""
 

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1058,7 +1058,7 @@ class TestDatasetCompress:
         ds.PixelData = None
         ds._pixel_array = None
         ds.compress(RLELossless, arr, encoding_plugin="pydicom")
-        assert id(ds.pixel_array) != id(arr)
+        assert arr is not ds.pixel_array
         assert np.array_equal(arr, ds.pixel_array)
 
     def test_planar_configuration(self):

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -805,12 +805,18 @@ class TestReader:
             dcmread("InvalidFilePath")
         with pytest.raises(
             TypeError,
-            match="dcmread: Expected a file path or " "a file-like, but got None",
+            match=(
+                "dcmread: Expected a file path, file-like or readable "
+                "buffer, but got NoneType"
+            ),
         ):
             dcmread(None)
         with pytest.raises(
             TypeError,
-            match="dcmread: Expected a file path or " "a file-like, but got int",
+            match=(
+                "dcmread: Expected a file path, file-like or readable "
+                "buffer, but got int"
+            ),
         ):
             dcmread(42)
 

--- a/tests/test_fileset.py
+++ b/tests/test_fileset.py
@@ -149,7 +149,7 @@ def private(dicomdir):
         fp.is_little_endian = True
         write_dataset(fp, ds)
 
-        return fp.parent.getvalue()
+        return fp.getvalue()
 
     def private_record():
         record = Dataset()

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -393,7 +393,7 @@ class TestWriteDataElement:
             fp.is_implicit_VR = is_implicit_VR
             fp.is_little_endian = is_little_endian
             write_data_element(fp, elem)
-            return fp.parent.getvalue()
+            return fp.getvalue()
 
     def test_empty_AT(self):
         """Write empty AT correctly.........."""
@@ -1476,12 +1476,18 @@ class TestDCMWrite:
         ds = dcmread(ct_name)
         with pytest.raises(
             TypeError,
-            match="dcmwrite: Expected a file path or a file-like, but got None",
+            match=(
+                "dcmwrite: Expected a file path, file-like or writeable "
+                "buffer, but got NoneType"
+            ),
         ):
             ds.save_as(None)
         with pytest.raises(
             TypeError,
-            match="dcmwrite: Expected a file path or a file-like, but got int",
+            match=(
+                "dcmwrite: Expected a file path, file-like or writeable "
+                "buffer, but got int"
+            ),
         ):
             ds.save_as(42)
 


### PR DESCRIPTION
#### Describe the changes
* Complete refactor of `DicomIO`, `DicomFileLike` and `DicomBytesIO`
* `DicomIO` completely overhauled to be a better behaved base class (and made faster)
* `DicomFileLike` kept for backwards compatibility (deprecate?), but otherwise identical to `DicomIO`
* `DicomBytesIO` inherits directly from `DicomIO`
* Updated type hints for `dcmwrite()`, `dcmread()`, `Dataset.save_as()` and `FileDataset.__init__()` to be more generic 
* Closes #1395

##### Benchmarks
```python
import time

from pydicom import examples, dcmread, dcmwrite
from pydicom.filebase import DicomBytesIO
from pydicom.data import get_testdata_file

ds = examples.ct
fp = DicomBytesIO()
ds.save_as(fp)
p = get_testdata_file("MR_small.dcm")

for ii in range(5):
    start = time.perf_counter()
    for _ in range(5 * 10**4):
        fp.seek(0)
        dcmread(fp)

    print(f"{time.perf_counter() - start:.1f} s")

# dcmread() from DicomBytesIO()
# main: 14.8, 14.8, 15.0, 14.9, 14.9
# dev-filebase: 14.0, 13.9, 13.9, 13.9, 14.0

for ii in range(5):
    start = time.perf_counter()
    for _ in range(5 * 10**4):
        dcmread(p)

    print(f"{time.perf_counter() - start:.1f} s")

# dcmread() from path
# main: 20.5, 20.5, 20.5, 20.5, 20.4
# dev-filebase: 20.4, 20.4, 20.4, 20.4, 20.4

for ii in range(5):
    start = time.perf_counter()
    for _ in range(10**4):
        fp.seek(0)
        dcmwrite(fp, ds)

    print(f"{time.perf_counter() - start:.1f} s")

# dcmwrite() to DicomBytesIO()
# main: 13.3, 13.2, 13.2, 13.2, 13.4
# dev-filebase: 11.8, 11.8, 11.8, 11.8, 12.1

for ii in range(5):
    start = time.perf_counter()
    for _ in range(10**4):
        dcmwrite("out.dcm", ds)

    print(f"{time.perf_counter() - start:.1f} s")

# dcmwrite() to path
# main: 17.5, 17.5, 17.7, 17.6, 17.6
# dev-filebase: 15.8, 15.3, 15.5, 15.6, 15.6
```

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/4a034fca-cdee-419b-93a3-1cecd97c1ca2/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
