### PR TITLE
[MRG] Fix tests for J2K lossless decoding with MacOS

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         # One Python version per OS, one combo does coverage
         # PyPy only has one line in pydicom (as of 2003-07) so cover in merge only
@@ -20,6 +21,14 @@ jobs:
             python-version: "3.11"
             test-extras: true
             upload-coverage: true
+          - os: windows
+            python-version: "3.11"
+            test-extras: true
+            upload-coverage: true
+          - os: macos
+            python-version: "3.10"
+            test-extras: true
+            upload-coverage: false
     uses: ./.github/workflows/tests_wf.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -21,10 +21,6 @@ jobs:
             python-version: "3.11"
             test-extras: true
             upload-coverage: true
-          - os: windows
-            python-version: "3.11"
-            test-extras: true
-            upload-coverage: true
           - os: macos
             python-version: "3.10"
             test-extras: true

--- a/tests/pixels/pixels_reference.py
+++ b/tests/pixels/pixels_reference.py
@@ -2052,7 +2052,7 @@ J2KI_08_08_3_0_1F_RGB = PixelReference("SC_rgb_gdcm_KY.dcm", "u1", test)
 # J2KI, (8, 8), (1, 480, 640, 3), OB, YBR_ICT, 0
 def test(ref, arr, **kwargs):
     ref = get_testdata_file("US1_UNCI.dcm", read=True).pixel_array
-    assert np.array_equal(arr, ref)
+    assert np.allclose(arr, ref, atol=1)
 
 
 J2KI_08_08_3_0_1F_YBR_ICT = PixelReference("US1_J2KI.dcm", "u1", test)
@@ -2070,7 +2070,7 @@ J2KI_16_10_1_0_1F_M1 = PixelReference("RG3_J2KI.dcm", "<u2", test)
 # J2KI, (16, 12), (1, 1024, 1024, 1), OB, MONOCHROME2, 0
 def test(ref, arr, **kwargs):
     ref = get_testdata_file("MR2_UNCI.dcm", read=True).pixel_array
-    assert np.array_equal(arr, ref)
+    assert np.allclose(arr, ref, atol=1)
 
 
 J2KI_16_12_1_0_1F_M2 = PixelReference("MR2_J2KI.dcm", "<u2", test)
@@ -2079,7 +2079,7 @@ J2KI_16_12_1_0_1F_M2 = PixelReference("MR2_J2KI.dcm", "<u2", test)
 # J2KI, (16, 15), (1, 1955, 1841, 1), OB, MONOCHROME1, 0
 def test(ref, arr, **kwargs):
     ref = get_testdata_file("RG1_UNCI.dcm", read=True).pixel_array
-    assert np.array_equal(arr, ref)
+    assert np.allclose(arr, ref, atol=1)
 
 
 J2KI_16_15_1_0_1F_M1 = PixelReference("RG1_J2KI.dcm", "<u2", test)
@@ -2088,7 +2088,7 @@ J2KI_16_15_1_0_1F_M1 = PixelReference("RG1_J2KI.dcm", "<u2", test)
 # J2KI, (16, 14), (1, 512, 512, 1), OW, MONOCHROME2, 1
 def test(ref, arr, **kwargs):
     ref = get_testdata_file("693_UNCI.dcm", read=True).pixel_array
-    assert np.array_equal(arr, ref)
+    assert np.allclose(arr, ref, atol=1)
 
 
 J2KI_16_14_1_1_1F_M2 = PixelReference("693_J2KI.dcm", "<i2", test)

--- a/tests/pixels/pixels_reference.py
+++ b/tests/pixels/pixels_reference.py
@@ -2061,7 +2061,7 @@ J2KI_08_08_3_0_1F_YBR_ICT = PixelReference("US1_J2KI.dcm", "u1", test)
 # J2KI, (16, 10), (1, 1760, 1760, 1), OB, MONOCHROME1, 0
 def test(ref, arr, **kwargs):
     ref = get_testdata_file("RG3_UNCI.dcm", read=True).pixel_array
-    assert np.array_equal(arr, ref)
+    assert np.allclose(arr, ref, atol=1)
 
 
 J2KI_16_10_1_0_1F_M1 = PixelReference("RG3_J2KI.dcm", "<u2", test)
