### PR TITLE
[MRG] Enhancements for encaps module

### DIFF
--- a/doc/reference/encaps.rst
+++ b/doc/reference/encaps.rst
@@ -19,9 +19,14 @@ Parsing Encapsulated Data
    generate_pixel_data
    generate_pixel_data_fragment
    generate_pixel_data_frame
-   get_frame
    get_frame_offsets
    read_item
+   parse_basic_offsets
+   parse_fragments
+   generate_fragments
+   generate_fragmented_frames
+   generate_frames
+   get_frame
 
 Creating Encapsulated Data
 --------------------------

--- a/doc/reference/encaps.rst
+++ b/doc/reference/encaps.rst
@@ -19,6 +19,7 @@ Parsing Encapsulated Data
    generate_pixel_data
    generate_pixel_data_fragment
    generate_pixel_data_frame
+   get_frame
    get_frame_offsets
    read_item
 

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -22,11 +22,11 @@ This API reference guide details the functions, modules and objects included in
    dataset
    elem
    examples
-   handlers
-   encoders
-   fileset
    encaps
+   encoders
    errors
    fileio
+   fileset
+   handlers
    misc
    uid

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -119,6 +119,12 @@ Enhancements
   syntaxes to :class:`~pydicom.uid.UID` via the :meth:`~pydicom.uid.UID.set_private_encoding`
   method
 * Warning messages are also sent to the pydicom logger (:issue:`1529`)
+* Added :func:`~pydicom.encaps.get_frame` to make it easier to get the
+  encapsulated pixel data for a given frame
+* Added `extended_offsets` and `little_endian` keyword parameters to
+  :func:`~pydicom.encaps.generate_pixel_data` and
+  :func:`~pydicom.encaps.generate_pixel_data_frame` and made `number_of_frames`
+  keyword only
 
 Fixes
 -----

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -147,9 +147,9 @@ Enhancements
 
   These new functions support reading encapsulated data from both :class:`bytes`
   or any Python object with ``read()``, ``seek()`` and ``tell()`` methods such
-  as :class:`typing.BinaryIO` or :class:`mmap.mmap`. They also support using the
-  :dcm:`Extended Offset Table<part03/sect_C.7.6.3.html#sect_C.7.6.3.1.8>` for
-  determining frame boundaries.
+  as :class:`io.BytesIO`, :class:`BinaryIO<typing.BinaryIO>` or :class:`mmap.mmap`.
+  They also support using the :dcm:`Extended Offset Table<part03/sect_C.7.6.3.html#sect_C.7.6.3.1.8>`
+  for determining frame boundaries.
 
 
 Fixes
@@ -175,22 +175,20 @@ Fixes
 
 Deprecations
 ------------
-* :attr:`~pydicom.dataset.Dataset.is_little_endian` and
-  :attr:`~pydicom.dataset.Dataset.is_implicit_VR` will be removed in v4.0
-* :attr:`~pydicom.dataset.Dataset.read_little_endian` and
-  :attr:`~pydicom.dataset.Dataset.read_implicit_vr` will be removed in v4.0,
-  use :attr:`~pydicom.dataset.Dataset.original_encoding` instead
-* :attr:`~pydicom.dataset.Dataset.read_encoding` will be removed in v4.0,
-  use :attr:`~pydicom.dataset.Dataset.original_character_set` instead
+* :attr:`Dataset.is_little_endian <pydicom.dataset.Dataset.is_little_endian>` and
+  :attr:`Dataset.is_implicit_VR<pydicom.dataset.Dataset.is_implicit_VR>` will be removed in v4.0
+* :attr:`Dataset.read_little_endian<pydicom.dataset.Dataset.read_little_endian>` and
+  :attr:`Dataset.read_implicit_vr<pydicom.dataset.Dataset.read_implicit_vr>` will be removed in v4.0,
+  use :attr:`Dataset.original_encoding<pydicom.dataset.Dataset.original_encoding>` instead
+* :attr:`Dataset.read_encoding<pydicom.dataset.Dataset.read_encoding>` will be removed in v4.0,
+  use :attr:`Dataset.original_character_set<pydicom.dataset.Dataset.original_character_set>` instead
 * The `write_like_original` optional argument to
-  :meth:`~pydicom.dataset.Dataset.save_as` and
+  :meth:`Dataset.save_as<pydicom.dataset.Dataset.save_as>` and
   :func:`~pydicom.filewriter.dcmwrite` will be removed in v4.0, use
   `enforce_file_format` instead
-* The following :mod:`~pydicom.encaps` module functions will be removed in v4.0
+* The following :mod:`~pydicom.encaps` module functions will be removed in v4.0:
 
   * :func:`~pydicom.encaps.get_frame_offsets`, use :func:`~pydicom.encaps.parse_basic_offsets`
-    instead
-  * :func:`~pydicom.encaps.get_nr_fragments`, use :func:`~pydicom.encaps.parse_fragments`
     instead
   * :func:`~pydicom.encaps.generate_pixel_data_fragment`, use :func:`~pydicom.encaps.generate_fragments`
     instead

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -133,8 +133,6 @@ Enhancements
   syntaxes to :class:`~pydicom.uid.UID` via the :meth:`~pydicom.uid.UID.set_private_encoding`
   method
 * Warning messages are also sent to the pydicom logger (:issue:`1529`)
-* Added :func:`~pydicom.encaps.get_frame` to make it easier to get the
-  encapsulated pixel data for a given frame
 * Added the following to the :mod:`~pydicom.encaps` module:
 
   * :func:`~pydicom.encaps.parse_basic_offsets` for parsing the Basic Offset Table
@@ -144,7 +142,8 @@ Enhancements
   * :func:`~pydicom.encaps.generate_fragmented_frames` for yielding encapsulated frame
     fragments
   * :func:`~pydicom.encaps.generate_frames` for yielding whole encapsulated frames
-  * :func:`~pydicom.encaps.get_item` for returning the specific encapsulated frame at `index`
+  * :func:`~pydicom.encaps.get_frame` for returning the specific encapsulated frame at `index`
+    without necessarily having to read the preceding frames into memory
 
   These new functions support reading encapsulated data from both :class:`bytes`
   or any Python object with ``read()``, ``seek()`` and ``tell()`` methods such

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -135,10 +135,22 @@ Enhancements
 * Warning messages are also sent to the pydicom logger (:issue:`1529`)
 * Added :func:`~pydicom.encaps.get_frame` to make it easier to get the
   encapsulated pixel data for a given frame
-* Added `extended_offsets` and `little_endian` keyword parameters to
-  :func:`~pydicom.encaps.generate_pixel_data` and
-  :func:`~pydicom.encaps.generate_pixel_data_frame` and made `number_of_frames`
-  keyword only
+* Added the following to the :mod:`~pydicom.encaps` module:
+
+  * :func:`~pydicom.encaps.parse_basic_offsets` for parsing the Basic Offset Table
+  * :func:`~pydicom.encaps.parse_fragments` for determining the number of encapsulated
+    fragments and their byte offsets
+  * :func:`~pydicom.encaps.generate_fragments` for yielding encapsulated fragments
+  * :func:`~pydicom.encaps.generate_fragmented_frames` for yielding encapsulated frame
+    fragments
+  * :func:`~pydicom.encaps.generate_frames` for yielding whole encapsulated frames
+  * :func:`~pydicom.encaps.get_item` for returning the specific encapsulated frame at `index`
+
+  These new functions support reading encapsulated data from both :class:`bytes`
+  or any Python object with ``read()``, ``seek()`` and ``tell()`` methods such
+  as :class:`typing.BinaryIO` or :class:`mmap.mmap`. They also support using the
+  :dcm:`Extended Offset Table<part03/sect_C.7.6.3.html#sect_C.7.6.3.1.8>` for
+  determining frame boundaries.
 
 
 Fixes
@@ -160,7 +172,7 @@ Fixes
   explicit and implicit VR when only the *Transfer Syntax UID* was changed (:issue:`1943`)
 * Fixed the ``jpeg_ls``, ``pillow`` and ``rle`` pixel data handlers not working
   correctly when a frame is spread across multiple fragments (:issue:`1774`)
-  
+
 
 Deprecations
 ------------
@@ -175,6 +187,24 @@ Deprecations
   :meth:`~pydicom.dataset.Dataset.save_as` and
   :func:`~pydicom.filewriter.dcmwrite` will be removed in v4.0, use
   `enforce_file_format` instead
+* The following :mod:`~pydicom.encaps` module functions will be removed in v4.0
+
+  * :func:`~pydicom.encaps.get_frame_offsets`, use :func:`~pydicom.encaps.parse_basic_offsets`
+    instead
+  * :func:`~pydicom.encaps.get_nr_fragments`, use :func:`~pydicom.encaps.parse_fragments`
+    instead
+  * :func:`~pydicom.encaps.generate_pixel_data_fragment`, use :func:`~pydicom.encaps.generate_fragments`
+    instead
+  * :func:`~pydicom.encaps.generate_pixel_data_frame`, use :func:`~pydicom.encaps.generate_fragmented_frames`
+    instead
+  * :func:`~pydicom.encaps.generate_pixel_data`, use :func:`~pydicom.encaps.generate_frames`
+    instead
+  * :func:`~pydicom.encaps.decode_data_sequence`, use :func:`~pydicom.encaps.generate_fragments`
+    instead
+  * :func:`~pydicom.encaps.defragment_data`, use :func:`~pydicom.encaps.generate_frames`
+    instead
+  * :func:`~pydicom.encaps.read_item`, use :func:`~pydicom.encaps.generate_fragments`
+    instead
 
 
 Pydicom Internals

