### PR TITLE
dataset.py - compress() sets PixelData VR to 'OB'

### DIFF
--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -1954,7 +1954,7 @@ class Dataset:
             self.PixelData = encapsulate(encoded)
 
         # Might have been OW originally but must be OB now
-        self["PixelData"].VR = 'OB'
+        self["PixelData"].VR = "OB"
 
         # PS3.5 Annex A.4 - encapsulated pixel data uses undefined length
         self["PixelData"].is_undefined_length = True

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -1953,6 +1953,9 @@ class Dataset:
         else:
             self.PixelData = encapsulate(encoded)
 
+        # Might have been OW originally but must be OB now
+        self["PixelData"].VR = 'OB'
+
         # PS3.5 Annex A.4 - encapsulated pixel data uses undefined length
         self["PixelData"].is_undefined_length = True
         self._pixel_array = None

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -1954,7 +1954,7 @@ class Dataset:
             self.PixelData = encapsulate(encoded)
 
         # Might have been OW originally but must be OB now
-        self["PixelData"].VR = "OB"
+        self["PixelData"].VR = VR_.OB
 
         # PS3.5 Annex A.4 - encapsulated pixel data uses undefined length
         self["PixelData"].is_undefined_length = True


### PR DESCRIPTION
Just in case it was originally 'OW' (e.g. 16-bit pixels) but after compression is not an even number of bytes then it must be set to 'OB' instead. Fixes #2013 

<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
The related issue or a description of the bug or feature that this PR addresses.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
