### PR TITLE
[MRG] Switch Circle build deploy step to run step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "36:ae:e2:2f:a7:11:f1:3f:d5:45:1d:c1:ef:55:0b:9d"
-      - deploy:
+      - run:
           name: Deploy documentation
           environment:
             USERNAME: darcymason


### PR DESCRIPTION
#### Describe the changes
`deploy` step is deprecated, [needs to be changed to run](https://circleci.com/docs/migrate-from-deploy-to-run/)

tests/test_encoders.py::TestDatasetCompress::test_round_trip seems to be intermittently failing, too...

#### Tasks
- [x] Fix or feature added
- [x] [Documentation updated (if relevant)
](https://output.circle-artifacts.com/output/job/a02a3b64-06bf-434d-ac34-ee04cd68a75d/artifacts/0/doc/_build/html/index.html)