### PR TITLE
[MRG] Allow accessing a deferred element via Dataset.get_item()

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -134,6 +134,9 @@ Enhancements
   syntaxes to :class:`~pydicom.uid.UID` via the :meth:`~pydicom.uid.UID.set_private_encoding`
   method
 * Warning messages are also sent to the pydicom logger (:issue:`1529`)
+* Added the `keep_deferred` keyword argument to :meth:`Dataset.get_item()
+  <pydicom.dataset.Dataset.get_item>` to allow accessing the file offset and
+  element length without having to read the element value. (:issue:`1873`)
 
 
 Fixes

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -1197,21 +1197,28 @@ class Dataset:
         return self.__getitem__(block.get_tag(element_offset))
 
     @overload
-    def get_item(self, key: slice) -> "Dataset":
+    def get_item(self, key: slice, *, keep_deferred: bool = ...) -> "Dataset":
         pass  # pragma: no cover
 
     @overload
-    def get_item(self, key: TagType) -> DataElement:
+    def get_item(self, key: TagType, *, keep_deferred: bool = ...) -> DataElement:
         pass  # pragma: no cover
 
     def get_item(
-        self, key: "slice | TagType"
+        self,
+        key: "slice | TagType",
+        *,
+        keep_deferred: bool = False,
     ) -> "Dataset | DataElement | RawDataElement | None":
         """Return the raw data element if possible.
 
         It will be raw if the user has never accessed the value, or set their
         own value. Note if the data element is a deferred-read element,
         then it is read and converted before being returned.
+
+        .. versionchanged: 3.0
+
+            Added the `keep_deferred` keyword argument.
 
         Parameters
         ----------
@@ -1220,10 +1227,14 @@ class Dataset:
             :func:`~pydicom.tag.Tag` such as ``[0x0010, 0x0010]``,
             ``(0x10, 0x10)``, ``0x00100010``, etc. May also be a :class:`slice`
             made up of DICOM tags.
+        keep_deferred : bool, optional
+            If ``True`` then when returning :class:`~pydicom.dataelem.RawDataElement`
+            do not perform the deferred read of the element's value (accessing
+            the value will return ``None`` instead). Default ``False``.
 
         Returns
         -------
-        dataelem.DataElement
+        dataelem.DataElement | dataelem.RawDataElement
             The corresponding element.
         """
         if isinstance(key, slice):
@@ -1231,7 +1242,11 @@ class Dataset:
 
         elem = self._dict.get(Tag(key))
         # If a deferred read, return using __getitem__ to read and convert it
-        if isinstance(elem, RawDataElement) and elem.value is None:
+        if (
+            isinstance(elem, RawDataElement)
+            and not keep_deferred
+            and elem.value is None
+        ):
             return self[key]
 
         return elem

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1024,6 +1024,18 @@ class TestDataset:
         # Slice all items - should return original dataset
         assert ds == ds.get_item(slice(None, None))
 
+    def test_getitem_deferred(self):
+        """Test get_item(..., keep_deferred)"""
+        test_file = get_testdata_file("MR_small.dcm")
+        ds = dcmread(test_file, force=True, defer_size="0.8 kB")
+        elem = ds.get_item("PixelData", keep_deferred=True)
+        assert isinstance(elem, RawDataElement)
+        assert elem.value is None
+
+        elem = ds.get_item("PixelData", keep_deferred=False)
+        assert isinstance(elem, DataElement)
+        assert elem.value is not None
+
     def test_get_private_item(self):
         ds = Dataset()
         ds.add_new(0x00080005, "CS", "ISO_IR 100")


### PR DESCRIPTION
#### Describe the changes
* Allow returning a deferred `RawDataElement` via `Dataset.get_item()`
* Closes #1873

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