--- a/src/pydicom/encaps.py
+++ b/src/pydicom/encaps.py
@@ -45,10 +45,6 @@ def parse_basic_offsets(
     fragment of each frame as measured from the first byte of the first item
     tag following the Basic Offset Table Item.
 
-    When the total amount of encoded frame data is too large for a 32-byte
-    offset field then it's strongly recommended you use the Extended Offset
-    Table instead (see the :func:`~pydicom.encaps.encapsulate_extended` function).
-
     Parameters
     ----------
     buffer : bytes | readable buffer

--- a/src/pydicom/encaps.py
+++ b/src/pydicom/encaps.py
@@ -16,34 +16,9 @@ from pydicom.tag import Tag, ItemTag, SequenceDelimiterTag
 def parse_basic_offsets(
     buffer: bytes | ReadableBuffer, /, *, endianness: str = "<"
 ) -> list[int]:
-    """Return the basic offset table length and the offsets to each frame.
+    """Return the encapsulated pixel data's basic offset table frame offsets.
 
     .. versionadded:: 3.0
-
-    **Basic Offset Table**
-
-    The Basic Offset Table Item must be present and have a tag (FFFE,E000) and
-    a length, however it may or may not have a value.
-
-    Basic Offset Table with no value::
-
-        Item Tag   | Length    |
-        FE FF 00 E0 00 00 00 00
-
-    Basic Offset Table with value (2 frames)::
-
-        Item Tag   | Length    | Offset 1  | Offset 2  |
-        FE FF 00 E0 08 00 00 00 00 00 00 00 10 00 00 00
-
-    For single or multi-frame images with only one frame, the Basic Offset
-    Table may or may not have a value. When it has no value then its length
-    shall be ``0x00000000``.
-
-    For multi-frame images with more than one frame, the Basic Offset Table
-    should have a value containing concatenated 32-bit unsigned integer values
-    that are the byte offsets to the first byte of the Item tag of the first
-    fragment of each frame as measured from the first byte of the first item
-    tag following the Basic Offset Table Item.
 
     Parameters
     ----------
@@ -59,14 +34,13 @@ def parse_basic_offsets(
 
     Returns
     -------
-    tuple[int, list[int]]
-        The length of the basic offset table in bytes, and a list of the offset
-        positions to the first item tag of each frame, as measured from the
-        end of the offset table.
+    list[int]
+        A list of the offset positions to the first item tag of each frame, as
+        measured from the end of the basic offset table.
 
-    See Also
-    --------
-    :func:`~pydicom.encaps.encapsulate_extended`
+    References
+    ----------
+    :dcm:`DICOM Standard, Part 5, Annex A.4<part05/sect_A.4.html#table_A.4-1>`
     """
     if isinstance(buffer, bytes):
         buffer = BytesIO(buffer)

--- a/src/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/src/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -286,7 +286,9 @@ def get_pixeldata(ds: "Dataset") -> "numpy.ndarray":
     tsyntax = ds.file_meta.TransferSyntaxUID
     if config.APPLY_J2K_CORRECTIONS and tsyntax in [JPEG2000, JPEG2000Lossless]:
         nr_frames = get_nr_frames(ds)
-        codestream = next(generate_pixel_data(ds.PixelData, nr_frames))[0]
+        codestream = next(
+            generate_pixel_data(ds.PixelData, number_of_frames=nr_frames)
+        )[0]
 
         params = get_j2k_parameters(codestream)
         j2k_precision = cast(int, params.setdefault("precision", ds.BitsStored))

--- a/src/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/src/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -116,8 +116,10 @@ def create_data_element(ds: "Dataset") -> "DataElement":
     if tsyntax.is_compressed:
         fragments = gdcm.SequenceOfFragments.New()
         nr_frames = get_nr_frames(ds, warn=False)
-        func = generate_fragmented_frames(ds.PixelData, number_of_frames=nr_frames)
-        for frame_fragments in func:
+        fragment_gen = generate_fragmented_frames(
+            ds.PixelData, number_of_frames=nr_frames
+        )
+        for frame_fragments in fragment_gen:
             for fragment_data in frame_fragments:
                 fragment = gdcm.Fragment()
                 fragment.SetByteStringValue(fragment_data)

--- a/src/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/src/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -286,9 +286,7 @@ def get_pixeldata(ds: "Dataset") -> "numpy.ndarray":
     tsyntax = ds.file_meta.TransferSyntaxUID
     if config.APPLY_J2K_CORRECTIONS and tsyntax in [JPEG2000, JPEG2000Lossless]:
         nr_frames = get_nr_frames(ds)
-        codestream = next(
-            generate_pixel_data(ds.PixelData, number_of_frames=nr_frames)
-        )[0]
+        codestream = next(generate_pixel_data(ds.PixelData, nr_frames))[0]
 
         params = get_j2k_parameters(codestream)
         j2k_precision = cast(int, params.setdefault("precision", ds.BitsStored))

--- a/src/pydicom/pixel_data_handlers/gdcm_handler.py
+++ b/src/pydicom/pixel_data_handlers/gdcm_handler.py
@@ -30,7 +30,7 @@ except ImportError:
     HAVE_GDCM_IN_MEMORY_SUPPORT = False
 
 from pydicom import config
-from pydicom.encaps import generate_pixel_data
+from pydicom.encaps import generate_frames, generate_fragmented_frames
 import pydicom.uid
 from pydicom.uid import UID, JPEG2000, JPEG2000Lossless
 from pydicom.pixel_data_handlers.util import (
@@ -114,16 +114,15 @@ def create_data_element(ds: "Dataset") -> "DataElement":
     tsyntax = ds.file_meta.TransferSyntaxUID
     data_element = gdcm.DataElement(gdcm.Tag(0x7FE0, 0x0010))
     if tsyntax.is_compressed:
-        if get_nr_frames(ds, warn=False) > 1:
-            pixel_data_sequence = pydicom.encaps.decode_data_sequence(ds.PixelData)
-        else:
-            pixel_data_sequence = [pydicom.encaps.defragment_data(ds.PixelData)]
-
         fragments = gdcm.SequenceOfFragments.New()
-        for pixel_data in pixel_data_sequence:
-            fragment = gdcm.Fragment()
-            fragment.SetByteStringValue(pixel_data)
-            fragments.AddFragment(fragment)
+        nr_frames = get_nr_frames(ds, warn=False)
+        func = generate_fragmented_frames(ds.PixelData, number_of_frames=nr_frames)
+        for frame_fragments in func:
+            for fragment_data in frame_fragments:
+                fragment = gdcm.Fragment()
+                fragment.SetByteStringValue(fragment_data)
+                fragments.AddFragment(fragment)
+
         data_element.SetValue(fragments.__ref__())
     else:
         data_element.SetByteStringValue(ds.PixelData)
@@ -286,7 +285,7 @@ def get_pixeldata(ds: "Dataset") -> "numpy.ndarray":
     tsyntax = ds.file_meta.TransferSyntaxUID
     if config.APPLY_J2K_CORRECTIONS and tsyntax in [JPEG2000, JPEG2000Lossless]:
         nr_frames = get_nr_frames(ds)
-        codestream = next(generate_pixel_data(ds.PixelData, nr_frames))[0]
+        codestream = next(generate_frames(ds.PixelData, number_of_frames=nr_frames))
 
         params = get_j2k_parameters(codestream)
         j2k_precision = cast(int, params.setdefault("precision", ds.BitsStored))

--- a/src/pydicom/pixel_data_handlers/jpeg_ls_handler.py
+++ b/src/pydicom/pixel_data_handlers/jpeg_ls_handler.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     HAVE_JPEGLS = False
 
-from pydicom.encaps import generate_pixel_data_frame
+from pydicom.encaps import generate_frames
 from pydicom.pixel_data_handlers.util import pixel_dtype, get_nr_frames
 import pydicom.uid
 
@@ -108,7 +108,7 @@ def get_pixeldata(ds: "Dataset") -> "numpy.ndarray":
     pixel_bytes = bytearray()
 
     nr_frames = get_nr_frames(ds, warn=False)
-    for frame in generate_pixel_data_frame(ds.PixelData, nr_frames):
+    for frame in generate_frames(ds.PixelData, number_of_frames=nr_frames):
         im = jpeg_ls.decode(numpy.frombuffer(frame, dtype="u1"))
         pixel_bytes.extend(im.tobytes())
 

--- a/src/pydicom/pixel_data_handlers/pillow_handler.py
+++ b/src/pydicom/pixel_data_handlers/pillow_handler.py
@@ -29,7 +29,7 @@ except ImportError:
     HAVE_JPEG2K = False
 
 from pydicom import config
-from pydicom.encaps import generate_pixel_data_frame
+from pydicom.encaps import generate_frames
 from pydicom.misc import warn_and_log
 from pydicom.pixel_data_handlers.util import (
     pixel_dtype,
@@ -193,7 +193,7 @@ def get_pixeldata(ds: "Dataset") -> "numpy.ndarray":
 
     pixel_bytes = bytearray()
     j2k_precision, j2k_sign = None, None
-    for frame in generate_pixel_data_frame(ds.PixelData, nr_frames):
+    for frame in generate_frames(ds.PixelData, number_of_frames=nr_frames):
         im = _decompress_single_frame(
             frame, transfer_syntax, photometric_interpretation
         )

--- a/src/pydicom/pixel_data_handlers/pylibjpeg_handler.py
+++ b/src/pydicom/pixel_data_handlers/pylibjpeg_handler.py
@@ -272,7 +272,7 @@ def generate_frames(ds: "Dataset", reshape: bool = True) -> Iterable["np.ndarray
     bits_stored = cast(int, ds.BitsStored)
     bits_allocated = cast(int, ds.BitsAllocated)
 
-    for frame in generate_pixel_data_frame(ds.PixelData, number_of_frames=nr_frames):
+    for frame in generate_pixel_data_frame(ds.PixelData, nr_frames):
         arr = decoder(frame, pixel_module)
 
         if tsyntax in [JPEG2000, JPEG2000Lossless] and config.APPLY_J2K_CORRECTIONS:

--- a/src/pydicom/pixel_data_handlers/pylibjpeg_handler.py
+++ b/src/pydicom/pixel_data_handlers/pylibjpeg_handler.py
@@ -98,7 +98,7 @@ except ImportError:
     HAVE_RLE = False
 
 from pydicom import config
-from pydicom.encaps import generate_pixel_data_frame
+from pydicom.encaps import generate_frames as frame_generator
 from pydicom.pixel_data_handlers.util import (
     pixel_dtype,
     get_expected_length,
@@ -272,7 +272,7 @@ def generate_frames(ds: "Dataset", reshape: bool = True) -> Iterable["np.ndarray
     bits_stored = cast(int, ds.BitsStored)
     bits_allocated = cast(int, ds.BitsAllocated)
 
-    for frame in generate_pixel_data_frame(ds.PixelData, nr_frames):
+    for frame in frame_generator(ds.PixelData, number_of_frames=nr_frames):
         arr = decoder(frame, pixel_module)
 
         if tsyntax in [JPEG2000, JPEG2000Lossless] and config.APPLY_J2K_CORRECTIONS:

--- a/src/pydicom/pixel_data_handlers/pylibjpeg_handler.py
+++ b/src/pydicom/pixel_data_handlers/pylibjpeg_handler.py
@@ -272,7 +272,7 @@ def generate_frames(ds: "Dataset", reshape: bool = True) -> Iterable["np.ndarray
     bits_stored = cast(int, ds.BitsStored)
     bits_allocated = cast(int, ds.BitsAllocated)
 
-    for frame in generate_pixel_data_frame(ds.PixelData, nr_frames):
+    for frame in generate_pixel_data_frame(ds.PixelData, number_of_frames=nr_frames):
         arr = decoder(frame, pixel_module)
 
         if tsyntax in [JPEG2000, JPEG2000Lossless] and config.APPLY_J2K_CORRECTIONS:

--- a/src/pydicom/pixel_data_handlers/rle_handler.py
+++ b/src/pydicom/pixel_data_handlers/rle_handler.py
@@ -46,7 +46,7 @@ try:
 except ImportError:
     HAVE_RLE = False
 
-from pydicom.encaps import generate_pixel_data_frame
+from pydicom.encaps import generate_frames
 from pydicom.misc import warn_and_log
 from pydicom.pixel_data_handlers.util import pixel_dtype, get_nr_frames
 from pydicom.encoders.native import _encode_frame  # noqa: F401
@@ -160,7 +160,7 @@ def get_pixeldata(ds: "Dataset", rle_segment_order: str = ">") -> "np.ndarray":
 
     # Decompress each frame of the pixel data
     pixel_data = bytearray()
-    for frame in generate_pixel_data_frame(ds.PixelData, nr_frames):
+    for frame in generate_frames(ds.PixelData, number_of_frames=nr_frames):
         im = _rle_decode_frame(
             frame, rows, cols, nr_samples, nr_bits, rle_segment_order
         )

--- a/tests/test_encaps.py
+++ b/tests/test_encaps.py
@@ -1387,16 +1387,16 @@ class TestParseBasicOffsets:
         buffer = b"\xFE\xFF\x00\xE1\x08\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08"
         msg = r"Unexpected tag '\(FFFE,E100\)' when parsing the Basic Table Offset item"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             with pytest.raises(ValueError, match=msg):
-                parse_basic_offsets(buffer)
+                parse_basic_offsets(src)
 
         buffer = b"\xFE\xFF\x00\xE1\x08\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08"
         msg = r"Unexpected tag '\(FEFF,00E1\)' when parsing the Basic Table Offset item"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             with pytest.raises(ValueError, match=msg):
-                parse_basic_offsets(buffer, endianness=">")
+                parse_basic_offsets(src, endianness=">")
 
     def test_bad_length_multiple(self):
         """Test raises exception if the item length is not a multiple of 4."""
@@ -1408,9 +1408,9 @@ class TestParseBasicOffsets:
         )
         msg = "The length of the Basic Offset Table item is not a multiple of 4"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             with pytest.raises(ValueError, match=msg):
-                parse_basic_offsets(buffer)
+                parse_basic_offsets(src)
 
         buffer = (
             b"\xFF\xFE\xE0\x00"
@@ -1418,27 +1418,27 @@ class TestParseBasicOffsets:
             b"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             with pytest.raises(ValueError, match=msg):
-                parse_basic_offsets(buffer, endianness=">")
+                parse_basic_offsets(src, endianness=">")
 
     def test_zero_length(self):
         """Test reading BOT with zero length"""
         # Little endian
         buffer = b"\xFE\xFF\x00\xE0\x00\x00\x00\x00"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert [] == parse_basic_offsets(buffer)
+            src = func(buffer)
+            assert [] == parse_basic_offsets(src)
 
-        assert buffer.tell() == 8
+        assert src.tell() == 8
 
         # Big endian
         buffer = b"\xFF\xFE\xE0\x00\x00\x00\x00\x00"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert [] == parse_basic_offsets(buffer, endianness=">")
+            src = func(buffer)
+            assert [] == parse_basic_offsets(src, endianness=">")
 
-        assert buffer.tell() == 8
+        assert src.tell() == 8
 
     def test_multi_frame(self):
         """Test reading multi-frame BOT item"""
@@ -1479,18 +1479,18 @@ class TestParseBasicOffsets:
         # Little endian
         buffer = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x00\x00\x00\x00" b"\xFE\xFF\x00\xE0"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert [0] == parse_basic_offsets(buffer)
+            src = func(buffer)
+            assert [0] == parse_basic_offsets(src)
 
-        assert buffer.tell() == 12
+        assert src.tell() == 12
 
         # Big endian
         buffer = b"\xFF\xFE\xE0\x00\x00\x00\x00\x04\x00\x00\x00\x00" b"\xFF\xFE\xE0\x00"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert [0] == parse_basic_offsets(buffer, endianness=">")
+            src = func(buffer)
+            assert [0] == parse_basic_offsets(src, endianness=">")
 
-        assert buffer.tell() == 12
+        assert src.tell() == 12
 
 
 class TestParseFragments:
@@ -1505,15 +1505,15 @@ class TestParseFragments:
             "parsing the encapsulated pixel data fragments"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             with pytest.raises(ValueError, match=msg):
-                parse_fragments(buffer)
+                parse_fragments(src)
 
         buffer = b"\xFF\xFE\xE0\x00\xFF\xFF\xFF\xFF\x00\x00\x00\x01"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             with pytest.raises(ValueError, match=msg):
-                parse_fragments(buffer, endianness=">")
+                parse_fragments(src, endianness=">")
 
     def test_item_sequence_delimiter(self):
         """Test that the fragments are returned if seq delimiter hit."""
@@ -1562,9 +1562,9 @@ class TestParseFragments:
             r"encapsulated pixel data fragment items"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             with pytest.raises(ValueError, match=msg):
-                parse_fragments(buffer)
+                parse_fragments(src)
 
         buffer = (
             b"\xFF\xFE\xE0\x00"
@@ -1577,25 +1577,25 @@ class TestParseFragments:
             b"\x00\x00\x00\x02"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             with pytest.raises(ValueError, match=msg):
-                parse_fragments(buffer, endianness=">")
+                parse_fragments(src, endianness=">")
 
     def test_single_fragment_no_delimiter(self):
         """Test single fragment is returned OK"""
         buffer = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert parse_fragments(buffer) == (1, [0])
+            src = func(buffer)
+            assert parse_fragments(src) == (1, [0])
 
-        assert buffer.tell() == 0
+        assert src.tell() == 0
 
         buffer = b"\xFF\xFE\xE0\x00\x00\x00\x00\x04\x00\x00\x00\x01"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert parse_fragments(buffer, endianness=">") == (1, [0])
+            src = func(buffer)
+            assert parse_fragments(src, endianness=">") == (1, [0])
 
-        assert buffer.tell() == 0
+        assert src.tell() == 0
 
     def test_multi_fragments_no_delimiter(self):
         """Test multi fragments are returned OK"""
@@ -1608,10 +1608,10 @@ class TestParseFragments:
             b"\x01\x02\x03\x04\x05\x06"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert parse_fragments(buffer) == (2, [0, 12])
+            src = func(buffer)
+            assert parse_fragments(src) == (2, [0, 12])
 
-        assert buffer.tell() == 0
+        assert src.tell() == 0
 
         buffer = (
             b"\xFF\xFE\xE0\x00"
@@ -1622,10 +1622,10 @@ class TestParseFragments:
             b"\x01\x02\x03\x04\x05\x06"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert parse_fragments(buffer, endianness=">") == (2, [0, 12])
+            src = func(buffer)
+            assert parse_fragments(src, endianness=">") == (2, [0, 12])
 
-        assert buffer.tell() == 0
+        assert src.tell() == 0
 
     def test_single_fragment_delimiter(self):
         """Test single fragment is returned OK with sequence delimiter item"""
@@ -1636,10 +1636,10 @@ class TestParseFragments:
             b"\xFE\xFF\xDD\xE0"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert parse_fragments(buffer) == (1, [0])
+            src = func(buffer)
+            assert parse_fragments(src) == (1, [0])
 
-        assert buffer.tell() == 0
+        assert src.tell() == 0
 
         buffer = (
             b"\xFF\xFE\xE0\x00"
@@ -1648,10 +1648,10 @@ class TestParseFragments:
             b"\xFF\xFE\xE0\xDD"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert parse_fragments(buffer, endianness=">") == (1, [0])
+            src = func(buffer)
+            assert parse_fragments(src, endianness=">") == (1, [0])
 
-        assert buffer.tell() == 0
+        assert src.tell() == 0
 
     def test_multi_fragments_delimiter(self):
         """Test multi fragments are returned OK with sequence delimiter item"""
@@ -1665,10 +1665,10 @@ class TestParseFragments:
             b"\xFE\xFF\xDD\xE0"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert parse_fragments(buffer) == (2, [0, 12])
+            src = func(buffer)
+            assert parse_fragments(src) == (2, [0, 12])
 
-        assert buffer.tell() == 0
+        assert src.tell() == 0
 
         buffer = (
             b"\xFF\xFE\xE0\x00"
@@ -1680,10 +1680,10 @@ class TestParseFragments:
             b"\xFF\xFE\xE0\xDD"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert parse_fragments(buffer, endianness=">") == (2, [0, 12])
+            src = func(buffer)
+            assert parse_fragments(src, endianness=">") == (2, [0, 12])
 
-        assert buffer.tell() == 0
+        assert src.tell() == 0
 
 
 class TestGenerateFragments:
@@ -1697,8 +1697,8 @@ class TestGenerateFragments:
             "pixel data fragments"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer)
+            src = func(buffer)
+            fragments = generate_fragments(src)
             with pytest.raises(ValueError, match=msg):
                 next(fragments)
 
@@ -1706,8 +1706,8 @@ class TestGenerateFragments:
 
         buffer = b"\xFF\xFE\xE0\x00\xFF\xFF\xFF\xFF\x00\x00\x00\x01"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer, endianness=">")
+            src = func(buffer)
+            fragments = generate_fragments(src, endianness=">")
             with pytest.raises(ValueError, match=msg):
                 next(fragments)
 
@@ -1726,8 +1726,8 @@ class TestGenerateFragments:
             b"\x02\x00\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer)
+            src = func(buffer)
+            fragments = generate_fragments(src)
             assert next(fragments) == b"\x01\x00\x00\x00"
             pytest.raises(StopIteration, next, fragments)
 
@@ -1742,8 +1742,8 @@ class TestGenerateFragments:
             b"\x00\x00\x00\x02"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer, endianness=">")
+            src = func(buffer)
+            fragments = generate_fragments(src, endianness=">")
             assert next(fragments) == b"\x00\x00\x00\x01"
             pytest.raises(StopIteration, next, fragments)
 
@@ -1764,8 +1764,8 @@ class TestGenerateFragments:
             "encapsulated pixel data fragment items"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer)
+            src = func(buffer)
+            fragments = generate_fragments(src)
             assert next(fragments) == b"\x01\x00\x00\x00"
             with pytest.raises(ValueError, match=msg):
                 next(fragments)
@@ -1782,8 +1782,8 @@ class TestGenerateFragments:
             b"\x02\x00\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer, endianness=">")
+            src = func(buffer)
+            fragments = generate_fragments(src, endianness=">")
             assert next(fragments) == b"\x00\x00\x00\x01"
             with pytest.raises(ValueError, match=msg):
                 next(fragments)
@@ -1793,15 +1793,15 @@ class TestGenerateFragments:
         """Test single fragment is returned OK"""
         buffer = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer)
+            src = func(buffer)
+            fragments = generate_fragments(src)
             assert next(fragments) == b"\x01\x00\x00\x00"
             pytest.raises(StopIteration, next, fragments)
 
         buffer = b"\xFF\xFE\xE0\x00\x00\x00\x00\x04\x01\x00\x00\x00"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer, endianness=">")
+            src = func(buffer)
+            fragments = generate_fragments(src, endianness=">")
             assert next(fragments) == b"\x01\x00\x00\x00"
             pytest.raises(StopIteration, next, fragments)
 
@@ -1816,8 +1816,8 @@ class TestGenerateFragments:
             b"\x01\x02\x03\x04\x05\x06"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer)
+            src = func(buffer)
+            fragments = generate_fragments(src)
             assert next(fragments) == b"\x01\x00\x00\x00"
             assert next(fragments) == b"\x01\x02\x03\x04\x05\x06"
             pytest.raises(StopIteration, next, fragments)
@@ -1831,8 +1831,8 @@ class TestGenerateFragments:
             b"\x01\x02\x03\x04\x05\x06"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer, endianness=">")
+            src = func(buffer)
+            fragments = generate_fragments(src, endianness=">")
             assert next(fragments) == b"\x01\x00\x00\x00"
             assert next(fragments) == b"\x01\x02\x03\x04\x05\x06"
             pytest.raises(StopIteration, next, fragments)
@@ -1846,8 +1846,8 @@ class TestGenerateFragments:
             b"\xFE\xFF\xDD\xE0"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer)
+            src = func(buffer)
+            fragments = generate_fragments(src)
             assert next(fragments) == b"\x01\x00\x00\x00"
             pytest.raises(StopIteration, next, fragments)
 
@@ -1858,8 +1858,8 @@ class TestGenerateFragments:
             b"\xFF\xFE\xE0\xDD"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer, endianness=">")
+            src = func(buffer)
+            fragments = generate_fragments(src, endianness=">")
             assert next(fragments) == b"\x01\x00\x00\x00"
             pytest.raises(StopIteration, next, fragments)
 
@@ -1875,8 +1875,8 @@ class TestGenerateFragments:
             b"\xFE\xFF\xDD\xE0"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer)
+            src = func(buffer)
+            fragments = generate_fragments(src)
             assert next(fragments) == b"\x01\x00\x00\x00"
             assert next(fragments) == b"\x01\x02\x03\x04\x05\x06"
             pytest.raises(StopIteration, next, fragments)
@@ -1891,8 +1891,8 @@ class TestGenerateFragments:
             b"\xFF\xFE\xE0\xDD"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            fragments = generate_fragments(buffer, endianness=">")
+            src = func(buffer)
+            fragments = generate_fragments(src, endianness=">")
             assert next(fragments) == b"\x01\x00\x00\x00"
             assert next(fragments) == b"\x01\x02\x03\x04\x05\x06"
             pytest.raises(StopIteration, next, fragments)
@@ -1912,8 +1912,8 @@ class TestGenerateFragmentedFrames:
             b"\x01\x00\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            frames = generate_fragmented_frames(buffer)
+            src = func(buffer)
+            frames = generate_fragmented_frames(src)
             assert next(frames) == (b"\x01\x00\x00\x00",)
             pytest.raises(StopIteration, next, frames)
 
@@ -1925,8 +1925,8 @@ class TestGenerateFragmentedFrames:
             b"\x01\x00\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            frames = generate_fragmented_frames(buffer, endianness=">")
+            src = func(buffer)
+            frames = generate_fragmented_frames(src, endianness=">")
             assert next(frames) == (b"\x01\x00\x00\x00",)
             pytest.raises(StopIteration, next, frames)
 
@@ -1947,8 +1947,8 @@ class TestGenerateFragmentedFrames:
             b"\x03\x00\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            frames = generate_fragmented_frames(buffer, number_of_frames=1)
+            src = func(buffer)
+            frames = generate_fragmented_frames(src, number_of_frames=1)
             assert next(frames) == (
                 b"\x01\x00\x00\x00",
                 b"\x02\x00\x00\x00",
@@ -1970,7 +1970,7 @@ class TestGenerateFragmentedFrames:
             b"\x03\x00\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             frames = generate_fragmented_frames(
                 buffer, number_of_frames=1, endianness=">"
             )
@@ -2003,9 +2003,9 @@ class TestGenerateFragmentedFrames:
             r"number of frames has not been supplied"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             with pytest.raises(ValueError, match=msg):
-                next(generate_fragmented_frames(buffer))
+                next(generate_fragmented_frames(src))
 
     def test_empty_bot_too_few_fragments(self):
         """Test parsing with too few fragments."""
@@ -2018,9 +2018,9 @@ class TestGenerateFragmentedFrames:
             "or the number of frames may be incorrect"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(ds.PixelData)
+            src = func(ds.PixelData)
             with pytest.raises(ValueError, match=msg):
-                next(generate_fragmented_frames(buffer, number_of_frames=20))
+                next(generate_fragmented_frames(src, number_of_frames=20))
 
     def test_empty_bot_multi_fragments_per_frame(self):
         """Test parsing with multiple fragments per frame."""
@@ -2035,8 +2035,8 @@ class TestGenerateFragmentedFrames:
             b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\xFF\xD9\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            frames = generate_fragmented_frames(buffer, number_of_frames=4)
+            src = func(buffer)
+            frames = generate_fragmented_frames(src, number_of_frames=4)
             for ii in range(4):
                 next(frames)
 
@@ -2055,8 +2055,8 @@ class TestGenerateFragmentedFrames:
             b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\xFF\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            frames = generate_fragmented_frames(buffer, number_of_frames=4)
+            src = func(buffer)
+            frames = generate_fragmented_frames(src, number_of_frames=4)
             for ii in range(3):
                 next(frames)
 
@@ -2088,10 +2088,10 @@ class TestGenerateFragmentedFrames:
             "fewer frames than expected have been found"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             with pytest.warns(UserWarning, match=msg):
                 for ii, frame in enumerate(
-                    generate_fragmented_frames(buffer, number_of_frames=4)
+                    generate_fragmented_frames(src, number_of_frames=4)
                 ):
                     pass
 
@@ -2109,8 +2109,8 @@ class TestGenerateFragmentedFrames:
             b"\x01\x00\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            frames = generate_fragmented_frames(buffer)
+            src = func(buffer)
+            frames = generate_fragmented_frames(src)
             assert next(frames) == (b"\x01\x00\x00\x00",)
             pytest.raises(StopIteration, next, frames)
 
@@ -2132,8 +2132,8 @@ class TestGenerateFragmentedFrames:
             b"\x03\x00\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            frames = generate_fragmented_frames(buffer)
+            src = func(buffer)
+            frames = generate_fragmented_frames(src)
             assert next(frames) == (
                 b"\x01\x00\x00\x00",
                 b"\x02\x00\x00\x00",
@@ -2161,8 +2161,8 @@ class TestGenerateFragmentedFrames:
             b"\x03\x00\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            frames = generate_fragmented_frames(buffer)
+            src = func(buffer)
+            frames = generate_fragmented_frames(src)
             assert next(frames) == (b"\x01\x00\x00\x00",)
             assert next(frames) == (b"\x02\x00\x00\x00",)
             assert next(frames) == (b"\x03\x00\x00\x00",)
@@ -2188,8 +2188,8 @@ class TestGenerateFragmentedFrames:
             b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x03\x00\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            frames = generate_fragmented_frames(buffer)
+            src = func(buffer)
+            frames = generate_fragmented_frames(src)
             assert next(frames) == (
                 b"\x01\x00\x00\x00",
                 b"\x02\x00\x00\x00",
@@ -2230,8 +2230,8 @@ class TestGenerateFragmentedFrames:
             b"\x02\x00\x00\x00\x02\x04"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            frames = generate_fragmented_frames(buffer)
+            src = func(buffer)
+            frames = generate_fragmented_frames(src)
             assert next(frames) == (b"\x01\x00\x00\x00\x00\x01",)
             assert next(frames) == (
                 b"\x02\x00",
@@ -2254,8 +2254,18 @@ class TestGenerateFragmentedFrames:
         )
         eot = ([0], [4])
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            frames = generate_fragmented_frames(buffer, extended_offsets=eot)
+            src = func(buffer)
+            frames = generate_fragmented_frames(src, extended_offsets=eot)
+            assert next(frames) == (b"\x01\x00\x00\x00",)
+            pytest.raises(StopIteration, next, frames)
+
+        eot = (  # unsigned long, 8 bytes
+            b"\x00\x00\x00\x00\x00\x00\x00\x00",
+            b"\x04\x00\x00\x00\x00\x00\x00\x00",
+        )
+        for func in (bytes, as_bytesio):
+            src = func(buffer)
+            frames = generate_fragmented_frames(src, extended_offsets=eot)
             assert next(frames) == (b"\x01\x00\x00\x00",)
             pytest.raises(StopIteration, next, frames)
 
@@ -2280,8 +2290,22 @@ class TestGenerateFragmentedFrames:
         )
         eot = ([0, 12, 24], [4, 4, 4])
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            frames = generate_fragmented_frames(buffer, extended_offsets=eot)
+            src = func(buffer)
+            frames = generate_fragmented_frames(src, extended_offsets=eot)
+            assert next(frames) == (b"\x01\x00\x00\x00",)
+            assert next(frames) == (b"\x02\x00\x00\x00",)
+            assert next(frames) == (b"\x03\x00\x00\x00",)
+            pytest.raises(StopIteration, next, frames)
+
+        eot = (  # unsigned long, 8 bytes
+            b"\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x0C\x00\x00\x00\x00\x00\x00\x00"
+            b"\x18\x00\x00\x00\x00\x00\x00\x00",
+            b"\x04\x00\x00\x00\x00\x00\x00\x00" * 3,
+        )
+        for func in (bytes, as_bytesio):
+            src = func(buffer)
+            frames = generate_fragmented_frames(src, extended_offsets=eot)
             assert next(frames) == (b"\x01\x00\x00\x00",)
             assert next(frames) == (b"\x02\x00\x00\x00",)
             assert next(frames) == (b"\x03\x00\x00\x00",)
@@ -2461,7 +2485,6 @@ class TestGenerateFrames:
             src = func(ds.PixelData)
             frame_gen = generate_frames(src, number_of_frames=ds.NumberOfFrames)
             for ii in range(10):
-                print(ii)
                 next(frame_gen)
 
             with pytest.raises(StopIteration):
@@ -2477,8 +2500,33 @@ class TestGenerateFrames:
             # Note that we will yield 10 frames, not 8
             frame_gen = generate_frames(src, number_of_frames=8)
             for ii in range(10):
-                print(ii)
                 next(frame_gen)
+
+            with pytest.raises(StopIteration):
+                next(frame_gen)
+
+    def test_empty_bot_multi_fragments_per_frame_excess_frames(self):
+        """Test multi-frame where multiple frags per frame and no BOT."""
+        # Regression test for #685
+        ds = dcmread(JP2K_10FRAME_NOBOT)
+        assert 10 == ds.NumberOfFrames
+        msg = (
+            "The end of the encapsulated pixel data has been reached but "
+            "no JPEG EOI/EOC marker was found, the final frame may be "
+            "be invalid"
+        )
+        excess = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x00\x01\x02\x03"
+        for func in (bytes, as_bytesio):
+            src = func(b"".join([ds.PixelData, excess]))
+            # Note that we will yield 10 frames, not 8
+            frame_gen = generate_frames(src, number_of_frames=8)
+            for ii in range(10):
+                next(frame_gen)
+
+            with pytest.warns(UserWarning, match=msg):
+                frame = next(frame_gen)
+
+            assert frame == b"\x00\x01\x02\x03"
 
             with pytest.raises(StopIteration):
                 next(frame_gen)
@@ -2520,8 +2568,8 @@ class TestGetFrame:
             b"\x01\x00\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert get_frame(buffer, 0) == b"\x01\x00\x00\x00"
+            src = func(buffer)
+            assert get_frame(src, 0) == b"\x01\x00\x00\x00"
 
     def test_empty_bot_triple_fragment_single_frame(self):
         """Test a single-frame image where the frame is three fragments"""
@@ -2540,8 +2588,8 @@ class TestGetFrame:
             b"\x03\x00\x00\x00"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
-            assert get_frame(buffer, 0, number_of_frames=1) == (
+            src = func(buffer)
+            assert get_frame(src, 0, number_of_frames=1) == (
                 b"\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00"
             )
 
@@ -2567,9 +2615,9 @@ class TestGetFrame:
             r"and the number of frames has not been supplied"
         )
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             with pytest.raises(ValueError, match=msg):
-                get_frame(buffer, 0)
+                get_frame(src, 0)
 
     def test_empty_bot_too_few_fragments(self):
         """Test parsing with too few fragments."""
@@ -2594,22 +2642,22 @@ class TestGetFrame:
         )
         msg = "There is insufficient pixel data to contain 5 frames"
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
 
             # Note that we can access a single "extra" frame
             assert (
-                get_frame(buffer, 0, number_of_frames=3)
+                get_frame(src, 0, number_of_frames=3)
                 == b"\x01\x00\x00\x00\x01\xFF\xD9\x00"
             )
-            assert get_frame(buffer, 1, number_of_frames=3) == b"\x01\x00\xFF\xD9"
-            assert get_frame(buffer, 2, number_of_frames=3) == b"\x01\xFF\xD9\x00"
+            assert get_frame(src, 1, number_of_frames=3) == b"\x01\x00\xFF\xD9"
+            assert get_frame(src, 2, number_of_frames=3) == b"\x01\xFF\xD9\x00"
             assert (
-                get_frame(buffer, 3, number_of_frames=3)
+                get_frame(src, 3, number_of_frames=3)
                 == b"\x01\x00\x00\x00\x01\xFF\xD9\x00"
             )
 
             with pytest.raises(ValueError, match=msg):
-                get_frame(buffer, 4, number_of_frames=3)
+                get_frame(src, 4, number_of_frames=3)
 
     def test_empty_bot_no_marker(self):
         """Test parsing no BOT and no final marker with multi fragments."""
@@ -2625,27 +2673,66 @@ class TestGetFrame:
         )
 
         for func in (bytes, as_bytesio):
-            buffer = func(buffer)
+            src = func(buffer)
             assert (
-                get_frame(buffer, 0, number_of_frames=3)
+                get_frame(src, 0, number_of_frames=3)
                 == b"\x01\x00\x00\x00\x01\xFF\xD9\x00"
             )
             assert (
-                get_frame(buffer, 1, number_of_frames=3)
+                get_frame(src, 1, number_of_frames=3)
                 == b"\x01\x00\x00\x00\x01\xFF\xD9\x00"
             )
-            assert get_frame(buffer, 2, number_of_frames=3) == b"\x01\xFF\xFF\xD9"
+            assert get_frame(src, 2, number_of_frames=3) == b"\x01\xFF\xFF\xD9"
 
             msg = (
                 "The end of the encapsulated pixel data has been reached but no "
                 "JPEG EOI/EOC marker was found, the returned frame data may be invalid"
             )
             with pytest.warns(UserWarning, match=msg):
-                assert get_frame(buffer, 3, number_of_frames=3) == b"\x01\xFF\x00\x00"
+                assert get_frame(src, 3, number_of_frames=3) == b"\x01\xFF\x00\x00"
 
             msg = "There is insufficient pixel data to contain 5 frames"
             with pytest.raises(ValueError, match=msg):
-                get_frame(buffer, 4, number_of_frames=3)
+                get_frame(src, 4, number_of_frames=3)
+
+    def test_empty_bot_index_greater_than_frames_raises(self):
+        """Test multiple fragments, 1 frame raises if index > 0"""
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+        )
+        msg = "The 'index' must be 0 if the number of frames is 1"
+        for func in (bytes, as_bytesio):
+            src = func(buffer)
+            with pytest.raises(ValueError, match=msg):
+                get_frame(src, 1, number_of_frames=1)
+
+    def test_empty_bot_index_greater_than_multi_frames_raises(self):
+        """Test 1:1 fragments:frames raises if index > number of frames"""
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+        )
+        msg = (
+            "Found 2 frame fragments in the encapsulated pixel data, an "
+            "'index' of 2 is invalid"
+        )
+        for func in (bytes, as_bytesio):
+            src = func(buffer)
+            with pytest.raises(ValueError, match=msg):
+                get_frame(src, 2, number_of_frames=2)
 
     def test_bot_single_fragment(self):
         """Test a single-frame image where the frame is one fragment"""
@@ -2804,6 +2891,16 @@ class TestGetFrame:
             with pytest.raises(ValueError, match=msg):
                 get_frame(src, 1)
 
+        eot = (  # unsigned long, 8 bytes
+            b"\x00\x00\x00\x00\x00\x00\x00\x00",
+            b"\x04\x00\x00\x00\x00\x00\x00\x00",
+        )
+        for func in (bytes, as_bytesio):
+            src = func(buffer)
+            assert get_frame(src, 0, extended_offsets=eot) == b"\x01\x00\x00\x00"
+            with pytest.raises(ValueError, match=msg):
+                get_frame(src, 1)
+
     def test_eot_multi_fragment(self):
         """Test a single-frame image where the frame is three fragments"""
         # 3 frames, 1 fragments long
@@ -2824,9 +2921,23 @@ class TestGetFrame:
         msg = "There aren't enough offsets in the Extended Offset Table for 4 frames"
         for func in (bytes, as_bytesio):
             src = func(buffer)
-            assert get_frame(buffer, 0, extended_offsets=eot) == b"\x01\x00\x00\x00"
-            assert get_frame(buffer, 1, extended_offsets=eot) == b"\x02\x00\x00\x00"
-            assert get_frame(buffer, 2, extended_offsets=eot) == b"\x03\x00\x00\x00"
+            assert get_frame(src, 0, extended_offsets=eot) == b"\x01\x00\x00\x00"
+            assert get_frame(src, 1, extended_offsets=eot) == b"\x02\x00\x00\x00"
+            assert get_frame(src, 2, extended_offsets=eot) == b"\x03\x00\x00\x00"
+            with pytest.raises(ValueError, match=msg):
+                get_frame(src, 3, extended_offsets=eot)
+
+        eot = (  # unsigned long, 8 bytes
+            b"\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x0C\x00\x00\x00\x00\x00\x00\x00"
+            b"\x18\x00\x00\x00\x00\x00\x00\x00",
+            b"\x04\x00\x00\x00\x00\x00\x00\x00" * 3,
+        )
+        for func in (bytes, as_bytesio):
+            src = func(buffer)
+            assert get_frame(src, 0, extended_offsets=eot) == b"\x01\x00\x00\x00"
+            assert get_frame(src, 1, extended_offsets=eot) == b"\x02\x00\x00\x00"
+            assert get_frame(src, 2, extended_offsets=eot) == b"\x03\x00\x00\x00"
             with pytest.raises(ValueError, match=msg):
                 get_frame(src, 3, extended_offsets=eot)
 

--- a/tests/test_encaps.py
+++ b/tests/test_encaps.py
@@ -20,6 +20,11 @@ from pydicom.encaps import (
     itemise_frame,
     encapsulate,
     encapsulate_extended,
+    _get_frame_offsets,
+    _get_nr_fragments,
+    _generate_fragments,
+    # _generate_frame_data,
+    get_frame,
 )
 from pydicom.filebase import DicomBytesIO
 
@@ -33,9 +38,7 @@ class TestGetFrameOffsets:
     def test_bad_tag(self):
         """Test raises exception if no item tag."""
         # (FFFE,E100)
-        bytestream = (
-            b"\xFE\xFF\x00\xE1" b"\x08\x00\x00\x00" b"\x01\x02\x03\x04\x05\x06\x07\x08"
-        )
+        bytestream = b"\xFE\xFF\x00\xE1\x08\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08"
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
         with pytest.raises(
@@ -57,13 +60,13 @@ class TestGetFrameOffsets:
         fp.is_little_endian = True
         with pytest.raises(
             ValueError,
-            match="The length of the Basic Offset Table item" " is not a multiple of 4",
+            match="The length of the Basic Offset Table item is not a multiple of 4",
         ):
             get_frame_offsets(fp)
 
     def test_zero_length(self):
         """Test reading BOT with zero length"""
-        bytestream = b"\xFE\xFF\x00\xE0" b"\x00\x00\x00\x00"
+        bytestream = b"\xFE\xFF\x00\xE0\x00\x00\x00\x00"
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
         assert (False, [0]) == get_frame_offsets(fp)
@@ -84,14 +87,14 @@ class TestGetFrameOffsets:
 
     def test_single_frame(self):
         """Test reading single-frame BOT item"""
-        bytestream = b"\xFE\xFF\x00\xE0" b"\x04\x00\x00\x00" b"\x00\x00\x00\x00"
+        bytestream = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x00\x00\x00\x00"
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
         assert (True, [0]) == get_frame_offsets(fp)
 
     def test_not_little_endian(self):
         """Test reading big endian raises exception"""
-        bytestream = b"\xFE\xFF\x00\xE0" b"\x00\x00\x00\x00"
+        bytestream = b"\xFE\xFF\x00\xE0\x00\x00\x00\x00"
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = False
         with pytest.raises(ValueError, match="'fp.is_little_endian' must be True"):
@@ -103,7 +106,7 @@ class TestGetNrFragments:
 
     def test_item_undefined_length(self):
         """Test exception raised if item length undefined."""
-        bytestream = b"\xFE\xFF\x00\xE0" b"\xFF\xFF\xFF\xFF" b"\x00\x00\x00\x01"
+        bytestream = b"\xFE\xFF\x00\xE0\xFF\xFF\xFF\xFF\x00\x00\x00\x01"
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
         with pytest.raises(ValueError):
@@ -148,7 +151,7 @@ class TestGetNrFragments:
 
     def test_single_fragment_no_delimiter(self):
         """Test single fragment is returned OK"""
-        bytestream = b"\xFE\xFF\x00\xE0" b"\x04\x00\x00\x00" b"\x01\x00\x00\x00"
+        bytestream = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
         assert 1 == get_nr_fragments(fp)
@@ -196,7 +199,7 @@ class TestGetNrFragments:
 
     def test_not_little_endian(self):
         """Test reading big endian raises exception"""
-        bytestream = b"\xFE\xFF\x00\xE0" b"\x04\x00\x00\x00" b"\x01\x00\x00\x00"
+        bytestream = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = False
         with pytest.raises(ValueError, match="'fp.is_little_endian' must be True"):
@@ -208,7 +211,7 @@ class TestGeneratePixelDataFragment:
 
     def test_item_undefined_length(self):
         """Test exception raised if item length undefined."""
-        bytestream = b"\xFE\xFF\x00\xE0" b"\xFF\xFF\xFF\xFF" b"\x00\x00\x00\x01"
+        bytestream = b"\xFE\xFF\x00\xE0\xFF\xFF\xFF\xFF\x00\x00\x00\x01"
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
         fragments = generate_pixel_data_fragment(fp)
@@ -266,7 +269,7 @@ class TestGeneratePixelDataFragment:
 
     def test_single_fragment_no_delimiter(self):
         """Test single fragment is returned OK"""
-        bytestream = b"\xFE\xFF\x00\xE0" b"\x04\x00\x00\x00" b"\x01\x00\x00\x00"
+        bytestream = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
         fragments = generate_pixel_data_fragment(fp)
@@ -324,7 +327,7 @@ class TestGeneratePixelDataFragment:
 
     def test_not_little_endian(self):
         """Test reading big endian raises exception"""
-        bytestream = b"\xFE\xFF\x00\xE0" b"\x04\x00\x00\x00" b"\x01\x00\x00\x00"
+        bytestream = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = False
         fragments = generate_pixel_data_fragment(fp)
@@ -366,7 +369,7 @@ class TestGeneratePixelDataFrames:
             b"\x04\x00\x00\x00"
             b"\x03\x00\x00\x00"
         )
-        frames = generate_pixel_data_frame(bytestream, 1)
+        frames = generate_pixel_data_frame(bytestream, number_of_frames=1)
         assert next(frames) == (b"\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00")
         pytest.raises(StopIteration, next, frames)
 
@@ -438,8 +441,8 @@ class TestGeneratePixelDataFrames:
             b"\xFE\xFF\x00\xE0"
             b"\x0C\x00\x00\x00"
             b"\x00\x00\x00\x00"
-            b"\x20\x00\x00\x00"
-            b"\x40\x00\x00\x00"
+            b"\x24\x00\x00\x00"
+            b"\x48\x00\x00\x00"
             b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
             b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x02\x00\x00\x00"
             b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x03\x00\x00\x00"
@@ -451,9 +454,9 @@ class TestGeneratePixelDataFrames:
             b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x03\x00\x00\x00"
         )
         frames = generate_pixel_data_frame(bytestream)
-        assert next(frames) == (b"\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00")
-        assert next(frames) == (b"\x02\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00")
-        assert next(frames) == (b"\x03\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00")
+        assert next(frames) == b"\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00"
+        assert next(frames) == b"\x02\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00"
+        assert next(frames) == b"\x03\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00"
         pytest.raises(StopIteration, next, frames)
 
     def test_multi_frame_varied_ratio(self):
@@ -489,7 +492,9 @@ class TestGeneratePixelDataFrames:
         # Regression test for #685
         ds = dcmread(JP2K_10FRAME_NOBOT)
         assert 10 == ds.NumberOfFrames
-        frame_gen = generate_pixel_data_frame(ds.PixelData, ds.NumberOfFrames)
+        frame_gen = generate_pixel_data_frame(
+            ds.PixelData, number_of_frames=ds.NumberOfFrames
+        )
         for ii in range(10):
             next(frame_gen)
 
@@ -530,7 +535,7 @@ class TestGeneratePixelData:
             b"\x04\x00\x00\x00"
             b"\x03\x00\x00\x00"
         )
-        frames = generate_pixel_data(bytestream, 1)
+        frames = generate_pixel_data(bytestream, number_of_frames=1)
         assert next(frames) == (
             b"\x01\x00\x00\x00",
             b"\x02\x00\x00\x00",
@@ -538,8 +543,8 @@ class TestGeneratePixelData:
         )
         pytest.raises(StopIteration, next, frames)
 
-    def test_empty_bot_no_nr_frames_raises(self):
-        """Test parsing raises if not BOT and no nr_frames."""
+    def test_empty_bot_no_number_of_frames_raises(self):
+        """Test parsing raises if not BOT and no number_of_frames."""
         # 1 frame, 3 fragments long
         bytestream = (
             b"\xFE\xFF\x00\xE0"
@@ -555,9 +560,9 @@ class TestGeneratePixelData:
             b"\x03\x00\x00\x00"
         )
         msg = (
-            r"Unable to determine the frame boundaries for the "
-            r"encapsulated pixel data as the Basic Offset Table is empty "
-            r"and `nr_frames` parameter is None"
+            r"Unable to determine the frame boundaries for the encapsulated "
+            r"pixel data as there is no Basic or Extended Offset Table and the "
+            r"number of frames has not been supplied"
         )
         with pytest.raises(ValueError, match=msg):
             next(generate_pixel_data(bytestream))
@@ -568,12 +573,12 @@ class TestGeneratePixelData:
         assert 10 == ds.NumberOfFrames
 
         msg = (
-            r"Unable to parse encapsulated pixel data as the Basic "
-            r"Offset Table is empty and there are fewer fragments then "
-            r"frames; the dataset may be corrupt"
+            r"Unable to parse encapsulated pixel data as there is no Basic or "
+            r"Extended Offset Table and there are fewer fragments then frames; "
+            r"the dataset may be corrupt or the number of frames may be incorrect"
         )
         with pytest.raises(ValueError, match=msg):
-            next(generate_pixel_data_frame(ds.PixelData, 20))
+            next(generate_pixel_data_frame(ds.PixelData, number_of_frames=20))
 
     def test_empty_bot_multi_fragments_per_frame(self):
         """Test parsing with multiple fragments per frame."""
@@ -588,7 +593,7 @@ class TestGeneratePixelData:
             b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\xFF\xD9\x00"
         )
 
-        frames = generate_pixel_data(bytestream, 4)
+        frames = generate_pixel_data(bytestream, number_of_frames=4)
         for ii in range(4):
             next(frames)
 
@@ -608,15 +613,14 @@ class TestGeneratePixelData:
             b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\xFF\x00\x00"
         )
 
-        frames = generate_pixel_data(bytestream, 4)
+        frames = generate_pixel_data(bytestream, number_of_frames=4)
         for ii in range(3):
             next(frames)
 
         msg = (
-            r"The end of the encapsulated pixel data has been "
-            r"reached but one or more frame boundaries may have "
-            r"been missed; please confirm that the generated frame "
-            r"data is correct"
+            "The end of the encapsulated pixel data has been reached but fewer "
+            "frames than expected have been found. Please confirm that the "
+            "generated frame data is correct"
         )
         with pytest.warns(UserWarning, match=msg):
             next(frames)
@@ -625,7 +629,7 @@ class TestGeneratePixelData:
             next(frames)
 
     def test_empty_bot_missing_marker(self):
-        """Test parsing not BOT and missing marker with multi fragments."""
+        """Test parsing no BOT and missing marker with multi fragments."""
         # 4 frames in 6 fragments with JPEG EOI marker (1 missing EOI)
         bytestream = (
             b"\xFE\xFF\x00\xE0\x00\x00\x00\x00"
@@ -638,17 +642,16 @@ class TestGeneratePixelData:
         )
 
         msg = (
-            r"The end of the encapsulated pixel data has been "
-            r"reached but one or more frame boundaries may have "
-            r"been missed; please confirm that the generated frame "
-            r"data is correct"
+            "The end of the encapsulated pixel data has been reached but "
+            "fewer frames than expected have been found"
         )
         with pytest.warns(UserWarning, match=msg):
-            ii = 0
-            for frames in generate_pixel_data(bytestream, 4):
-                ii += 1
+            for ii, frame in enumerate(
+                generate_pixel_data(bytestream, number_of_frames=4)
+            ):
+                pass
 
-        assert 3 == ii
+        assert 2 == ii
 
     def test_bot_single_fragment(self):
         """Test a single-frame image where the frame is one fragment"""
@@ -722,8 +725,8 @@ class TestGeneratePixelData:
             b"\xFE\xFF\x00\xE0"
             b"\x0C\x00\x00\x00"
             b"\x00\x00\x00\x00"
-            b"\x20\x00\x00\x00"
-            b"\x40\x00\x00\x00"
+            b"\x24\x00\x00\x00"
+            b"\x48\x00\x00\x00"
             b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
             b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x02\x00\x00\x00"
             b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x03\x00\x00\x00"
@@ -969,7 +972,7 @@ class TestReadItem:
 
     def test_item_undefined_length(self):
         """Test exception raised if item length undefined."""
-        bytestream = b"\xFE\xFF\x00\xE0" b"\xFF\xFF\xFF\xFF" b"\x00\x00\x00\x01"
+        bytestream = b"\xFE\xFF\x00\xE0\xFF\xFF\xFF\xFF\x00\x00\x00\x01"
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
         with pytest.raises(
@@ -1037,7 +1040,7 @@ class TestReadItem:
 
     def test_single_fragment_no_delimiter(self):
         """Test single fragment is returned OK"""
-        bytestream = b"\xFE\xFF\x00\xE0" b"\x04\x00\x00\x00" b"\x01\x00\x00\x00"
+        bytestream = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
         fp = DicomBytesIO(bytestream)
         fp.is_little_endian = True
         assert read_item(fp) == b"\x01\x00\x00\x00"
@@ -1182,7 +1185,7 @@ class TestEncapsulateFrame:
         item_generator = itemise_frame(bytestream, nr_fragments=1)
         item = next(item_generator)
 
-        assert item == (b"\xfe\xff\x00\xe0" b"\x04\x00\x00\x00" b"\xFE\xFF\x00\xE1")
+        assert item == (b"\xfe\xff\x00\xe0\x04\x00\x00\x00\xFE\xFF\x00\xE1")
 
         pytest.raises(StopIteration, next, item_generator)
 
@@ -1192,10 +1195,10 @@ class TestEncapsulateFrame:
         item_generator = itemise_frame(bytestream, nr_fragments=2)
 
         item = next(item_generator)
-        assert item == (b"\xfe\xff\x00\xe0" b"\x02\x00\x00\x00" b"\xFE\xFF")
+        assert item == (b"\xfe\xff\x00\xe0\x02\x00\x00\x00\xFE\xFF")
 
         item = next(item_generator)
-        assert item == (b"\xfe\xff\x00\xe0" b"\x02\x00\x00\x00" b"\x00\xe1")
+        assert item == (b"\xfe\xff\x00\xe0\x02\x00\x00\x00\x00\xe1")
 
         pytest.raises(StopIteration, next, item_generator)
 
@@ -1335,3 +1338,721 @@ class TestEncapsulateExtended:
         eot_encapsulated, eot, eot_lengths = encapsulate_extended(frames)
         assert unpack(f"<{len(frames)}Q", eot) == (0, 10, 20)
         assert unpack(f"<{len(frames)}Q", eot_lengths) == (2, 2, 2)
+
+
+class TestBuffer_GetFrameOffsets:
+    """Tests for _get_frame_offsets()"""
+
+    def test_bad_tag(self):
+        """Test raises exception if no item tag."""
+        # (FFFE,E100)
+        buffer = b"\xFE\xFF\x00\xE1\x08\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08"
+        msg = r"Unexpected tag '\(FFFE,E100\)' when parsing the Basic Table Offset item"
+        with pytest.raises(ValueError, match=msg):
+            _get_frame_offsets(buffer)
+
+        msg = r"Unexpected tag '\(FEFF,00E1\)' when parsing the Basic Table Offset item"
+        with pytest.raises(ValueError, match=msg):
+            _get_frame_offsets(buffer, little_endian=False)
+
+    def test_bad_length_multiple(self):
+        """Test raises exception if the item length is not a multiple of 4."""
+        # Length 10
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x0A\x00\x00\x00"
+            b"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A"
+        )
+
+        msg = "The length of the Basic Offset Table item is not a multiple of 4"
+        with pytest.raises(ValueError, match=msg):
+            _get_frame_offsets(buffer)
+
+        buffer = (
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x0A"
+            b"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A"
+        )
+        with pytest.raises(ValueError, match=msg):
+            _get_frame_offsets(buffer, little_endian=False)
+
+    def test_zero_length(self):
+        """Test reading BOT with zero length"""
+        # Little endian
+        buffer = b"\xFE\xFF\x00\xE0\x00\x00\x00\x00"
+        assert (8, []) == _get_frame_offsets(buffer)
+
+        # Big endian
+        buffer = b"\xFF\xFE\xE0\x00\x00\x00\x00\x00"
+        assert (8, []) == _get_frame_offsets(buffer, little_endian=False)
+
+    def test_multi_frame(self):
+        """Test reading multi-frame BOT item"""
+        # Little endian
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x10\x00\x00\x00"
+            b"\x00\x00\x00\x00"
+            b"\x66\x13\x00\x00"
+            b"\xF4\x25\x00\x00"
+            b"\xFE\x37\x00\x00"
+        )
+        assert (24, [0, 4966, 9716, 14334]) == _get_frame_offsets(buffer)
+
+        # Big endian
+        buffer = (
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x10"
+            b"\x00\x00\x00\x00"
+            b"\x00\x00\x13\x66"
+            b"\x00\x00\x25\xF4"
+            b"\x00\x00\x37\xFE"
+        )
+        assert (24, [0, 4966, 9716, 14334]) == _get_frame_offsets(
+            buffer, little_endian=False
+        )
+
+    def test_single_frame(self):
+        """Test reading single-frame BOT item"""
+        # Little endian
+        buffer = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x00\x00\x00\x00"
+        assert (12, [0]) == _get_frame_offsets(buffer)
+
+        # Big endian
+        buffer = b"\xFF\xFE\xE0\x00\x00\x00\x00\x04\x00\x00\x00\x00"
+        assert (12, [0]) == _get_frame_offsets(buffer, little_endian=False)
+
+
+class TestBuffer_GetNrFragments:
+    """Tests for _get_nr_fragments()"""
+
+    def test_item_undefined_length(self):
+        """Test exception raised if item length undefined."""
+        buffer = b"\xFE\xFF\x00\xE0\xFF\xFF\xFF\xFF\x00\x00\x00\x01"
+
+        msg = (
+            "Undefined item length at offset 4 when "
+            "parsing the encapsulated pixel data fragments"
+        )
+        with pytest.raises(ValueError, match=msg):
+            _get_nr_fragments(buffer)
+
+        buffer = b"\xFF\xFE\xE0\x00\xFF\xFF\xFF\xFF\x00\x00\x00\x01"
+        with pytest.raises(ValueError, match=msg):
+            _get_nr_fragments(buffer, little_endian=False)
+
+    def test_item_sequence_delimiter(self):
+        """Test that the fragments are returned if seq delimiter hit."""
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\xDD\xE0"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x02\x00\x00\x00"
+        )
+        assert 1 == _get_nr_fragments(buffer)
+
+        buffer = (
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04"
+            b"\x00\x00\x00\x01"
+            b"\xFF\xFE\xE0\xDD"
+            b"\x00\x00\x00\x00"
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04`"
+            b"\x00\x00\x00\x02"
+        )
+        assert 1 == _get_nr_fragments(buffer, little_endian=False)
+
+    def test_item_bad_tag(self):
+        """Test exception raised if item has unexpected tag"""
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\x10\x00\x10\x00"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x02\x00\x00\x00"
+        )
+        msg = (
+            r"Unexpected tag '\(0010,0010\)' at offset 12 when parsing the "
+            r"encapsulated pixel data fragment items"
+        )
+        with pytest.raises(ValueError, match=msg):
+            _get_nr_fragments(buffer)
+
+        buffer = (
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04"
+            b"\x00\x00\x00\x01"
+            b"\x00\x10\x00\x10"
+            b"\x00\x00\x00\x00"
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04"
+            b"\x00\x00\x00\x02"
+        )
+        with pytest.raises(ValueError, match=msg):
+            _get_nr_fragments(buffer, little_endian=False)
+
+    def test_single_fragment_no_delimiter(self):
+        """Test single fragment is returned OK"""
+        buffer = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
+        assert 1 == _get_nr_fragments(buffer)
+
+        buffer = b"\xFF\xFE\xE0\x00\x00\x00\x00\x04\x00\x00\x00\x01"
+        assert 1 == _get_nr_fragments(buffer, little_endian=False)
+
+    def test_multi_fragments_no_delimiter(self):
+        """Test multi fragments are returned OK"""
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x06\x00\x00\x00"
+            b"\x01\x02\x03\x04\x05\x06"
+        )
+        assert 2 == _get_nr_fragments(buffer)
+
+        buffer = (
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04"
+            b"\x00\x00\x00\x01"
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x06"
+            b"\x01\x02\x03\x04\x05\x06"
+        )
+        assert 2 == _get_nr_fragments(buffer, little_endian=False)
+
+    def test_single_fragment_delimiter(self):
+        """Test single fragment is returned OK with sequence delimiter item"""
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\xDD\xE0"
+        )
+        assert 1 == _get_nr_fragments(buffer)
+
+        buffer = (
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04"
+            b"\x00\x00\x00\x01"
+            b"\xFF\xFE\xE0\xDD"
+        )
+        assert 1 == _get_nr_fragments(buffer, little_endian=False)
+
+    def test_multi_fragments_delimiter(self):
+        """Test multi fragments are returned OK with sequence delimiter item"""
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x06\x00\x00\x00"
+            b"\x01\x02\x03\x04\x05\x06"
+            b"\xFE\xFF\xDD\xE0"
+        )
+        assert 2 == _get_nr_fragments(buffer)
+
+        buffer = (
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04"
+            b"\x00\x00\x00\x01"
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x06"
+            b"\x01\x02\x03\x04\x05\x06"
+            b"\xFF\xFE\xE0\xDD"
+        )
+        assert 2 == _get_nr_fragments(buffer, little_endian=False)
+
+
+class TestBuffer_GenerateFragments:
+    """Test generate_fragments()"""
+
+    def test_item_undefined_length(self):
+        """Test exception raised if item length undefined."""
+        buffer = b"\xFE\xFF\x00\xE0\xFF\xFF\xFF\xFF\x00\x00\x00\x01"
+        fragments = _generate_fragments(buffer)
+        msg = (
+            "Undefined item length at offset 4 when parsing the encapsulated "
+            "pixel data fragments"
+        )
+        with pytest.raises(ValueError, match=msg):
+            next(fragments)
+
+        pytest.raises(StopIteration, next, fragments)
+
+    def test_item_sequence_delimiter(self):
+        """Test that the fragments are returned if seq delimiter hit."""
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\xDD\xE0"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x02\x00\x00\x00"
+        )
+        fragments = _generate_fragments(buffer)
+        assert next(fragments) == b"\x01\x00\x00\x00"
+        pytest.raises(StopIteration, next, fragments)
+
+        buffer = (
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04"
+            b"\x00\x00\x00\x01"
+            b"\xFF\xFE\xE0\xDD"
+            b"\x00\x00\x00\x00"
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04"
+            b"\x00\x00\x00\x02"
+        )
+        fragments = _generate_fragments(buffer, little_endian=False)
+        assert next(fragments) == b"\x00\x00\x00\x01"
+        pytest.raises(StopIteration, next, fragments)
+
+    def test_item_bad_tag(self):
+        """Test exception raised if item has unexpected tag"""
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\x10\x00\x10\x00"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x02\x00\x00\x00"
+        )
+        fragments = _generate_fragments(buffer)
+        assert next(fragments) == b"\x01\x00\x00\x00"
+        msg = (
+            r"Unexpected tag '\(0010,0010\)' at offset 12 when parsing the "
+            "encapsulated pixel data fragment items"
+        )
+        with pytest.raises(ValueError, match=msg):
+            next(fragments)
+        pytest.raises(StopIteration, next, fragments)
+
+        buffer = (
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04"
+            b"\x00\x00\x00\x01"
+            b"\x00\x10\x00\x10"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x02\x00\x00\x00"
+        )
+        fragments = _generate_fragments(buffer, little_endian=False)
+        assert next(fragments) == b"\x00\x00\x00\x01"
+        with pytest.raises(ValueError, match=msg):
+            next(fragments)
+        pytest.raises(StopIteration, next, fragments)
+
+    def test_single_fragment_no_delimiter(self):
+        """Test single fragment is returned OK"""
+        buffer = b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
+        fragments = _generate_fragments(buffer)
+        assert next(fragments) == b"\x01\x00\x00\x00"
+        pytest.raises(StopIteration, next, fragments)
+
+        buffer = b"\xFF\xFE\xE0\x00\x00\x00\x00\x04\x01\x00\x00\x00"
+        fragments = _generate_fragments(buffer, little_endian=False)
+        assert next(fragments) == b"\x01\x00\x00\x00"
+        pytest.raises(StopIteration, next, fragments)
+
+    def test_multi_fragments_no_delimiter(self):
+        """Test multi fragments are returned OK"""
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x06\x00\x00\x00"
+            b"\x01\x02\x03\x04\x05\x06"
+        )
+        fragments = _generate_fragments(buffer)
+        assert next(fragments) == b"\x01\x00\x00\x00"
+        assert next(fragments) == b"\x01\x02\x03\x04\x05\x06"
+        pytest.raises(StopIteration, next, fragments)
+
+        buffer = (
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04"
+            b"\x01\x00\x00\x00"
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x06"
+            b"\x01\x02\x03\x04\x05\x06"
+        )
+        fragments = _generate_fragments(buffer, little_endian=False)
+        assert next(fragments) == b"\x01\x00\x00\x00"
+        assert next(fragments) == b"\x01\x02\x03\x04\x05\x06"
+        pytest.raises(StopIteration, next, fragments)
+
+    def test_single_fragment_delimiter(self):
+        """Test single fragment is returned OK with sequence delimiter item"""
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\xDD\xE0"
+        )
+        fragments = _generate_fragments(buffer)
+        assert next(fragments) == b"\x01\x00\x00\x00"
+        pytest.raises(StopIteration, next, fragments)
+
+        buffer = (
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04"
+            b"\x01\x00\x00\x00"
+            b"\xFF\xFE\xE0\xDD"
+        )
+        fragments = _generate_fragments(buffer, little_endian=False)
+        assert next(fragments) == b"\x01\x00\x00\x00"
+        pytest.raises(StopIteration, next, fragments)
+
+    def test_multi_fragments_delimiter(self):
+        """Test multi fragments are returned OK with sequence delimiter item"""
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x06\x00\x00\x00"
+            b"\x01\x02\x03\x04\x05\x06"
+            b"\xFE\xFF\xDD\xE0"
+        )
+        fragments = _generate_fragments(buffer)
+        assert next(fragments) == b"\x01\x00\x00\x00"
+        assert next(fragments) == b"\x01\x02\x03\x04\x05\x06"
+        pytest.raises(StopIteration, next, fragments)
+
+        buffer = (
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x04"
+            b"\x01\x00\x00\x00"
+            b"\xFF\xFE\xE0\x00"
+            b"\x00\x00\x00\x06"
+            b"\x01\x02\x03\x04\x05\x06"
+            b"\xFF\xFE\xE0\xDD"
+        )
+        fragments = _generate_fragments(buffer, little_endian=False)
+        assert next(fragments) == b"\x01\x00\x00\x00"
+        assert next(fragments) == b"\x01\x02\x03\x04\x05\x06"
+        pytest.raises(StopIteration, next, fragments)
+
+
+class TestBuffer_GetFrame:
+    """Tests for get_frame()"""
+
+    def test_empty_bot_single_fragment(self):
+        """Test a single-frame image where the frame is one fragments"""
+        # 1 frame, 1 fragment long
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+        )
+        assert get_frame(buffer, 0) == b"\x01\x00\x00\x00"
+
+    def test_empty_bot_triple_fragment_single_frame(self):
+        """Test a single-frame image where the frame is three fragments"""
+        # 1 frame, 3 fragments long
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x02\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x03\x00\x00\x00"
+        )
+        assert get_frame(buffer, 0, number_of_frames=1) == (
+            b"\x01\x00\x00\x00" b"\x02\x00\x00\x00" b"\x03\x00\x00\x00"
+        )
+
+    def test_empty_bot_no_number_of_frames_raises(self):
+        """Test parsing raises if not BOT and no number_of_frames."""
+        # 1 frame, 3 fragments long
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x02\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x03\x00\x00\x00"
+        )
+        msg = (
+            r"Unable to determine the frame boundaries for the encapsulated "
+            r"pixel data as there is no Basic or Extended Offset Table "
+            r"and the number of frames has not been supplied"
+        )
+        with pytest.raises(ValueError, match=msg):
+            get_frame(buffer, 0)
+
+    def test_empty_bot_too_few_fragments(self):
+        """Test parsing with too few fragments."""
+        ds = dcmread(JP2K_10FRAME_NOBOT)
+        assert 10 == ds.NumberOfFrames
+
+        msg = "There is insufficient pixel data to contain 12 frames"
+        with pytest.raises(ValueError, match=msg):
+            get_frame(ds.PixelData, 11, number_of_frames=20)
+
+    def test_empty_bot_multi_fragments_per_frame(self):
+        """Test parsing with multiple fragments per frame."""
+        # 4 frames in 6 fragments with JPEG EOI marker
+        buffer = (
+            b"\xFE\xFF\x00\xE0\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\xFF\xD9\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\xFF\xD9"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\xFF\xD9\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\xFF\xD9\x00"
+        )
+
+        # Note that we can access a single "extra" frame
+        assert (
+            get_frame(buffer, 0, number_of_frames=3)
+            == b"\x01\x00\x00\x00\x01\xFF\xD9\x00"
+        )
+        assert get_frame(buffer, 1, number_of_frames=3) == b"\x01\x00\xFF\xD9"
+        assert get_frame(buffer, 2, number_of_frames=3) == b"\x01\xFF\xD9\x00"
+        assert (
+            get_frame(buffer, 3, number_of_frames=3)
+            == b"\x01\x00\x00\x00\x01\xFF\xD9\x00"
+        )
+
+        msg = "There is insufficient pixel data to contain 5 frames"
+        with pytest.raises(ValueError, match=msg):
+            get_frame(buffer, 4, number_of_frames=3)
+
+    def test_empty_bot_no_marker(self):
+        """Test parsing no BOT and no final marker with multi fragments."""
+        # 4 frames in 6 fragments with JPEG EOI marker (1 missing EOI)
+        buffer = (
+            b"\xFE\xFF\x00\xE0\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\xFF\xD9\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\xFF\xD9\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\xFF\xFF\xD9"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\xFF\x00\x00"
+        )
+
+        assert (
+            get_frame(buffer, 0, number_of_frames=3)
+            == b"\x01\x00\x00\x00\x01\xFF\xD9\x00"
+        )
+        assert (
+            get_frame(buffer, 1, number_of_frames=3)
+            == b"\x01\x00\x00\x00\x01\xFF\xD9\x00"
+        )
+        assert get_frame(buffer, 2, number_of_frames=3) == b"\x01\xFF\xFF\xD9"
+
+        msg = (
+            "The end of the encapsulated pixel data has been reached but no "
+            "JPEG EOI/EOC marker was found, the returned frame data may be invalid"
+        )
+        with pytest.warns(UserWarning, match=msg):
+            assert get_frame(buffer, 3, number_of_frames=3) == b"\x01\xFF\x00\x00"
+
+        msg = "There is insufficient pixel data to contain 5 frames"
+        with pytest.raises(ValueError, match=msg):
+            get_frame(buffer, 4, number_of_frames=3)
+
+    def test_bot_single_fragment(self):
+        """Test a single-frame image where the frame is one fragment"""
+        # 1 frame, 1 fragment long
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+        )
+        assert get_frame(buffer, 0) == b"\x01\x00\x00\x00"
+        msg = "There is insufficient pixel data to contain 2 frames"
+        with pytest.raises(ValueError, match=msg):
+            get_frame(buffer, 1)
+
+    def test_bot_triple_fragment_single_frame(self):
+        """Test a single-frame image where the frame is three fragments"""
+        # 1 frame, 3 fragments long
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x02\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x03\x00\x00\x00"
+        )
+
+        assert get_frame(buffer, 0) == (
+            b"\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00"
+        )
+
+        msg = "There is insufficient pixel data to contain 2 frames"
+        with pytest.raises(ValueError, match=msg):
+            get_frame(buffer, 1)
+
+    def test_multi_frame_one_to_one(self):
+        """Test a multi-frame image where each frame is one fragment"""
+        # 3 frames, each 1 fragment long
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x0C\x00\x00\x00"
+            b"\x00\x00\x00\x00"
+            b"\x0C\x00\x00\x00"
+            b"\x18\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x02\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x03\x00\x00\x00"
+        )
+        assert get_frame(buffer, 0) == b"\x01\x00\x00\x00"
+        assert get_frame(buffer, 1) == b"\x02\x00\x00\x00"
+        assert get_frame(buffer, 2) == b"\x03\x00\x00\x00"
+
+        msg = "There is insufficient pixel data to contain 4 frames"
+        with pytest.raises(ValueError, match=msg):
+            get_frame(buffer, 3)
+
+    def test_multi_frame_three_to_one(self):
+        """Test a multi-frame image where each frame is three fragments"""
+        # 3 frames, each 3 fragments long
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x0C\x00\x00\x00"
+            b"\x00\x00\x00\x00"
+            b"\x24\x00\x00\x00"
+            b"\x48\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x02\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x03\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x02\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x02\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x03\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x03\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x02\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0\x04\x00\x00\x00\x03\x00\x00\x00"
+        )
+        assert get_frame(buffer, 0) == (
+            b"\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00"
+        )
+        assert get_frame(buffer, 1) == (
+            b"\x02\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00"
+        )
+        assert get_frame(buffer, 2) == (
+            b"\x03\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00"
+        )
+
+        msg = "There is insufficient pixel data to contain 4 frames"
+        with pytest.raises(ValueError, match=msg):
+            get_frame(buffer, 3)
+
+    def test_multi_frame_varied_ratio(self):
+        """Test a multi-frame image where each frames is random fragments"""
+        # 3 frames, 1st is 1 fragment, 2nd is 3 fragments, 3rd is 2 fragments
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x0C\x00\x00\x00"
+            b"\x00\x00\x00\x00"
+            b"\x0E\x00\x00\x00"
+            b"\x32\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x06\x00\x00\x00\x01\x00\x00\x00\x00\x01"
+            b"\xFE\xFF\x00\xE0"
+            b"\x02\x00\x00\x00\x02\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00\x02\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x06\x00\x00\x00\x03\x00\x00\x00\x00\x02"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00\x03\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x02\x00\x00\x00\x02\x04"
+        )
+        assert get_frame(buffer, 0) == b"\x01\x00\x00\x00\x00\x01"
+        assert get_frame(buffer, 1) == (
+            b"\x02\x00\x02\x00\x00\x00\x03\x00\x00\x00\x00\x02"
+        )
+        assert get_frame(buffer, 2) == b"\x03\x00\x00\x00\x02\x04"
+
+        msg = "There is insufficient pixel data to contain 4 frames"
+        with pytest.raises(ValueError, match=msg):
+            get_frame(buffer, 3)
+
+    def test_eot_single_fragment(self):
+        """Test a single-frame image where the frame is one fragment"""
+        # 1 frame, 1 fragment long
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+        )
+        eot = ([0], [4])
+        assert get_frame(buffer, 0, extended_offsets=eot) == b"\x01\x00\x00\x00"
+
+        msg = "The encapsulated pixel data only contains 1 frame"
+        with pytest.raises(ValueError, match=msg):
+            get_frame(buffer, 1)
+
+    def test_eot_multi_fragment(self):
+        """Test a single-frame image where the frame is three fragments"""
+        # 3 frames, 1 fragments long
+        buffer = (
+            b"\xFE\xFF\x00\xE0"
+            b"\x00\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x01\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x02\x00\x00\x00"
+            b"\xFE\xFF\x00\xE0"
+            b"\x04\x00\x00\x00"
+            b"\x03\x00\x00\x00"
+        )
+        eot = ([0, 12, 24], [4, 4, 4])
+
+        assert get_frame(buffer, 0, extended_offsets=eot) == b"\x01\x00\x00\x00"
+        assert get_frame(buffer, 1, extended_offsets=eot) == b"\x02\x00\x00\x00"
+        assert get_frame(buffer, 2, extended_offsets=eot) == b"\x03\x00\x00\x00"
+
+        msg = "There is insufficient pixel data to contain 4 frames"
+        with pytest.raises(ValueError, match=msg):
+            get_frame(buffer, 3, extended_offsets=eot)

--- a/tests/test_encaps.py
+++ b/tests/test_encaps.py
@@ -2502,7 +2502,7 @@ class TestGenerateFrames:
             assert reference[-10:] == b"\x56\xF7\xFF\x4E\x60\xE3\xDA\x0F\xFF\xD9"
 
         with open(JP2K_10FRAME_NOBOT, "rb") as f:
-            mm = mmap.mmap(f.fileno(), 0, prot=mmap.PROT_READ)
+            mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
             # Start of BOT is at offset 2352
             mm.seek(elem.file_tell)
             # frame 9 (index 8) starts at offset 32802 and is 3754 bytes long
@@ -2899,7 +2899,7 @@ class TestGetFrame:
             assert reference[-10:] == b"\x56\xF7\xFF\x4E\x60\xE3\xDA\x0F\xFF\xD9"
 
         with open(JP2K_10FRAME_NOBOT, "rb") as f:
-            mm = mmap.mmap(f.fileno(), 0, prot=mmap.PROT_READ)
+            mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
             # Start of BOT is at offset 2352
             mm.seek(elem.file_tell)
             # frame 9 (index 8) starts at offset 32802 and is 3754 bytes long

--- a/tests/test_encoders_pydicom.py
+++ b/tests/test_encoders_pydicom.py
@@ -14,7 +14,7 @@ except ImportError:
 from pydicom import dcmread, Dataset
 from pydicom.data import get_testdata_file
 from pydicom.dataset import FileMetaDataset
-from pydicom.encaps import defragment_data
+from pydicom.encaps import get_frame
 from pydicom.encoders import RLELosslessEncoder
 from pydicom.encoders.native import _encode_frame, _encode_segment, _encode_row
 from pydicom.pixel_data_handlers.rle_handler import (
@@ -335,7 +335,7 @@ class TestEncodeSegment:
     def test_one_row(self):
         """Test encoding data that contains only a single row."""
         ds = dcmread(RLE_8_1_1F)
-        pixel_data = defragment_data(ds.PixelData)
+        pixel_data = get_frame(ds.PixelData, 0)
         decoded = _rle_decode_segment(pixel_data[64:])
         assert ds.Rows * ds.Columns == len(decoded)
         arr = np.frombuffer(decoded, "uint8").reshape(ds.Rows, ds.Columns)
@@ -353,7 +353,7 @@ class TestEncodeSegment:
     def test_cycle(self):
         """Test the decoded data remains the same after encoding/decoding."""
         ds = dcmread(RLE_8_1_1F)
-        pixel_data = defragment_data(ds.PixelData)
+        pixel_data = get_frame(ds.PixelData, 0)
         decoded = _rle_decode_segment(pixel_data[64:])
         assert ds.Rows * ds.Columns == len(decoded)
         # Re-encode the decoded data

--- a/tests/test_gdcm_pixel_data.py
+++ b/tests/test_gdcm_pixel_data.py
@@ -19,7 +19,7 @@ except ImportError:
 import pydicom
 from pydicom.filereader import dcmread
 from pydicom.data import get_testdata_file
-from pydicom.encaps import defragment_data
+from pydicom.encaps import get_frame
 from pydicom.pixel_data_handlers import numpy_handler, gdcm_handler
 from pydicom.pixel_data_handlers.util import (
     _convert_YBR_FULL_to_RGB,
@@ -514,7 +514,7 @@ class TestsWithGDCM:
         assert 1 == ds.PixelRepresentation
         assert 13 == ds.BitsStored
 
-        bs = defragment_data(ds.PixelData)
+        bs = get_frame(ds.PixelData, 0)
         params = get_j2k_parameters(bs)
         assert 13 == params["precision"]
         assert not params["is_signed"]

--- a/tests/test_jpeg_ls_pixel_data.py
+++ b/tests/test_jpeg_ls_pixel_data.py
@@ -15,7 +15,7 @@ import pytest
 
 import pydicom
 from pydicom.data import get_testdata_file
-from pydicom.encaps import encapsulate, generate_pixel_data_frame
+from pydicom.encaps import encapsulate, generate_frames
 from pydicom.filereader import dcmread
 from pydicom.pixel_data_handlers import numpy_handler
 from pydicom.pixel_data_handlers import jpeg_ls_handler
@@ -193,7 +193,7 @@ class TestJPEGLS_JPEG_LS_with_jpeg_ls:
         """Test a frame split across multiple fragments."""
         ds = dcmread(jpeg_ls_lossless_name)
         ref = ds.pixel_array
-        frame = next(generate_pixel_data_frame(ds.PixelData, 1))
+        frame = next(generate_frames(ds.PixelData, number_of_frames=1))
         ds.PixelData = encapsulate([frame, frame], fragments_per_frame=4)
         ds.NumberOfFrames = 2
         assert np.array_equal(ds.pixel_array[0], ref)

--- a/tests/test_pylibjpeg.py
+++ b/tests/test_pylibjpeg.py
@@ -5,7 +5,7 @@ import pytest
 
 import pydicom
 from pydicom.data import get_testdata_file
-from pydicom.encaps import defragment_data
+from pydicom.encaps import get_frame
 from pydicom.filereader import dcmread
 from pydicom.pixel_data_handlers.util import (
     convert_color_space,
@@ -746,7 +746,7 @@ class TestJPEG2K:
         assert 1 == ds.PixelRepresentation
         assert 13 == ds.BitsStored
 
-        bs = defragment_data(ds.PixelData)
+        bs = get_frame(ds.PixelData, 0)
         params = get_j2k_parameters(bs)
         assert 13 == params["precision"]
         assert not params["is_signed"]


### PR DESCRIPTION
#### Describe the changes
* Adds the following encapsulation functions:
  * `parse_basic_offsets`
  * `parse_fragments`
  * `generate_fragments`
  * `generate_fragmented_frames`
  * `generate_frames`
  * `get_frame`
* Deprecates the following:
  * `get_frame_offsets` 
  * `get_nr_frames` 
  * `generate_pixel_data_fragment`
  * `generate_pixel_data_frame`
  * `generate_pixel_data`
  * `decode_data_sequence`
  * `defragement_data`
  * `read_item`
* Adds support for `bytes` | `BinaryIO` | `filebase.ReadableBuffer` as the encapsulated data source
* Adds support for the Extended Offsets Table
* Adds support for non-conformant big endian encoded encapsulation, probably never get used but it's there
* Adds `get_frame` to allow accessing a specific encoded frame without having to read all the preceding pixel data into memory (via BinaryIO/mmap).

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/3638af13-65f6-4036-88d0-0b3376d23414/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
