### PR TITLE
[MRG] Fix test for changes to dict in PyPy 3.10.14 

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -25,10 +25,6 @@ jobs:
             python-version: "3.10"
             test-extras: true
             upload-coverage: false
-          - os: ubuntu
-            python-version: "pypy3.10"
-            test-extras: false
-            upload-coverage: false
     uses: ./.github/workflows/tests_wf.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -25,6 +25,10 @@ jobs:
             python-version: "3.10"
             test-extras: true
             upload-coverage: false
+          - os: ubuntu
+            python-version: "pypy3.10"
+            test-extras: false
+            upload-coverage: false
     uses: ./.github/workflows/tests_wf.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2170,6 +2170,11 @@ class TestFileDataset:
             "__or__",
             "__class_getitem__",
         }
+        if "PyPy" in python_implementation():
+            # __ror__ missing in <= 3.10.13
+            if "__ror__" not in dir(dict):
+                expected_diff.remove("__ror__")
+
         assert expected_diff == set(dir(di)) - set(dir(ds))
 
     def test_copy_filedataset(self):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2170,8 +2170,6 @@ class TestFileDataset:
             "__or__",
             "__class_getitem__",
         }
-        if "PyPy" in python_implementation():
-            expected_diff.remove("__ror__")
         assert expected_diff == set(dir(di)) - set(dir(ds))
 
     def test_copy_filedataset(self):


### PR DESCRIPTION
#### Describe the changes
Fixes test failure due to `dict.__ror__()` being added to PyPy 3.10.14 (weirdly, did they forget to remove it?)

[Passing workflow](https://github.com/pydicom/pydicom/actions/runs/9120144978/job/25076941007?pr=2057)

#### Tasks
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
