### PR TITLE
[MRG] Fix handlers not working with multiple fragments per frame

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -134,6 +134,8 @@ Fixes
   :meth:`Dataset.update<pydicom.dataset.Dataset.update>` (:issue:`1816`)
 * Fixed :func:`~pydicom.encaps.encapsulate_extended` not returning the correct
   values for odd-length frames (:issue:`1968`)
+* Fixed the ``jpeg_ls``, ``pillow`` and ``rle`` pixel data handlers not working
+  correctly when a frame is spread across multiple fragments (:issue:`1774`)
 
 Pydicom Internals
 -----------------

--- a/src/pydicom/pixel_data_handlers/pylibjpeg_handler.py
+++ b/src/pydicom/pixel_data_handlers/pylibjpeg_handler.py
@@ -258,7 +258,7 @@ def generate_frames(ds: "Dataset", reshape: bool = True) -> Iterable["np.ndarray
     if missing:
         raise AttributeError(
             "Unable to convert the pixel data as the following required "
-            "elements are missing from the dataset: " + ", ".join(missing)
+            f"elements are missing from the dataset: {', '.join(missing)}"
         )
 
     decoder = _DECODERS[tsyntax]

--- a/tests/test_JPEG_LS_transfer_syntax.py
+++ b/tests/test_JPEG_LS_transfer_syntax.py
@@ -3,15 +3,16 @@
 import os
 import sys
 import pytest
+
 import pydicom
 from pydicom.filereader import dcmread
 from pydicom.data import get_testdata_file
 
-pillow_missing_message = "pillow is not available " "in this test environment"
+pillow_missing_message = "pillow is not available in this test environment"
 pillow_present_message = "pillow is being tested"
 gdcm_missing_message = "GDCM is not available in this test environment"
-numpy_missing_message = "numpy is not available " "in this test environment"
-jpeg_ls_missing_message = "jpeg_ls is not available " "in this test environment"
+numpy_missing_message = "numpy is not available in this test environment"
+jpeg_ls_missing_message = "jpeg_ls is not available in this test environment"
 
 
 try:

--- a/tests/test_JPEG_LS_transfer_syntax.py
+++ b/tests/test_JPEG_LS_transfer_syntax.py
@@ -3,16 +3,15 @@
 import os
 import sys
 import pytest
-
 import pydicom
 from pydicom.filereader import dcmread
 from pydicom.data import get_testdata_file
 
-pillow_missing_message = "pillow is not available in this test environment"
+pillow_missing_message = "pillow is not available " "in this test environment"
 pillow_present_message = "pillow is being tested"
 gdcm_missing_message = "GDCM is not available in this test environment"
-numpy_missing_message = "numpy is not available in this test environment"
-jpeg_ls_missing_message = "jpeg_ls is not available in this test environment"
+numpy_missing_message = "numpy is not available " "in this test environment"
+jpeg_ls_missing_message = "jpeg_ls is not available " "in this test environment"
 
 
 try:

--- a/tests/test_jpeg_ls_pixel_data.py
+++ b/tests/test_jpeg_ls_pixel_data.py
@@ -4,7 +4,11 @@
 import os
 import sys
 
-import numpy as np
+try:
+    import numpy as np
+    HAVE_NP = True
+except ImportError:
+    HAVE_NP = False
 
 import pytest
 
@@ -183,6 +187,7 @@ class TestJPEGLS_JPEG_LS_with_jpeg_ls:
         b = self.emri_small.pixel_array
         assert b.mean() == a.mean()
 
+    @pytest.mark.skipif(not HAVE_NP, reason="Numpy not available")
     def test_frame_multiple_fragments(self):
         """Test a frame split across multiple fragments."""
         ds = dcmread(jpeg_ls_lossless_name)

--- a/tests/test_jpeg_ls_pixel_data.py
+++ b/tests/test_jpeg_ls_pixel_data.py
@@ -6,6 +6,7 @@ import sys
 
 try:
     import numpy as np
+
     HAVE_NP = True
 except ImportError:
     HAVE_NP = False

--- a/tests/test_pillow_pixel_data.py
+++ b/tests/test_pillow_pixel_data.py
@@ -4,7 +4,7 @@ import pytest
 
 import pydicom
 from pydicom.data import get_testdata_file
-from pydicom.encaps import defragment_data
+from pydicom.encaps import defragment_data, generate_pixel_data_frame, encapsulate
 from pydicom.filereader import dcmread
 from pydicom.pixel_data_handlers.util import convert_color_space, get_j2k_parameters
 from pydicom.uid import (
@@ -682,8 +682,8 @@ class TestPillowHandler_JPEG:
         """Test decoding JPEG lossy with pillow handler fails."""
         ds = dcmread(JPGE_16_12_1_0_1F_M2)
         msg = (
-            r"1.2.840.10008.1.2.4.51 - JPEG Extended \(Process 2 and 4\) only "
-            r"supported by Pillow if Bits Allocated = 8"
+            r"1.2.840.10008.1.2.4.51 - JPEG Extended \(Process 2 and 4\) is only "
+            r"supported by Pillow if \(0028,0100\) Bits Allocated = 8"
         )
         with pytest.raises(NotImplementedError, match=msg):
             ds.pixel_array
@@ -701,3 +701,11 @@ class TestPillowHandler_JPEG:
         pixel_data = ds.pixel_array
         assert pixel_data.nbytes == 27
         assert pixel_data.shape == (3, 3, 3)
+
+    def test_frame_multiple_fragments(self):
+        """Test a frame split across multiple fragments."""
+        ds = dcmread(JPGB_08_08_3_0_120F_YBR_FULL_422)
+        ref = ds.pixel_array
+        frames = [f for f in generate_pixel_data_frame(ds.PixelData, ds.NumberOfFrames)]
+        ds.PixelData = encapsulate(frames, fragments_per_frame=4)
+        assert np.array_equal(ds.pixel_array, ref)

--- a/tests/test_rle_pixel_data.py
+++ b/tests/test_rle_pixel_data.py
@@ -29,7 +29,7 @@ import pytest
 from pydicom import dcmread
 import pydicom.config
 from pydicom.data import get_testdata_file
-from pydicom.encaps import defragment_data
+from pydicom.encaps import defragment_data, generate_pixel_data_frame, encapsulate
 from pydicom.uid import RLELossless, AllTransferSyntaxes
 
 try:
@@ -717,6 +717,15 @@ class TestNumpy_RLEHandler:
 
         # Frame 2 is frame 1 inverted
         assert np.array_equal((2**ds.BitsAllocated - 1) - arr[1], arr[0])
+
+    def test_frame_multiple_fragments(self):
+        """Test a frame split across multiple fragments."""
+        ds = dcmread(RLE_8_1_2F)
+        ref = ds.pixel_array
+
+        frames = [f for f in generate_pixel_data_frame(ds.PixelData, ds.NumberOfFrames)]
+        ds.PixelData = encapsulate(frames, fragments_per_frame=4)
+        assert np.array_equal(ds.pixel_array, ref)
 
 
 # Tests for rle_handler module with Numpy available


### PR DESCRIPTION
#### Describe the changes
* Switches pixel data handlers to use `generate_pixel_data_frames`
* Closes #1774, however the underlying issue with `decode_data_sequence` remains

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
