### PR TITLE
[MRG] Fix encapsulate_extended() for odd length frames

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -132,6 +132,8 @@ Fixes
   :class:`~pydicom.fileset.FileSet` (:issue:`1922`)
 * Fixed an ``AttributeError`` when running :py:func:`~copy.deepcopy` after
   :meth:`Dataset.update<pydicom.dataset.Dataset.update>` (:issue:`1816`)
+* Fixed :func:`~pydicom.encaps.encapsulate_extended` not returning the correct
+  values for odd-length frames (:issue:`1968`)
 
 Pydicom Internals
 -----------------

--- a/src/pydicom/encaps.py
+++ b/src/pydicom/encaps.py
@@ -792,6 +792,8 @@ def encapsulate_extended(frames: list[bytes]) -> tuple[bytes, bytes, bytes]:
     """
     nr_frames = len(frames)
     frame_lengths = [len(frame) for frame in frames]
+    # Odd-length frames get padded to even length by `encapsulate()`
+    frame_lengths = [ii + 1 if ii % 2 else ii for ii in frame_lengths]
     frame_offsets = [0]
     for ii, length in enumerate(frame_lengths[:-1]):
         # Extra 8 bytes for the Item tag and length

--- a/tests/test_encaps.py
+++ b/tests/test_encaps.py
@@ -1328,3 +1328,10 @@ class TestEncapsulateExtended:
         # Extended Offset Table Lengths are OK
         assert isinstance(out[2], bytes)
         assert [len(f) for f in frames] == list(unpack("<10Q", out[2]))
+
+    def test_encapsulate_odd_length(self):
+        """Test encapsulating odd-length frames"""
+        frames = [b"\x00", b"\x01", b"\x02"]
+        eot_encapsulated, eot, eot_lengths = encapsulate_extended(frames)
+        assert unpack(f'<{len(frames)}Q', eot) == (0, 10, 20)
+        assert unpack(f'<{len(frames)}Q', eot_lengths) == (2, 2, 2)

--- a/tests/test_encaps.py
+++ b/tests/test_encaps.py
@@ -1333,5 +1333,5 @@ class TestEncapsulateExtended:
         """Test encapsulating odd-length frames"""
         frames = [b"\x00", b"\x01", b"\x02"]
         eot_encapsulated, eot, eot_lengths = encapsulate_extended(frames)
-        assert unpack(f'<{len(frames)}Q', eot) == (0, 10, 20)
-        assert unpack(f'<{len(frames)}Q', eot_lengths) == (2, 2, 2)
+        assert unpack(f"<{len(frames)}Q", eot) == (0, 10, 20)
+        assert unpack(f"<{len(frames)}Q", eot_lengths) == (2, 2, 2)


### PR DESCRIPTION
#### Describe the changes
Fixes `encapsulate_extended()` returning incorrect values for odd-length frames, closes #1968

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
