### PR TITLE
[MRG] Apply Repo-Review suggestions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
-      - id: requirements-txt-fixer
       - id: trailing-whitespace
 repos:
 - repo: https://github.com/crate-ci/typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,20 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+repos:
 - repo: https://github.com/crate-ci/typos
   rev: v1.16.25
   hooks:
@@ -11,8 +25,15 @@ repos:
   rev: v0.1.9
   hooks:
   - id: ruff
-    args: [src, --fix, --exit-non-zero-on-fix]
-- repo: https://github.com/psf/black
+    args: [src, --fix, --show-fixes, --exit-non-zero-on-fix]
+- repo: https://github.com/psf/black-pre-commit-mirror
   rev: 23.12.1
   hooks:
   - id: black
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.7.1
+  hooks:
+    - id: mypy
+      files: src
+      args: []
+      additional_dependencies: ["types-requests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,12 @@ force-exclude = ".venv|/_.*_dict.py$"  # to not do files pre-commit asks for
 
 
 [tool.ruff]
+src = ["src"]
+line-length = 214
+target-version = "py310"
+include = ["src/*.py", "tests/*.py", "doc/*.py"]
+
+[tool.ruff.lint]
 select = [
     "UP",
     "C9",
@@ -108,20 +114,17 @@ ignore = [
     "PLW0603",
     "PLW2901",
 ]
-line-length = 214
-target-version = "py310"
-include = ["src/*.py", "tests/*.py", "doc/*.py"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 36
 
-[tool.ruff.pylint]
+[tool.ruff.lint.pylint]
 max-args = 17
 max-branches = 43
 max-returns = 9
 max-statements = 108
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "*/__init__.py" = ["F401"]
 "src/pydicom/config.py" = ["PLW0602"]
 "src/pydicom/sr/_concepts_dict.py" = ["F601"]
@@ -131,7 +134,7 @@ max-statements = 108
 python_version = "3.10"
 files = "src/"
 exclude = ["src/pydicom/benchmarks/", "src/pydicom/pixel_data_handlers/pillow_handler.py"]
-show_error_codes = true
+hide_error_codes = false
 warn_redundant_casts = false
 warn_unused_ignores = false
 warn_return_any = true
@@ -140,7 +143,7 @@ ignore_missing_imports = true
 disallow_untyped_calls = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
-disable_error_code = ["method-assign"]
+disable_error_code = ["method-assign", "ignore-without-code", "redundant-expr", "truthy-bool"]
 
 [[tool.mypy.overrides]]
 # 2023-06: mypy complains for a line in this file if ignore used or not.


### PR DESCRIPTION
#### Describe the changes

Apply some [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=pydicom%2Fpydicom&branch=main) suggestions.

I went for the low-hanging fruits, other changes are more invasive and deserve a PR of their own, such as enabling more ruff rules (#1771).
* [PC100](https://learn.scientific-python.org/development/guides/style#PC100): Has pre-commit-hooks
  Must have `https://github.com/pre-commit/pre-commit-hooks` repo in `.pre-commit-config.yaml`
* [PC110](https://learn.scientific-python.org/development/guides/style#PC110): Uses black or ruff-format
  Use `https://github.com/psf/black-pre-commit-mirror` instead of `https://github.com/psf/black` in `.pre-commit-config.yaml`
* [PC140](https://learn.scientific-python.org/development/guides/style#PC140): Uses mypy
  Must have `https://github.com/pre-commit/mirrors-mypy` repo in `.pre-commit-config.yaml`
* PC140: Uses mypy
  Must have `https://github.com/pre-commit/mirrors-mypy` repo in `.pre-commit-config.yaml`
* [PC191](https://learn.scientific-python.org/development/guides/style#PC191): Ruff show fixes if fixes enabled
  If `--fix` is present, `--show-fixes` must be too.
* [MY104](https://learn.scientific-python.org/development/guides/style#MY104): MyPy enables ignore-without-code
  Must have `"ignore-without-code"` in `enable_error_code = [...]`. This will force all skips in your project to include the error code, which makes them more readable, and avoids skipping something unintended.
  ```toml
  [tool.mypy]
  enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
  ```
* [MY105](https://learn.scientific-python.org/development/guides/style#MY105): MyPy enables redundant-expr
  Must have `"redundant-expr"` in `enable_error_code = [...]`. This helps catch useless lines of code, like checking the same condition twice.
  ```toml
  [tool.mypy]
  enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
  ```
* [MY106](https://learn.scientific-python.org/development/guides/style#MY106): MyPy enables truthy-bool
  Must have `"truthy-bool"` in `enable_error_code = []`. This catches mistakes in using a value as truthy if it cannot be falsey.
  ```toml
  [tool.mypy]
  enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
  ```
* [RF003](https://learn.scientific-python.org/development/guides/style#RF003): src directory specified if used
  Must specify `src` directory if it exists.
  ```toml
  [tool.ruff]
  src = ["src"]
  ```
* RF202: Use (new) lint config section
  * `ignore` should be set as `lint.ignore` instead
  * `mccabe` should be set as `lint.mccabe` instead
  * `per-file-ignores` should be set as `lint.per-file-ignores` instead
  * `pylint` should be set as `lint.pylint` instead
  * `select` should be set as `lint.select` instead

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
