### PR TITLE
[MRG] Add support for using registered private transfer syntaxes with dcmread()

### DIFF
--- a/doc/reference/uid.rst
+++ b/doc/reference/uid.rst
@@ -65,6 +65,7 @@ Transfer Syntax Lists
    MPEGTransferSyntaxes
    RLETransferSyntaxes
    UncompressedTransferSyntaxes
+   PrivateTransferSyntaxes
 
 
 UID Utilities
@@ -74,6 +75,7 @@ UID Utilities
    :toctree: generated/
 
    generate_uid
+   register_transfer_syntax
    PYDICOM_ROOT_UID
    PYDICOM_IMPLEMENTATION_UID
    RE_VALID_UID

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -133,6 +133,9 @@ Enhancements
 * Added the ability to set the corresponding dataset encoding for private transfer
   syntaxes to :class:`~pydicom.uid.UID` via the :meth:`~pydicom.uid.UID.set_private_encoding`
   method
+* Added the ability to register private transfer syntaxes with
+  :func:`~pydicom.uid.register_transfer_syntax` so they can be used when reading
+  datasets with :func:`~pydicom.filereader.dcmread`
 * Warning messages are also sent to the pydicom logger (:issue:`1529`)
 
 

--- a/src/pydicom/filereader.py
+++ b/src/pydicom/filereader.py
@@ -894,6 +894,12 @@ def read_partial(
         unzipped = zlib.decompress(zipped, -zlib.MAX_WBITS)
         fileobj = BytesIO(unzipped)  # a file-like object
         is_implicit_VR = False
+    elif transfer_syntax in pydicom.uid.PrivateTransferSyntaxes:
+        # Replace with the registered UID as it has the encoding information
+        index = pydicom.uid.PrivateTransferSyntaxes.index(transfer_syntax)
+        transfer_syntax = pydicom.uid.PrivateTransferSyntaxes[index]
+        is_implicit_VR = transfer_syntax.is_implicit_VR
+        is_little_endian = transfer_syntax.is_little_endian
     else:
         # Any other syntax should be Explicit VR Little Endian,
         #   e.g. all Encapsulated (JPEG etc) are ExplVR-LE
@@ -1037,12 +1043,10 @@ def dcmread(
     if config.debugging:
         logger.debug("\n" + "-" * 80)
         logger.debug("Call to dcmread()")
-        msg = (
-            "filename:'%s', defer_size='%s', "
-            "stop_before_pixels=%s, force=%s, specific_tags=%s"
-        )
         logger.debug(
-            msg % (fp.name, defer_size, stop_before_pixels, force, specific_tags)
+            f"filename: {getattr(fp, 'name', '<none>')}, defer_size={defer_size}, "
+            f"stop_before_pixels={stop_before_pixels}, force={force}, "
+            f"specific_tags={specific_tags}"
         )
         if caller_owns_file:
             logger.debug("Caller passed file object")

--- a/src/pydicom/uid.py
+++ b/src/pydicom/uid.py
@@ -468,8 +468,7 @@ def register_transfer_syntax(
     pydicom.uid.UID
         The registered UID.
     """
-    if not isinstance(uid, UID):
-        uid = UID(uid)
+    uid = UID(uid)
 
     if None in (implicit_vr, little_endian) and not uid.is_transfer_syntax:
         raise ValueError(

--- a/src/pydicom/uid.py
+++ b/src/pydicom/uid.py
@@ -73,7 +73,12 @@ class UID(str):
             if validation_mode is None:
                 validation_mode = config.settings.reading_validation_mode
             validate_value("UI", val, validation_mode)
-            return super().__new__(cls, val.strip())
+
+            uid = super().__new__(cls, val.strip())
+            if hasattr(val, "_PRIVATE_TS_ENCODING"):
+                uid._PRIVATE_TS_ENCODING = val._PRIVATE_TS_ENCODING
+
+            return uid
 
         raise TypeError("A UID must be created from a string")
 
@@ -233,10 +238,10 @@ class UID(str):
         ----------
         implicit_vr : bool
             ``True`` if the corresponding dataset encoding uses implicit VR,
-            ``False`` otherwise.
+            ``False`` for explicit VR.
         little_endian : bool
             ``True`` if the corresponding dataset encoding uses little endian
-            byte order, ``False`` otherwise.
+            byte order, ``False`` for big endian byte order.
         """
         self._PRIVATE_TS_ENCODING = (implicit_vr, little_endian)
 
@@ -427,6 +432,58 @@ UncompressedTransferSyntaxes = [
     ExplicitVRBigEndian,
 ]
 """Uncompressed (native) transfer syntaxes."""
+
+PrivateTransferSyntaxes = []
+"""Private transfer syntaxes added using the
+:func:`~pydicom.uid.register_transfer_syntax` function.
+"""
+
+
+def register_transfer_syntax(
+    uid: str | UID,
+    implicit_vr: bool | None = None,
+    little_endian: bool | None = None,
+) -> UID:
+    """Register a private transfer syntax with the :mod:`~pydicom.uid` module
+    so it can be used when reading datasets with :func:`~pydicom.filereader.dcmread`.
+
+    .. versionadded: 3.0
+
+    Parameters
+    ----------
+    uid : str | pydicom.uid.UID
+        A UID which may or may not have had the corresponding dataset encoding
+        set using :meth:`~pydicom.uid.UID.set_private_encoding`.
+    implicit_vr : bool, optional
+        If ``True`` then the transfer syntax uses implicit VR encoding, otherwise
+        if ``False`` then it uses explicit VR encoding. Required when `uid` has
+        not had the encoding set using :meth:`~pydicom.uid.UID.set_private_encoding`.
+    little_endian : bool, optional
+        If ``True`` then the transfer syntax uses little endian encoding, otherwise
+        if ``False`` then it uses big endian encoding. Required when `uid` has
+        not had the encoding set using :meth:`~pydicom.uid.UID.set_private_encoding`.
+
+    Returns
+    -------
+    pydicom.uid.UID
+        The registered UID.
+    """
+    if not isinstance(uid, UID):
+        uid = UID(uid)
+
+    if None in (implicit_vr, little_endian) and not uid.is_transfer_syntax:
+        raise ValueError(
+            "The corresponding dataset encoding for 'uid' must be set using "
+            "the 'implicit_vr' and 'little_endian' arguments"
+        )
+
+    if implicit_vr is not None and little_endian is not None:
+        uid.set_private_encoding(implicit_vr, little_endian)
+
+    if uid not in PrivateTransferSyntaxes:
+        PrivateTransferSyntaxes.append(uid)
+
+    return uid
 
 
 _MAX_PREFIX_LENGTH = 54


### PR DESCRIPTION
#### Describe the changes
* Adds `uid.PrivateTransferSyntaxes`
* Adds `uid.register_transfer_syntax()`
* Fixes loss of encoding for `UID(private_uid)`
* Adds support for using registered private transfer syntaxes during reading

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/9121cc88-bfab-4f45-b46f-55acbd47ffe1/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