@@ -2088,7 +2088,7 @@ J2KI_16_15_1_0_1F_M1 = PixelReference("RG1_J2KI.dcm", "<u2", test)
 # J2KI, (16, 14), (1, 512, 512, 1), OW, MONOCHROME2, 1
 def test(ref, arr, **kwargs):
     ref = get_testdata_file("693_UNCI.dcm", read=True).pixel_array
-    assert np.allclose(arr, ref, atol=1)
+    assert np.array_equal(arr, ref)
 
 
 J2KI_16_14_1_1_1F_M2 = PixelReference("693_J2KI.dcm", "<i2", test)

--- a/tests/test_pillow_pixel_data.py
+++ b/tests/test_pillow_pixel_data.py
@@ -545,7 +545,6 @@ class TestPillowHandler_JPEG2K:
             arr = convert_color_space(arr, ds.PhotometricInterpretation, "RGB")
 
         ref = dcmread(rpath).pixel_array
-        diff = arr.astype(float) - ref.astype(float)
         assert np.allclose(arr, ref, atol=1)
 
     def test_warning(self):

--- a/tests/test_pillow_pixel_data.py
+++ b/tests/test_pillow_pixel_data.py
@@ -546,8 +546,7 @@ class TestPillowHandler_JPEG2K:
 
         ref = dcmread(rpath).pixel_array
         diff = arr.astype(float) - ref.astype(float)
-        print(diff.min(), diff.max())
-        assert np.array_equal(arr, ref)
+        assert np.allclose(arr, ref, atol=1)
 
     def test_warning(self):
         """Test that the precision warning works OK."""

--- a/tests/test_pillow_pixel_data.py
+++ b/tests/test_pillow_pixel_data.py
@@ -378,7 +378,7 @@ JPEG_MATCHING_DATASETS = [
         ],
     ),
 ]
-JPEG2K_MATCHING_DATASETS = [
+J2KR_MATCHING_DATASETS = [
     # (compressed, reference, fixes)
     pytest.param(
         J2KR_08_08_3_0_1F_YBR_ICT,
@@ -415,6 +415,9 @@ JPEG2K_MATCHING_DATASETS = [
         get_testdata_file("MR_small.dcm"),
         {},
     ),
+]
+J2KI_MATCHING_DATASETS = [
+    # (compressed, reference, fixes)
     pytest.param(
         J2KI_08_08_3_0_1F_RGB,
         get_testdata_file("SC_rgb_gdcm2k_uncompressed.dcm"),
@@ -516,8 +519,8 @@ class TestPillowHandler_JPEG2K:
         assert data[5] == arr.shape
         assert arr.dtype == data[6]
 
-    @pytest.mark.parametrize("fpath, rpath, fixes", JPEG2K_MATCHING_DATASETS)
-    def test_array(self, fpath, rpath, fixes):
+    @pytest.mark.parametrize("fpath, rpath, fixes", J2KR_MATCHING_DATASETS)
+    def test_array_lossless(self, fpath, rpath, fixes):
         """Test pixel_array returns correct values."""
         ds = dcmread(fpath)
         # May need to correct some element values
@@ -528,6 +531,22 @@ class TestPillowHandler_JPEG2K:
             arr = convert_color_space(arr, ds.PhotometricInterpretation, "RGB")
 
         ref = dcmread(rpath).pixel_array
+        assert np.array_equal(arr, ref)
+
+    @pytest.mark.parametrize("fpath, rpath, fixes", J2KI_MATCHING_DATASETS)
+    def test_array_lossy(self, fpath, rpath, fixes):
+        """Test pixel_array returns correct values."""
+        ds = dcmread(fpath)
+        # May need to correct some element values
+        for kw, val in fixes.items():
+            setattr(ds, kw, val)
+        arr = ds.pixel_array
+        if "YBR_FULL" in ds.PhotometricInterpretation:
+            arr = convert_color_space(arr, ds.PhotometricInterpretation, "RGB")
+
+        ref = dcmread(rpath).pixel_array
+        diff = arr.astype(float) - ref.astype(float)
+        print(diff.min(), diff.max())
         assert np.array_equal(arr, ref)
 
     def test_warning(self):


### PR DESCRIPTION
* Changed to `allclose()` with `atol=1` for J2K lossy tests because `array_equal()` has started failing with GDCM and Pillow on MacOS for some reason.
* Added the MacOS runner to the PR workflow given the difference in results to Ubuntu/Windows

Closes #2048

#### Tasks
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
