### PR TITLE
[MRG] Handle code comparision when SRT code not in mapping

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -135,6 +135,9 @@ Fixes
   :meth:`Dataset.update<pydicom.dataset.Dataset.update>` (:issue:`1816`)
 * Fixed :func:`~pydicom.encaps.encapsulate_extended` not returning the correct
   values for odd-length frames (:issue:`1968`)
+* Fixed a ``KeyError`` when comparing codes with one of the codes having
+``scheme_designator`` set to ``SRT`` but not being included in the ``SRT``
+to ``SCT`` code mapping (:issue:`1994`)
 
 Pydicom Internals
 -----------------

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -179,8 +179,8 @@ Fixes
 * Fixed the ``jpeg_ls``, ``pillow`` and ``rle`` pixel data handlers not working
   correctly when a frame is spread across multiple fragments (:issue:`1774`)
 * Fixed a ``KeyError`` when comparing codes with one of the codes having
-``scheme_designator`` set to ``SRT`` but not being included in the ``SRT``
-to ``SCT`` code mapping (:issue:`1994`)
+  ``scheme_designator`` set to ``SRT`` but not being included in the ``SRT``
+  to ``SCT`` code mapping (:issue:`1994`)
 
 
 Deprecations

--- a/src/pydicom/sr/coding.py
+++ b/src/pydicom/sr/coding.py
@@ -22,7 +22,10 @@ class Code(NamedTuple):
         return hash(self.scheme_designator + self.value)
 
     def __eq__(self, other: Any) -> Any:
-        if self.scheme_designator == "SRT" and self.value in snomed_mapping["SRT"]:
+        if (
+            self.scheme_designator == "SRT"
+            and self.value in snomed_mapping["SRT"]
+        ):
             self_mapped = Code(
                 value=snomed_mapping["SRT"][self.value],
                 meaning="",
@@ -37,7 +40,10 @@ class Code(NamedTuple):
                 scheme_version=self.scheme_version,
             )
 
-        if other.scheme_designator == "SRT" and other.value in snomed_mapping["SRT"]:
+        if (
+            other.scheme_designator == "SRT"
+            and other.value in snomed_mapping["SRT"]
+        ):
             other_mapped = Code(
                 value=snomed_mapping["SRT"][other.value],
                 meaning="",

--- a/src/pydicom/sr/coding.py
+++ b/src/pydicom/sr/coding.py
@@ -22,10 +22,7 @@ class Code(NamedTuple):
         return hash(self.scheme_designator + self.value)
 
     def __eq__(self, other: Any) -> Any:
-        if (
-            self.scheme_designator == "SRT"
-            and self.value in snomed_mapping["SRT"]
-        ):
+        if self.scheme_designator == "SRT" and self.value in snomed_mapping["SRT"]:
             self_mapped = Code(
                 value=snomed_mapping["SRT"][self.value],
                 meaning="",
@@ -40,10 +37,7 @@ class Code(NamedTuple):
                 scheme_version=self.scheme_version,
             )
 
-        if (
-            other.scheme_designator == "SRT"
-            and other.value in snomed_mapping["SRT"]
-        ):
+        if other.scheme_designator == "SRT" and other.value in snomed_mapping["SRT"]:
             other_mapped = Code(
                 value=snomed_mapping["SRT"][other.value],
                 meaning="",

--- a/src/pydicom/sr/coding.py
+++ b/src/pydicom/sr/coding.py
@@ -22,7 +22,7 @@ class Code(NamedTuple):
         return hash(self.scheme_designator + self.value)
 
     def __eq__(self, other: Any) -> Any:
-        if self.scheme_designator == "SRT":
+        if self.scheme_designator == "SRT" and self.value in snomed_mapping["SRT"]:
             self_mapped = Code(
                 value=snomed_mapping["SRT"][self.value],
                 meaning="",
@@ -37,7 +37,7 @@ class Code(NamedTuple):
                 scheme_version=self.scheme_version,
             )
 
-        if other.scheme_designator == "SRT":
+        if other.scheme_designator == "SRT" and other.value in snomed_mapping["SRT"]:
             other_mapped = Code(
                 value=snomed_mapping["SRT"][other.value],
                 meaning="",

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -91,6 +91,12 @@ class TestCode:
         assert c1 == c2
         assert c2 == c1
 
+    def test_equal_not_in_snomed_mapping(self):
+        c1 = Code(self._value, self._scheme_designator, self._meaning)
+        c2 = Code("bla bal bla", "SRT", self._meaning)
+        assert c1 != c2
+        assert c2 != c1
+
 
 class TestCodesDict:
     def test_dcm_1(self):


### PR DESCRIPTION
#### Describe the changes
When doing `SRT` to `SCT` mapping check that the code is in the snomed dict. Closes #1994.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
