### PR TITLE
[MRG] Improve robustness of version check for decoding plugins

### DIFF
--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -63,10 +63,11 @@ def _passes_version_check(package_name: str, minimum_version: tuple[int, ...]) -
     """
     try:
         module = importlib.import_module(package_name, "__version__")
-    except ModuleNotFoundError:
-        return False
+        return tuple(int(x) for x in module.__version__.split(".")) >= minimum_version
+    except Exception as exc:
+        LOGGER.exception(exc)
 
-    return tuple(int(x) for x in module.__version__.split(".")) >= minimum_version
+    return False
 
 
 # TODO: Python 3.11 switch to StrEnum

--- a/tests/pixels/test_decoder_base.py
+++ b/tests/pixels/test_decoder_base.py
@@ -1517,7 +1517,7 @@ class TestDecoder_Array:
             decoder.as_array(reference.ds, view_only=True)
             assert msg in caplog.text
 
-    def test_expb_ow_index_invalid_raises(self, caplog):
+    def test_expb_ow_index_invalid_raises(self):
         """Test invalid index with BE swapped OW raises"""
         decoder = get_decoder(ExplicitVRBigEndian)
         reference = EXPB_8_1_1F
@@ -1873,7 +1873,7 @@ class TestDecoder_Buffer:
 
         assert len(buffer) == 11 * 64 * 64 * 2
 
-    def test_expb_ow_index_invalid_raises(self, caplog):
+    def test_expb_ow_index_invalid_raises(self):
         """Test invalid index with BE swapped OW raises"""
         decoder = get_decoder(ExplicitVRBigEndian)
         reference = EXPB_8_1_1F

--- a/tests/pixels/test_decoder_gdcm.py
+++ b/tests/pixels/test_decoder_gdcm.py
@@ -1,6 +1,7 @@
 """Test the GDCM decoder."""
 
 import importlib
+import logging
 
 import pytest
 
@@ -12,6 +13,7 @@ except ImportError:
     HAVE_NP = False
 
 from pydicom.pixels import get_decoder
+from pydicom.pixels.utils import _passes_version_check
 from pydicom.uid import (
     JPEGBaseline8Bit,
     JPEGExtended12Bit,
@@ -127,3 +129,12 @@ class TestDecoding:
         assert arr.shape == reference.shape
         assert arr.dtype == reference.dtype
         assert arr.flags.writeable
+
+
+@pytest.mark.skipif(SKIP_TEST, reason="Test is missing dependencies")
+def test_version_check(caplog):
+    """Test _passes_version_check() when the package has no __version__"""
+    # GDCM doesn't have a __version__ attribute
+    with caplog.at_level(logging.ERROR, logger="pydicom"):
+        assert _passes_version_check("gdcm", (3, 0)) is False
+        assert "module 'gdcm' has no attribute '__version__'" in caplog.text

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -350,13 +350,7 @@ class TestIterPixels:
 
 
 def test_version_check(caplog):
-    """Test _passes_version_check() when the package has no __version__"""
-    # GDCM doesn't have a __version__ attribute
-    with caplog.at_level(logging.ERROR, logger="pydicom"):
-        assert _passes_version_check("gdcm", (3, 0)) is False
-        assert "module 'gdcm' has no attribute '__version__'" in caplog.text
-
-    caplog.clear()
+    """Test _passes_version_check() when the package is absent"""
     with caplog.at_level(logging.ERROR, logger="pydicom"):
         assert _passes_version_check("foo", (3, 0)) is False
         assert "No module named 'foo'" in caplog.text

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -1,5 +1,6 @@
 import importlib
 from io import BytesIO
+import logging
 import os
 
 import pytest
@@ -14,7 +15,7 @@ except ImportError:
 from pydicom import dcmread, Dataset
 from pydicom.pixel_data_handlers.util import convert_color_space
 from pydicom.pixels import pixel_array, iter_pixels
-from pydicom.pixels.utils import _as_options
+from pydicom.pixels.utils import _as_options, _passes_version_check
 from pydicom.uid import EnhancedMRImageStorage, ExplicitVRLittleEndian
 
 from .pixels_reference import (
@@ -346,3 +347,16 @@ class TestIterPixels:
         pylibjpeg_gen = iter_pixels(RLE_16_1_10F.path, decoding_plugin="pylibjpeg")
         for frame1, frame2 in zip(pydicom_gen, pylibjpeg_gen):
             assert np.array_equal(frame1, frame2)
+
+
+def test_version_check(caplog):
+    """Test _passes_version_check() when the package has no __version__"""
+    # GDCM doesn't have a __version__ attribute
+    with caplog.at_level(logging.ERROR, logger="pydicom"):
+        assert _passes_version_check("gdcm", (3, 0)) is False
+        assert "module 'gdcm' has no attribute '__version__'" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.ERROR, logger="pydicom"):
+        assert _passes_version_check("foo", (3, 0)) is False
+        assert "No module named 'foo'" in caplog.text


### PR DESCRIPTION
#### Describe the changes
Makes `_passes_version_check()` more robust

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
