### PR TITLE
[MRG] handle (0028,0101) "Bits Stored" in numpy handler

### DIFF
--- a/tests/test_handler_util.py
+++ b/tests/test_handler_util.py
@@ -1236,21 +1236,17 @@ class TestNumpy_ModalityLUT:
         assert [4096, -2048, 16] == seq.LUTDescriptor
         arr = ds.pixel_array
         assert -2048 == arr.min()
-        assert 4095 == arr.max()
+        assert 2047 == arr.max()
         out = apply_modality_lut(arr, ds)
 
-        # IV > 2047 -> LUT[4095]
-        mapped_pixels = arr > 2047
-        assert seq.LUTData[-1] == out[mapped_pixels][0]
-        assert (seq.LUTData[-1] == out[mapped_pixels]).all()
         assert out.flags.writeable
         assert out.dtype == np.uint16
 
-        assert [65535, 65535, 49147, 49147, 65535] == list(out[0, 50:55])
-        assert [65535, 65535, 65535, 65535, 65535] == list(out[50, 50:55])
-        assert [65535, 65535, 65535, 65535, 65535] == list(out[100, 50:55])
-        assert [65535, 65535, 49147, 49147, 65535] == list(out[150, 50:55])
-        assert [65535, 65535, 49147, 49147, 65535] == list(out[200, 50:55])
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[0, 50:55])
+        assert [65535, 0, 0, 65535, 65535] == list(out[50, 50:55])
+        assert [65535, 0, 0, 0, 65535] == list(out[100, 50:55])
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[150, 50:55])
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[200, 50:55])
         assert 39321 == out[185, 340]
         assert 45867 == out[185, 385]
         assert 52428 == out[228, 385]
@@ -1297,21 +1293,17 @@ class TestNumpy_ModalityLUT:
         seq.LUTData = pack("<4096H", *seq.LUTData)
         arr = ds.pixel_array
         assert -2048 == arr.min()
-        assert 4095 == arr.max()
+        assert 2047 == arr.max()
         out = apply_modality_lut(arr, ds)
 
-        # IV > 2047 -> LUT[4095]
-        mapped_pixels = arr > 2047
-        assert 65535 == out[mapped_pixels][0]
-        assert (65535 == out[mapped_pixels]).all()
         assert out.flags.writeable
         assert out.dtype == np.uint16
 
-        assert [65535, 65535, 49147, 49147, 65535] == list(out[0, 50:55])
-        assert [65535, 65535, 65535, 65535, 65535] == list(out[50, 50:55])
-        assert [65535, 65535, 65535, 65535, 65535] == list(out[100, 50:55])
-        assert [65535, 65535, 49147, 49147, 65535] == list(out[150, 50:55])
-        assert [65535, 65535, 49147, 49147, 65535] == list(out[200, 50:55])
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[0, 50:55])
+        assert [65535, 0, 0, 65535, 65535] == list(out[50, 50:55])
+        assert [65535, 0, 0, 0, 65535] == list(out[100, 50:55])
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[150, 50:55])
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[200, 50:55])
         assert 39321 == out[185, 340]
         assert 45867 == out[185, 385]
         assert 52428 == out[228, 385]
@@ -2256,7 +2248,7 @@ class TestNumpy_ApplyWindowing:
         assert [4096, -2048, 16] == seq.LUTDescriptor
         arr = ds.pixel_array
         assert -2048 == arr.min()
-        assert 4095 == arr.max()
+        assert 2047 == arr.max()
 
         arr = ds.pixel_array
         assert 2047 == arr[16, 60]

--- a/tests/test_numpy_pixel_data.py
+++ b/tests/test_numpy_pixel_data.py
@@ -21,6 +21,7 @@ There are the following possibilities:
 
 * PixelRepresentation
 * BitsAllocated
+* BitsStored
 * SamplesPerPixel
 * NumberOfFrames
 * PlanarConfiguration
@@ -1306,3 +1307,11 @@ class TestNumpy_GetPixelData:
         data2 = ds2.pixel_array
         assert len(data1) == len(data2)
         assert (data1 == data2).all()
+
+    def test_bits_stored(self):
+        ds = dcmread(IMPL_16_1_1F)
+        assert ds.pixel_array.max() > 2047
+
+        ds = dcmread(IMPL_16_1_1F)
+        ds.BitsStored = 12
+        assert ds.pixel_array.max() <= 2047


### PR DESCRIPTION
#### Describe the changes
Handle the "Bits Stored" tag when interpreting pixel data in the numpy handler. 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/f769100d-55bb-4033-96be-fff65e77626c/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
