### PR TITLE
[WIP] Avoid truncating valid PixelData by computing the default expected frames instead of assuming 1

### DIFF
--- a/tests/test_handler_util.py
+++ b/tests/test_handler_util.py
@@ -1207,6 +1207,35 @@ class TestGetExpectedLength:
 
         assert length[2] == get_expected_length(ds, unit="bytes")
 
+    @pytest.mark.parametrize("shape, bits, length", REFERENCE_LENGTH)
+    def test_length_bytes_multiframe_nonumberofframes(self, shape, bits, length):
+        """Test get_expected_length(ds, unit='bytes') against a multiframe dicom scenario without NumberOfFrames defined."""
+        frames = 3
+        if shape[3] != 3 or bits == 1:
+        ds = Dataset()
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        ds.Rows = shape[1]
+        ds.Columns = shape[2]
+        ds.BitsAllocated = bits
+        ds.SamplesPerPixel = shape[3]
+        ds.PixelData = 'a' * (shape[1] * shape[2] * (bits // 8) * shape[3]) * frames
+
+        assert (length[0] * frames) == get_expected_length(ds, unit="bytes")
+
+    @pytest.mark.parametrize("shape, bits, length", REFERENCE_LENGTH)
+    def test_length_in_pixels_multiframe_nonumberofframes(self, shape, bits, length):
+        """Test get_expected_length(ds, unit='pixels') against a multiframe dicom scenario without NumberOfFrames defined."""
+        frames = 3
+        ds = Dataset()
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        ds.Rows = shape[1]
+        ds.Columns = shape[2]
+        ds.BitsAllocated = bits
+        ds.SamplesPerPixel = shape[3]
+        ds.PixelData = 'a' * (shape[1] * shape[2] * (bits // 8) * shape[3]) * frames
+
+        assert (length[1] * frames) == get_expected_length(ds, unit="pixels")
+
 
 @pytest.mark.skipif(not HAVE_NP, reason="Numpy is not available")
 class TestNumpy_ModalityLUT:

--- a/tests/test_handler_util.py
+++ b/tests/test_handler_util.py
@@ -1217,7 +1217,7 @@ class TestGetExpectedLength:
         ds.Columns = shape[2]
         ds.BitsAllocated = bits
         ds.SamplesPerPixel = shape[3]
-        ds.PixelData = 'a' * ((shape[1] * shape[2] * (bits // 8) * shape[3]) * frames)
+        ds.PixelData = "a" * ((shape[1] * shape[2] * (bits // 8) * shape[3]) * frames)
 
         assert (length[0] * frames) == get_expected_length(ds, unit="bytes")
 
@@ -1231,7 +1231,7 @@ class TestGetExpectedLength:
         ds.Columns = shape[2]
         ds.BitsAllocated = bits
         ds.SamplesPerPixel = shape[3]
-        ds.PixelData = 'a' * ((shape[1] * shape[2] * (bits // 8) * shape[3]) * frames)
+        ds.PixelData = "a" * ((shape[1] * shape[2] * (bits // 8) * shape[3]) * frames)
 
         assert (length[1] * frames) == get_expected_length(ds, unit="pixels")
 

--- a/tests/test_handler_util.py
+++ b/tests/test_handler_util.py
@@ -1211,14 +1211,13 @@ class TestGetExpectedLength:
     def test_length_bytes_multiframe_nonumberofframes(self, shape, bits, length):
         """Test get_expected_length(ds, unit='bytes') against a multiframe dicom scenario without NumberOfFrames defined."""
         frames = 3
-        if shape[3] != 3 or bits == 1:
         ds = Dataset()
         ds.PhotometricInterpretation = "MONOCHROME2"
         ds.Rows = shape[1]
         ds.Columns = shape[2]
         ds.BitsAllocated = bits
         ds.SamplesPerPixel = shape[3]
-        ds.PixelData = 'a' * (shape[1] * shape[2] * (bits // 8) * shape[3]) * frames
+        ds.PixelData = 'a' * ((shape[1] * shape[2] * (bits // 8) * shape[3]) * frames)
 
         assert (length[0] * frames) == get_expected_length(ds, unit="bytes")
 
@@ -1232,7 +1231,7 @@ class TestGetExpectedLength:
         ds.Columns = shape[2]
         ds.BitsAllocated = bits
         ds.SamplesPerPixel = shape[3]
-        ds.PixelData = 'a' * (shape[1] * shape[2] * (bits // 8) * shape[3]) * frames
+        ds.PixelData = 'a' * ((shape[1] * shape[2] * (bits // 8) * shape[3]) * frames)
 
         assert (length[1] * frames) == get_expected_length(ds, unit="pixels")
 


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
Addresses #2035 .
Basically, I compute the nearest integer number of frames based on actual length of pixel data divided by number of bytes computed. I then pass this value as the default return for get_nr_frames. If NumberOfFrames is undefined, we default to default number of frames, which is our predicted frame count.
The issue is that the current get_nr_frames assumes that a multiframe DICOM slice has only 1 frame when NumberOfFrames is not defined. This is not true in all cases and it is less accurate if a service omits adding the NumberOfFrames to header but still concatenates n frames into the PixelData buffer. The service also leaves Rows and Columns set such that it only reflects the dimensions of a single frame within this larger buffer. Calling pixel_array then truncates the data and returns only the first frame.
Added accompanying tests.
Updated comments to reflect the new requirement of PixelData.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
