### PR TITLE
[WIP] Performance improvements for reading

### DIFF
--- a/src/pydicom/datadict.py
+++ b/src/pydicom/datadict.py
@@ -283,6 +283,18 @@ def get_entry(tag: TagType) -> tuple[str, str, str, str, str]:
         raise KeyError(f"Tag {tag} not found in DICOM dictionary")
 
 
+def _fast_vr(tag: int) -> str:
+    try:
+        return DicomDictionary[tag][0]
+    except KeyError:
+        if not tag >> 16 % 2 == 1:
+            mask_x = mask_match(tag)
+            if mask_x:
+                return RepeatersDictionary[mask_x][0]
+
+        raise KeyError(f"Tag {tag} not found in DICOM dictionary")
+
+
 def dictionary_is_retired(tag: TagType) -> bool:
     """Return ``True`` if the element corresponding to `tag` is retired.
 


### PR DESCRIPTION
#### Describe the changes
Improves reading performance

##### Benchmarks
```python
import time

from pydicom import dcmread
from pydicom.filebase import DicomBytesIO
from pydicom.data import get_testdata_file

p = get_testdata_file("MR_small.dcm") # explicit VR
p = get_testdata_file("MR_small_implicit.dcm") # implicit VR
ds = dcmread(p)
fp = DicomBytesIO()
ds.save_as(fp)

for ii in range(5):
    start = time.perf_counter()
    for _ in range(10**4):
        fp.seek(0)
        dcmread(fp)

    print(f"{time.perf_counter() - start:.1f} s")

# dcmread() from DicomBytesIO()
# main
# implicit: 7.0, 6.9, 6.9, 6.9, 6.9
# explicit: 8.6, 8.5, 8.5, 8.5, 8.5

# perf-read
# implicit: 5.6, 5.5, 5.5, 5.5, 5.5
# explicit: 7.1, 6.9, 6.9, 6.9, 6.9
```

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
