### PR TITLE
[MRG] Update to use newest pylibjpeg-libjpeg release

### DIFF
--- a/src/pydicom/pixels/decoders/pylibjpeg.py
+++ b/src/pydicom/pixels/decoders/pylibjpeg.py
@@ -23,12 +23,12 @@ except ImportError:
 
 
 DECODER_DEPENDENCIES = {
-    uid.JPEGBaseline8Bit: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.0.2"),
-    uid.JPEGExtended12Bit: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.0.2"),
-    uid.JPEGLossless: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.0.2"),
-    uid.JPEGLosslessSV1: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.0.2"),
-    uid.JPEGLSLossless: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.0.2"),
-    uid.JPEGLSNearLossless: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.0.2"),
+    uid.JPEGBaseline8Bit: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.1"),
+    uid.JPEGExtended12Bit: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.1"),
+    uid.JPEGLossless: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.1"),
+    uid.JPEGLosslessSV1: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.1"),
+    uid.JPEGLSLossless: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.1"),
+    uid.JPEGLSNearLossless: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.1"),
     uid.JPEG2000Lossless: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.0"),
     uid.JPEG2000: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.0"),
     uid.HTJ2KLossless: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.0"),

--- a/tests/pixels/pixels_reference.py
+++ b/tests/pixels/pixels_reference.py
@@ -1346,21 +1346,35 @@ JPGB_08_08_3_0_1F_RGB_NO_APP14 = PixelReference(
 # JPGB, (8, 8), (1, 256, 256, 3), OB, RGB, 0
 # JPEG baseline in RGB colourspace with APP14 Adobe v101 marker
 def test(ref, arr, **kwargs):
-    # Works with pillow and GDCM
-    # pylibjpeg: decoding error due to unknown Adobe marker version
-    assert arr[99:104, 172].tolist() == [
-        [243, 244, 246],
-        [229, 224, 235],
-        [204, 190, 213],
-        [194, 176, 203],
-        [204, 188, 211],
-    ]
-    assert arr[84, 239:243].tolist() == [
-        [229, 225, 234],
-        [174, 174, 202],
-        [187, 185, 203],
-        [210, 207, 225],
-    ]
+    plugin = kwargs.get("plugin", None)
+    if plugin in ("pillow", "gdcm"):
+        assert arr[99:104, 172].tolist() == [
+            [243, 244, 246],
+            [229, 224, 235],
+            [204, 190, 213],
+            [194, 176, 203],
+            [204, 188, 211],
+        ]
+        assert arr[84, 239:243].tolist() == [
+            [229, 225, 234],
+            [174, 174, 202],
+            [187, 185, 203],
+            [210, 207, 225],
+        ]
+    elif plugin == "pylibjpeg":
+        assert arr[99:104, 172].tolist() == [
+            [243, 244, 246],
+            [229, 224, 235],
+            [204, 191, 213],
+            [194, 176, 203],
+            [204, 188, 211],
+        ]
+        assert arr[84, 239:243].tolist() == [
+            [229, 225, 234],
+            [174, 174, 202],
+            [187, 185, 203],
+            [211, 207, 225],
+        ]
 
 
 JPGB_08_08_3_0_1F_RGB_APP14 = PixelReference(
@@ -1371,21 +1385,35 @@ JPGB_08_08_3_0_1F_RGB_APP14 = PixelReference(
 # JPGB, (8, 8), (1, 256, 256, 3), OB, RGB, 0
 # JPEG baseline in RGB colourspace with APP14 Adobe v101 marker
 def test(ref, arr, **kwargs):
-    # Works with pillow and GDCM
-    # pylibjpeg: decoding error due to unknown Adobe marker version
-    assert arr[99:104, 172].tolist() == [
-        [243, 244, 246],
-        [229, 224, 235],
-        [204, 190, 213],
-        [194, 176, 203],
-        [204, 188, 211],
-    ]
-    assert arr[84, 239:243].tolist() == [
-        [229, 225, 234],
-        [174, 174, 202],
-        [187, 185, 203],
-        [210, 207, 225],
-    ]
+    plugin = kwargs.get("plugin", None)
+    if plugin in ("pillow", "gdcm"):
+        assert arr[99:104, 172].tolist() == [
+            [243, 244, 246],
+            [229, 224, 235],
+            [204, 190, 213],
+            [194, 176, 203],
+            [204, 188, 211],
+        ]
+        assert arr[84, 239:243].tolist() == [
+            [229, 225, 234],
+            [174, 174, 202],
+            [187, 185, 203],
+            [210, 207, 225],
+        ]
+    elif plugin == "pylibjpeg":
+        assert arr[99:104, 172].tolist() == [
+            [243, 244, 246],
+            [229, 224, 235],
+            [204, 191, 213],
+            [194, 176, 203],
+            [204, 188, 211],
+        ]
+        assert arr[84, 239:243].tolist() == [
+            [229, 225, 234],
+            [174, 174, 202],
+            [187, 185, 203],
+            [211, 207, 225],
+        ]
 
 
 JPGB_08_08_3_0_1F_RGB_DCMD_APP14 = PixelReference(

--- a/tests/pixels/test_decoder_pylibjpeg.py
+++ b/tests/pixels/test_decoder_pylibjpeg.py
@@ -34,8 +34,6 @@ from .pixels_reference import (
     PIXEL_REFERENCE,
     JPGE_BAD,
     J2KR_16_13_1_1_1F_M2_MISMATCH,
-    JPGB_08_08_3_0_1F_RGB_APP14,  # fails to decode
-    JPGB_08_08_3_0_1F_RGB_DCMD_APP14,  # fails to decode
     JLSN_08_01_1_0_1F,
 )
 
@@ -64,10 +62,6 @@ class TestLibJpegDecoder:
     @pytest.mark.parametrize("reference", PIXEL_REFERENCE[JPEGBaseline8Bit], ids=name)
     def test_jpg_baseline(self, reference):
         """Test the decoder with JPEGBaseline8Bit."""
-        # Decoding failures due to unknown APP14 version
-        # if reference in (JPGB_08_08_3_0_1F_RGB_APP14, JPGB_08_08_3_0_1F_RGB_DCMD_APP14):
-        #     return
-
         decoder = get_decoder(JPEGBaseline8Bit)
         arr = decoder.as_array(reference.ds, raw=True, decoding_plugin="pylibjpeg")
         reference.test(arr, plugin="pylibjpeg")
@@ -140,25 +134,6 @@ class TestLibJpegDecoder:
         )
         with pytest.raises(RuntimeError, match=msg):
             decoder.as_array(JPGE_BAD.ds, decoding_plugin="pylibjpeg")
-
-    # def test_decode_failures(self):
-    #     """Test decoding failures."""
-    #     decoder = get_decoder(JPEGBaseline8Bit)
-    #     msg = (
-    #         "Unable to decode as exceptions were raised by all available "
-    #         "plugins:\n  pylibjpeg: libjpeg error code '-1038' returned "
-    #         r"from Decode\(\): A misplaced marker segment was found - Adobe "
-    #         "marker version unrecognized"
-    #     )
-    #     with pytest.raises(RuntimeError, match=msg):
-    #         decoder.as_array(
-    #             JPGB_08_08_3_0_1F_RGB_APP14.ds, decoding_plugin="pylibjpeg"
-    #         )
-    #
-    #     with pytest.raises(RuntimeError, match=msg):
-    #         decoder.as_array(
-    #             JPGB_08_08_3_0_1F_RGB_DCMD_APP14.ds, decoding_plugin="pylibjpeg"
-    #         )
 
     def test_bits_allocated_mismatch(self):
         """Test the result when bits stored <= 8 and bits allocated 16"""

--- a/tests/pixels/test_decoder_pylibjpeg.py
+++ b/tests/pixels/test_decoder_pylibjpeg.py
@@ -65,8 +65,8 @@ class TestLibJpegDecoder:
     def test_jpg_baseline(self, reference):
         """Test the decoder with JPEGBaseline8Bit."""
         # Decoding failures due to unknown APP14 version
-        if reference in (JPGB_08_08_3_0_1F_RGB_APP14, JPGB_08_08_3_0_1F_RGB_DCMD_APP14):
-            return
+        # if reference in (JPGB_08_08_3_0_1F_RGB_APP14, JPGB_08_08_3_0_1F_RGB_DCMD_APP14):
+        #     return
 
         decoder = get_decoder(JPEGBaseline8Bit)
         arr = decoder.as_array(reference.ds, raw=True, decoding_plugin="pylibjpeg")
@@ -141,24 +141,24 @@ class TestLibJpegDecoder:
         with pytest.raises(RuntimeError, match=msg):
             decoder.as_array(JPGE_BAD.ds, decoding_plugin="pylibjpeg")
 
-    def test_decode_failures(self):
-        """Test decoding failures."""
-        decoder = get_decoder(JPEGBaseline8Bit)
-        msg = (
-            "Unable to decode as exceptions were raised by all available "
-            "plugins:\n  pylibjpeg: libjpeg error code '-1038' returned "
-            r"from Decode\(\): A misplaced marker segment was found - Adobe "
-            "marker version unrecognized"
-        )
-        with pytest.raises(RuntimeError, match=msg):
-            decoder.as_array(
-                JPGB_08_08_3_0_1F_RGB_APP14.ds, decoding_plugin="pylibjpeg"
-            )
-
-        with pytest.raises(RuntimeError, match=msg):
-            decoder.as_array(
-                JPGB_08_08_3_0_1F_RGB_DCMD_APP14.ds, decoding_plugin="pylibjpeg"
-            )
+    # def test_decode_failures(self):
+    #     """Test decoding failures."""
+    #     decoder = get_decoder(JPEGBaseline8Bit)
+    #     msg = (
+    #         "Unable to decode as exceptions were raised by all available "
+    #         "plugins:\n  pylibjpeg: libjpeg error code '-1038' returned "
+    #         r"from Decode\(\): A misplaced marker segment was found - Adobe "
+    #         "marker version unrecognized"
+    #     )
+    #     with pytest.raises(RuntimeError, match=msg):
+    #         decoder.as_array(
+    #             JPGB_08_08_3_0_1F_RGB_APP14.ds, decoding_plugin="pylibjpeg"
+    #         )
+    #
+    #     with pytest.raises(RuntimeError, match=msg):
+    #         decoder.as_array(
+    #             JPGB_08_08_3_0_1F_RGB_DCMD_APP14.ds, decoding_plugin="pylibjpeg"
+    #         )
 
     def test_bits_allocated_mismatch(self):
         """Test the result when bits stored <= 8 and bits allocated 16"""


### PR DESCRIPTION
#### Describe the changes
`pylibjpeg-libjpeg` has been updated to use `libjpeg` v1.67 which fixes the encoding failure when a v101 Adobe APP14 marker is present.

* Bumps the required `pylibjpeg-libjpeg` to v2.1
* Updates the `pylibjpeg` tests to no longer skip JPEG files with the v101 APP14 marker

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
