### PR TITLE
[MRG] Second attempt at codecov fix

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -26,6 +26,8 @@ jobs:
             test-extras: true
             upload-coverage: false
     uses: ./.github/workflows/tests_wf.yml
+    secrets:
+      codecov_token: $ {{ secrets.CODECOV_TOKEN }}
     with:
       os: ${{ matrix.os }}
       python-version:  ${{ matrix.python-version }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -34,6 +34,8 @@ jobs:
             python-version: "3.10"
             test-extras: false
     uses: ./.github/workflows/tests_wf.yml
+    secrets:
+      codecov_token: $ {{ secrets.CODECOV_TOKEN }}
     with:
       os: ${{ matrix.os }}
       python-version:  ${{ matrix.python-version }}

--- a/.github/workflows/tests_wf.yml
+++ b/.github/workflows/tests_wf.yml
@@ -17,6 +17,9 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+        codecov_token:
+            required: true
 
 env:
   PYTEST_ARGS: ""
@@ -80,6 +83,6 @@ jobs:
       if: success() && inputs.upload-coverage
       uses: codecov/codecov-action@v4
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        codecov_token: ${{ secrets.codecov_token }}
       with:
         env_vars: inputs.os, inputs.python-version


### PR DESCRIPTION
Codecov upload still isn't working in the merge workflow. I think the token needs to be [shared across workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow) because of the workflow_call
