### PR TITLE
[MRG] Check for JFIF and component IDs when determining decoded colour space

### DIFF
--- a/src/pydicom/pixels/decoders/base.py
+++ b/src/pydicom/pixels/decoders/base.py
@@ -226,7 +226,7 @@ class DecodeRunner(RunnerBase):
         pi = self.photometric_interpretation
 
         # Check the component IDs for RGB or rgb (in ASCII)
-        has_rgb_ids = info["component_ids"] in ([82, 71, 66], [114, 103, 98])
+        has_rgb_ids = info.get("component_ids", None) in ([82, 71, 66], [114, 103, 98])
         if has_rgb_ids and pi != PI.RGB:
             self.set_option("photometric_interpretation", PI.RGB)
             warn_and_log(

--- a/src/pydicom/pixels/decoders/base.py
+++ b/src/pydicom/pixels/decoders/base.py
@@ -46,6 +46,7 @@ from pydicom.uid import (
     UID,
     JPEG2000TransferSyntaxes,
     JPEGLSTransferSyntaxes,
+    JPEGTransferSyntaxes,
 )
 
 
@@ -211,6 +212,45 @@ class DecodeRunner(RunnerBase):
         elif self.transfer_syntax in JPEGLSTransferSyntaxes:
             self.set_option("apply_jls_sign_correction", True)
 
+    def _conform_jpg_colorspace(self, info: dict[str, Any]) -> None:
+        """Conform the photometric interpretation to the JPEG/JPEG-LS codestream.
+
+        Parameters
+        ----------
+        info : dict[str, Any]
+            A dictionary containing JPEG/JPEG-LS codestream metadata.
+        """
+        if self.samples_per_pixel != 3:
+            return
+
+        pi = self.photometric_interpretation
+
+        # Check the component IDs for RGB or rgb (in ASCII)
+        has_rgb_ids = info["component_ids"] in ([82, 71, 66], [114, 103, 98])
+        if has_rgb_ids and pi != PI.RGB:
+            self.set_option("photometric_interpretation", PI.RGB)
+            warn_and_log(
+                f"The (0028,0004) 'Photometric Interpretation' value is '{pi}' "
+                "however the encoded image's codestream uses component IDs that "
+                "indicate it should be 'RGB'"
+            )
+            return
+
+        # A JFIF APP marker means the decoded image should be YBR colour space
+        #   https://www.w3.org/Graphics/JPEG/jfif.pdf
+        cs = (
+            PI.YBR_FULL_422 if self.transfer_syntax == JPEGBaseline8Bit else PI.YBR_FULL
+        )
+        for marker in info.get("app", {}).values():
+            if marker.startswith(b"JFIF") and "YBR" not in pi:
+                self.set_option("photometric_interpretation", cs)
+                warn_and_log(
+                    "The (0028,0004) 'Photometric Interpretation' value is "
+                    f"'{pi}' however the encoded image's codestream contains a "
+                    f"JFIF APP marker which indicates it should be '{cs}'"
+                )
+                return
+
     def decode(self, index: int) -> bytes | bytearray:
         """Decode the frame of pixel data at `index`.
 
@@ -261,6 +301,10 @@ class DecodeRunner(RunnerBase):
             self.set_option(
                 "jls_precision", jls_info.get("precision", self.bits_stored)
             )
+            self._conform_jpg_colorspace(jls_info)
+        elif self.transfer_syntax in JPEGTransferSyntaxes:
+            jpg_info = _get_jpg_parameters(src)
+            self._conform_jpg_colorspace(jpg_info)
 
         # If self._previous is not set then this is the first frame being decoded
         # If self._previous is set, then the previously successful decoder

--- a/tests/pixels/pixels_reference.py
+++ b/tests/pixels/pixels_reference.py
@@ -1305,6 +1305,7 @@ PIXEL_REFERENCE[RLELossless] = [
 
 # tsyntax, (bits allocated, stored), (frames, rows, cols, planes), VR, PI, pixel repr.
 # 0: JPGB, (8, 8), (1, 3, 3, 3), OB, YBR_FULL, 0
+# Uses a JFIF APP marker
 def test(ref, arr, **kwargs):
     # Pillow, pylibjpeg
     assert tuple(arr[0, 0, :]) == (138, 78, 147)

--- a/tests/pixels/pixels_reference.py
+++ b/tests/pixels/pixels_reference.py
@@ -1608,6 +1608,7 @@ JPGB_08_08_3_0_1F_YBR_FULL_444 = PixelReference(
 
 
 # JPGB, (8, 8), (1, 100, 100, 3), OB, RGB, 0
+# Uses RGB component IDs
 def test(ref, arr, **kwargs):
     assert tuple(arr[5, 50, :]) == (255, 0, 0)
     assert tuple(arr[15, 50, :]) == (255, 128, 128)

--- a/tests/pixels/test_decoder_pillow.py
+++ b/tests/pixels/test_decoder_pillow.py
@@ -30,6 +30,8 @@ from .pixels_reference import (
     PIXEL_REFERENCE,
     J2KR_08_08_3_0_1F_YBR_RCT,
     JPGB_08_08_3_0_1F_RGB,
+    JPGB_08_08_3_0_1F_RGB,  # has RGB component IDs
+    JPGB_08_08_3_0_1F_YBR_FULL,  # has JFIF APP marker
 )
 
 
@@ -56,7 +58,12 @@ class TestLibJpegDecoder:
     def test_jpg_baseline(self, reference):
         """Test the decoder with JPEGBaseline8Bit."""
         decoder = get_decoder(JPEGBaseline8Bit)
-        arr = decoder.as_array(reference.ds, raw=True, decoding_plugin="pillow")
+        if reference in (JPGB_08_08_3_0_1F_RGB, JPGB_08_08_3_0_1F_YBR_FULL):
+            with pytest.warns(UserWarning):
+                arr = decoder.as_array(reference.ds, raw=True, decoding_plugin="pillow")
+        else:
+            arr = decoder.as_array(reference.ds, raw=True, decoding_plugin="pillow")
+
         reference.test(arr, plugin="pillow")
         assert arr.shape == reference.shape
         assert arr.dtype == reference.dtype
@@ -80,6 +87,44 @@ class TestLibJpegDecoder:
             assert arr.shape == reference.shape
             assert arr.dtype == reference.dtype
             assert arr.flags.writeable
+
+    def test_rgb_component_ids(self):
+        """Test decoding an incorrect photometric interpretation using cIDs."""
+        decoder = get_decoder(JPEGBaseline8Bit)
+        reference = JPGB_08_08_3_0_1F_RGB
+        msg = (
+            r"The \(0028,0004\) 'Photometric Interpretation' value is "
+            "'YBR_FULL_422' however the encoded image's codestream uses "
+            "component IDs that indicate it should be 'RGB'"
+        )
+        ds = reference.ds
+        ds.PhotometricInterpretation = "YBR_FULL_422"
+        with pytest.warns(UserWarning, match=msg):
+            arr = decoder.as_array(ds, raw=True, decoding_plugin="pillow")
+
+        reference.test(arr, plugin="pylibjpeg")
+        assert arr.shape == reference.shape
+        assert arr.dtype == reference.dtype
+        assert arr.flags.writeable
+
+    def test_jfif(self):
+        """Test decoding an incorrect photometric interpretation using JFIF."""
+        decoder = get_decoder(JPEGBaseline8Bit)
+        reference = JPGB_08_08_3_0_1F_YBR_FULL
+        msg = (
+            r"The \(0028,0004\) 'Photometric Interpretation' value is "
+            "'RGB' however the encoded image's codestream contains a JFIF APP "
+            "marker which indicates it should be 'YBR_FULL_422'"
+        )
+        ds = reference.ds
+        ds.PhotometricInterpretation = "RGB"
+        with pytest.warns(UserWarning, match=msg):
+            arr = decoder.as_array(ds, raw=True, decoding_plugin="pillow")
+
+        reference.test(arr, plugin="pylibjpeg")
+        assert arr.shape == reference.shape
+        assert arr.dtype == reference.dtype
+        assert arr.flags.writeable
 
 
 @pytest.mark.skipif(SKIP_OJ, reason="Test is missing dependencies")

--- a/tests/pixels/test_decoder_pillow.py
+++ b/tests/pixels/test_decoder_pillow.py
@@ -29,7 +29,6 @@ from pydicom.uid import (
 from .pixels_reference import (
     PIXEL_REFERENCE,
     J2KR_08_08_3_0_1F_YBR_RCT,
-    JPGB_08_08_3_0_1F_RGB,
     JPGB_08_08_3_0_1F_RGB,  # has RGB component IDs
     JPGB_08_08_3_0_1F_YBR_FULL,  # has JFIF APP marker
 )

--- a/tests/pixels/test_decoder_pylibjpeg.py
+++ b/tests/pixels/test_decoder_pylibjpeg.py
@@ -37,6 +37,8 @@ from .pixels_reference import (
     JPGB_08_08_3_0_1F_RGB_APP14,  # fails to decode
     JPGB_08_08_3_0_1F_RGB_DCMD_APP14,  # fails to decode
     JLSN_08_01_1_0_1F,
+    JPGB_08_08_3_0_1F_RGB,  # has RGB component IDs
+    JPGB_08_08_3_0_1F_YBR_FULL,  # has JFIF APP marker
 )
 
 
@@ -193,6 +195,44 @@ class TestLibJpegDecoder:
         arr = arr.reshape((ds.Rows, ds.Columns))
         JLSN_08_01_1_0_1F.test(arr)
         assert arr.shape == JLSN_08_01_1_0_1F.shape
+
+    def test_rgb_component_ids(self):
+        """Test decoding an incorrect photometric interpretation using cIDs."""
+        decoder = get_decoder(JPEGBaseline8Bit)
+        reference = JPGB_08_08_3_0_1F_RGB
+        msg = (
+            r"The \(0028,0004\) 'Photometric Interpretation' value is "
+            "'YBR_FULL_422' however the encoded image's codestream uses "
+            "component IDs that indicate it should be 'RGB'"
+        )
+        ds = reference.ds
+        ds.PhotometricInterpretation = "YBR_FULL_422"
+        with pytest.warns(UserWarning, match=msg):
+            arr = decoder.as_array(ds, raw=True, decoding_plugin="pylibjpeg")
+
+        reference.test(arr, plugin="pylibjpeg")
+        assert arr.shape == reference.shape
+        assert arr.dtype == reference.dtype
+        assert arr.flags.writeable
+
+    def test_jfif(self):
+        """Test decoding an incorrect photometric interpretation using JFIF."""
+        decoder = get_decoder(JPEGBaseline8Bit)
+        reference = JPGB_08_08_3_0_1F_YBR_FULL
+        msg = (
+            r"The \(0028,0004\) 'Photometric Interpretation' value is "
+            "'RGB' however the encoded image's codestream contains a JFIF APP "
+            "marker which indicates it should be 'YBR_FULL_422'"
+        )
+        ds = reference.ds
+        ds.PhotometricInterpretation = "RGB"
+        with pytest.warns(UserWarning, match=msg):
+            arr = decoder.as_array(ds, raw=True, decoding_plugin="pylibjpeg")
+
+        reference.test(arr, plugin="pylibjpeg")
+        assert arr.shape == reference.shape
+        assert arr.dtype == reference.dtype
+        assert arr.flags.writeable
 
 
 @pytest.mark.skipif(SKIP_OJ, reason="Test is missing dependencies")

--- a/tests/pixels/test_decoder_pylibjpeg.py
+++ b/tests/pixels/test_decoder_pylibjpeg.py
@@ -71,7 +71,13 @@ class TestLibJpegDecoder:
             return
 
         decoder = get_decoder(JPEGBaseline8Bit)
-        arr = decoder.as_array(reference.ds, raw=True, decoding_plugin="pylibjpeg")
+
+        if reference in (JPGB_08_08_3_0_1F_RGB, JPGB_08_08_3_0_1F_YBR_FULL):
+            with pytest.warns(UserWarning):
+                arr = decoder.as_array(reference.ds, raw=True, decoding_plugin="pylibjpeg")
+        else:
+            arr = decoder.as_array(reference.ds, raw=True, decoding_plugin="pylibjpeg")
+
         reference.test(arr, plugin="pylibjpeg")
         assert arr.shape == reference.shape
         assert arr.dtype == reference.dtype

--- a/tests/pixels/test_decoder_pylibjpeg.py
+++ b/tests/pixels/test_decoder_pylibjpeg.py
@@ -74,7 +74,9 @@ class TestLibJpegDecoder:
 
         if reference in (JPGB_08_08_3_0_1F_RGB, JPGB_08_08_3_0_1F_YBR_FULL):
             with pytest.warns(UserWarning):
-                arr = decoder.as_array(reference.ds, raw=True, decoding_plugin="pylibjpeg")
+                arr = decoder.as_array(
+                    reference.ds, raw=True, decoding_plugin="pylibjpeg"
+                )
         else:
             arr = decoder.as_array(reference.ds, raw=True, decoding_plugin="pylibjpeg")
 


### PR DESCRIPTION
#### Describe the changes
Checks the JPEG/JPEG-LS codestream for a JFIF marker (which implies YBR) or component IDs corresponding to to the ASCII values for RGB (which implies RGB), closes #2029

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
