### PR TITLE
[MRG] Add mitigation for pixel data memory re-use issue with id()

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -155,6 +155,9 @@ Fixes
   explicit and implicit VR when only the *Transfer Syntax UID* was changed (:issue:`1943`)
 * Fixed the ``jpeg_ls``, ``pillow`` and ``rle`` pixel data handlers not working
   correctly when a frame is spread across multiple fragments (:issue:`1774`)
+* Added mitigation for a rare case where clearing the pixel data value prior
+  to updating it may sometimes result in :attr:`~pydicom.dataset.Dataset.pixel_array`
+  returning the previous array instead of creating a new one (:issue:`1983`)
 
 
 Deprecations

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -1656,15 +1656,15 @@ class Dataset:
         # Check if already have converted to a NumPy array
         # Also check if pixel data has changed. If so, get new NumPy array
         already_have = True
-
         if not hasattr(self, "_pixel_array"):
             already_have = False
         elif self._pixel_array is None:
             already_have = False
 
-        # The _pixel_id may give a false negative if the pixel data memory
-        #   has been freed prior to setting a new value it may reuse that memory
-        #   and therefore give the same `id()` value
+        # Chcking `_pixel_id` may sometimes give a false result if the pixel
+        #   data memory has been freed (such as with ds.PixelData = None)
+        #   prior to setting a new value; Python may reuse that freed memory
+        #   for the new value and therefore give the same `id()` value
         if self._pixel_id != get_image_pixel_ids(self):
             already_have = False
 

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -702,6 +702,10 @@ class Dataset:
                 # deleted - will be re-created on next access
                 if self._private_blocks and BaseTag(tag).is_private_creator:
                     self._private_blocks = {}
+
+                if tag in PIXEL_KEYWORDS:
+                    self._pixel_array = None
+                    self._pixel_id = {}
         elif isinstance(key, BaseTag):
             del self._dict[key]
             if self._private_blocks and key.is_private_creator:
@@ -719,7 +723,7 @@ class Dataset:
                 self._private_blocks = {}
 
             # Deleting pixel data resets the stored array
-            if key in PIXEL_KEYWORDS:
+            if tag in PIXEL_KEYWORDS:
                 self._pixel_array = None
                 self._pixel_id = {}
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1420,7 +1420,31 @@ class TestDataset:
         ds._pixel_id = {"SamplesPerPixel": 3}
         ds._pixel_array = True
 
+        del ds["PixelData"]
+        assert ds._pixel_id == {}
+        assert ds._pixel_array is None
+
+        ds.PixelData = b"\x00\x01"
+        ds._pixel_id = {"SamplesPerPixel": 3}
+        ds._pixel_array = True
+
+        del ds[Tag("PixelData")]
+        assert ds._pixel_id == {}
+        assert ds._pixel_array is None
+
+        ds.PixelData = b"\x00\x01"
+        ds._pixel_id = {"SamplesPerPixel": 3}
+        ds._pixel_array = True
+
         del ds[0x7FE00010]
+        assert ds._pixel_id == {}
+        assert ds._pixel_array is None
+
+        ds.PixelData = b"\x00\x01"
+        ds._pixel_id = {"SamplesPerPixel": 3}
+        ds._pixel_array = True
+
+        del ds[0x7FE00000:0x7FE00012]
         assert ds._pixel_id == {}
         assert ds._pixel_array is None
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1403,6 +1403,27 @@ class TestDataset:
 
         pydicom.config.pixel_data_handlers = orig_handlers
 
+    def test_pixel_array_id_reset_on_delete(self):
+        """Test _pixel_array and _pixel_id reset when deleting pixel data"""
+        fpath = get_testdata_file("CT_small.dcm")
+        ds = dcmread(fpath)
+        assert ds._pixel_id == {}
+        assert ds._pixel_array is None
+        ds._pixel_id = {"SamplesPerPixel": 3}
+        ds._pixel_array = True
+
+        del ds.PixelData
+        assert ds._pixel_id == {}
+        assert ds._pixel_array is None
+
+        ds.PixelData = b"\x00\x01"
+        ds._pixel_id = {"SamplesPerPixel": 3}
+        ds._pixel_array = True
+
+        del ds[0x7FE00010]
+        assert ds._pixel_id == {}
+        assert ds._pixel_array is None
+
     def test_pixel_array_unknown_syntax(self):
         """Test that pixel_array for an unknown syntax raises exception."""
         ds = dcmread(get_testdata_file("CT_small.dcm"))

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1055,11 +1055,11 @@ class TestDatasetCompress:
         """Test an encoding round-trip"""
         ds = get_testdata_file("MR_small_RLE.dcm", read=True)
         arr = ds.pixel_array
+        # Setting PixelData to None frees the memory which may
+        #   sometimes be reused, causes the _pixel_id check to fail
         ds.PixelData = None
         ds._pixel_array = None
         ds.compress(RLELossless, arr, encoding_plugin="pydicom")
-        # `pixel_array` will be regenerated
-        assert ds._pixel_array is None
         assert ds.PixelData is not None
         assert np.array_equal(arr, ds.pixel_array)
 


### PR DESCRIPTION
#### Describe the changes
When PixelData (or other pixel elements) are set to `None` prior to having their value updated then `get_pixel_ids()` may sometimes return the same `id()` value because the freed memory gets reused. This PR attempts to mitigate this by resetting the `Dataset._pixel_array` and `Dataset._pixel_id` attr values to their defaults whenever the value of Pixel Data, Float Pixel Data or  Double Float Pixel Data are changed or deleted.

I couldn't come up with a way of tracking whether the pixel data values changed without creating a separate reference, which obviously isn't a great idea for a bulk data element.

Closes #1983 (again)

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
