### PR TITLE
[MRG] Fix windows test failures not triggering workflow failure

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -25,6 +25,11 @@ jobs:
             python-version: "3.10"
             test-extras: true
             upload-coverage: false
+          - os: windows
+            shell: bash
+            python-version: "3.11"
+            test-extras: true
+            upload-coverage: true
     uses: ./.github/workflows/tests_wf.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -25,10 +25,6 @@ jobs:
             python-version: "3.10"
             test-extras: true
             upload-coverage: false
-          - os: windows
-            python-version: "3.11"
-            test-extras: true
-            upload-coverage: true
     uses: ./.github/workflows/tests_wf.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -25,6 +25,10 @@ jobs:
             python-version: "3.10"
             test-extras: true
             upload-coverage: false
+          - os: windows
+            python-version: "3.11"
+            test-extras: true
+            upload-coverage: true
     uses: ./.github/workflows/tests_wf.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -26,7 +26,6 @@ jobs:
             test-extras: true
             upload-coverage: false
           - os: windows
-            shell: bash
             python-version: "3.11"
             test-extras: true
             upload-coverage: true

--- a/.github/workflows/tests_wf.yml
+++ b/.github/workflows/tests_wf.yml
@@ -63,6 +63,7 @@ jobs:
 
     - name: Test with all optional dependencies
       if: inputs.test-extras
+      shell: bash
       run: |
         python -m pip install .[pixeldata,gpl-license]
         python -m pytest ${{ env.PYTEST_ARGS }} tests/test_pylibjpeg.py
@@ -70,7 +71,6 @@ jobs:
         python -m pytest ${{ env.PYTEST_ARGS }} tests/test_JPEG_LS_transfer_syntax.py tests/test_jpeg_ls_pixel_data.py
         python -m pytest ${{ env.PYTEST_ARGS }} tests/test_gdcm_pixel_data.py tests/pixels/test_encoder_gdcm.py
         python -m pytest ${{ env.PYTEST_ARGS }} tests/pixels
-        python -m pip uninstall -y pydicom-data
 
     - name: Test with missing libs
       if: inputs.test-extras

--- a/.github/workflows/tests_wf.yml
+++ b/.github/workflows/tests_wf.yml
@@ -34,12 +34,8 @@ jobs:
     - name: Install BLAS on PyPy3.10
       if: startsWith(inputs.python-version, 'pypy')
       run: sudo apt install -y libopenblas-dev
-    - name: Set env variables for ubuntu
-      if: inputs.upload-coverage && startsWith(inputs.os, 'ubuntu')
+    - name: Set env variables
       run: echo "PYTEST_ARGS=--cov-append --cov=pydicom" >> "$GITHUB_ENV"
-    - name: Set env variables for windows
-      if: inputs.upload-coverage && startsWith(inputs.os, 'windows')
-      run: echo "PYTEST_ARGS=--cov-append --cov=pydicom" >> "$env:GITHUB_ENV"
     - name: Check-out code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/tests_wf.yml
+++ b/.github/workflows/tests_wf.yml
@@ -27,6 +27,9 @@ env:
 jobs:
   tests:
     runs-on: ${{ inputs.os }}-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - name: Install BLAS on PyPy3.10
       if: startsWith(inputs.python-version, 'pypy')
@@ -63,7 +66,6 @@ jobs:
 
     - name: Test with all optional dependencies
       if: inputs.test-extras
-      shell: bash
       run: |
         python -m pip install .[pixeldata,gpl-license]
         python -m pytest ${{ env.PYTEST_ARGS }} tests/test_pylibjpeg.py

--- a/tests/pixels/test_encoder_pylibjpeg.py
+++ b/tests/pixels/test_encoder_pylibjpeg.py
@@ -922,7 +922,7 @@ class TestJ2KEncoding:
 
         for bits_stored in range(1, 9):
             ref = self.ref * (2**bits_stored - 1)
-            ref = ref.clip(0, 255)
+            ref = ref.clip(0, 2**bits_stored - 1)
             ref = ref.astype("uint8")
 
             opts["bits_stored"] = bits_stored
@@ -958,7 +958,7 @@ class TestJ2KEncoding:
 
         for bits_stored in range(1, 17):
             ref = self.ref * (2**bits_stored - 1)
-            ref = ref.clip(0, 2**16 - 1)
+            ref = ref.clip(0, 2**bits_stored - 1)
             ref = ref.astype("uint16")
 
             opts["bits_stored"] = bits_stored
@@ -995,7 +995,7 @@ class TestJ2KEncoding:
         atols.extend([23, 31, 52, 63, 116, 2928854, 7404089, 9687927])
         for bits_stored, atol in zip(range(1, 25), atols):
             ref = self.ref * (2**bits_stored - 1)
-            ref = ref.clip(0, 2**24 - 1)
+            ref = ref.clip(0, 2**bits_stored - 1)
             ref = ref.astype("uint32")
 
             opts["bits_stored"] = bits_stored
@@ -1006,7 +1006,7 @@ class TestJ2KEncoding:
                 **opts,
             )
             assert not np.array_equal(out, ref)
-            assert np.allclose(out, ref, atol=atol)
+            assert np.allclose(out, ref, atol=atol, rtol=0.05)
 
     def test_arr_u1_spp3(self):
         """Test unsigned bits allocated 8, bits stored (1, 8), samples per pixel 3"""
@@ -1031,7 +1031,7 @@ class TestJ2KEncoding:
 
         for bits_stored in range(1, 9):
             ref = self.ref3 * (2**bits_stored - 1)
-            ref = ref.clip(0, 255)
+            ref = ref.clip(0, 2**bits_stored - 1)
             ref = ref.astype("uint8")
 
             opts["bits_stored"] = bits_stored
@@ -1066,7 +1066,7 @@ class TestJ2KEncoding:
 
         for bits_stored in range(1, 17):
             ref = self.ref3 * (2**bits_stored - 1)
-            ref = ref.clip(0, 2**16 - 1)
+            ref = ref.clip(0, 2**bits_stored - 1)
             ref = ref.astype("uint16")
 
             opts["bits_stored"] = bits_stored
@@ -1094,12 +1094,13 @@ class TestJ2KEncoding:
             "planar_configuration": 0,
             "j2k_cr": [2],
         }
+        # 21+ bits stored gives horrible results
         atols = [1, 2, 2, 2, 2, 2, 2, 2]
         atols.extend([2, 2, 1, 1, 1, 2, 3, 4])
-        atols.extend([4, 4, 5, 5, 2097151, 1982469, 3964935, 7929869])
+        atols.extend([8, 15, 30, 60, 2097151, 4194303, 8388607, 16777215])
         for bits_stored, atol in zip(range(1, 25), atols):
             ref = self.ref3 * (2**bits_stored - 1)
-            ref = ref.clip(0, 2**16 - 1)
+            ref = ref.clip(0, 2**bits_stored - 1)
             ref = ref.astype("uint32")
 
             opts["bits_stored"] = bits_stored
@@ -1135,7 +1136,9 @@ class TestJ2KEncoding:
         for bits_stored in range(1, 9):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
-            ref = ref.clip(-128, 127)
+            minimum = -2**(bits_stored - 1)
+            maximum = 2**(bits_stored - 1) - 1
+            ref = ref.clip(minimum, maximum)
             ref = ref.astype("int8")
 
             opts["bits_stored"] = bits_stored
@@ -1173,7 +1176,9 @@ class TestJ2KEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
-            ref = ref.clip(-32768, 32767)
+            minimum = -2**(bits_stored - 1)
+            maximum = 2**(bits_stored - 1) - 1
+            ref = ref.clip(minimum, maximum)
             ref = ref.astype("int16")
 
             opts["bits_stored"] = bits_stored
@@ -1212,7 +1217,9 @@ class TestJ2KEncoding:
         for bits_stored, atol in zip(range(1, 25), atols):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
-            ref = ref.clip(-8388608, 8388607)
+            minimum = -2**(bits_stored - 1)
+            maximum = 2**(bits_stored - 1) - 1
+            ref = ref.clip(minimum, maximum)
             ref = ref.astype("int32")
 
             opts["bits_stored"] = bits_stored
@@ -1223,7 +1230,7 @@ class TestJ2KEncoding:
                 **opts,
             )
             assert not np.array_equal(out, ref)
-            assert np.allclose(out, ref, atol=atol)
+            assert np.allclose(out, ref, atol=atol, rtol=0.05)
 
     def test_buffer_u1_spp1(self):
         """Test unsigned bits allocated 8, bits stored (1, 8), samples per pixel 1"""
@@ -1247,7 +1254,7 @@ class TestJ2KEncoding:
 
         for bits_stored in range(1, 9):
             ref = self.ref * (2**bits_stored - 1)
-            ref = ref.clip(0, 255)
+            ref = ref.clip(0, 2**bits_stored - 1)
             ref = ref.astype("uint8")
 
             buffer = ref.tobytes()
@@ -1286,7 +1293,7 @@ class TestJ2KEncoding:
 
         for bits_stored in range(1, 17):
             ref = self.ref * (2**bits_stored - 1)
-            ref = ref.clip(0, 65535)
+            ref = ref.clip(0, 2**bits_stored - 1)
             ref = ref.astype("uint16")
 
             buffer = ref.tobytes()
@@ -1325,7 +1332,7 @@ class TestJ2KEncoding:
         atols.extend([23, 31, 52, 63, 116, 2928854, 7404089, 9687927])
         for bits_stored, atol in zip(range(1, 25), atols):
             ref = self.ref * (2**bits_stored - 1)
-            ref = ref.clip(0, 2**24 - 1)
+            ref = ref.clip(0, 2**bits_stored - 1)
             ref = ref.astype("uint32")
 
             buffer = ref.tobytes()
@@ -1338,8 +1345,9 @@ class TestJ2KEncoding:
                 decoding_plugin="pylibjpeg",
                 **opts,
             )
+            diff = np.absolute(out.astype("float") - ref.astype("float"))
             assert not np.array_equal(out, ref)
-            assert np.allclose(out, ref, atol=atol)
+            assert np.allclose(out, ref, atol=atol, rtol=0.05)
 
     def test_buffer_u1_spp3(self):
         """Test unsigned bits allocated 8, bits stored (1, 8), samples per pixel 3"""
@@ -1364,7 +1372,7 @@ class TestJ2KEncoding:
 
         for bits_stored in range(1, 9):
             ref = self.ref3 * (2**bits_stored - 1)
-            ref = ref.clip(0, 255)
+            ref = ref.clip(0, 2**bits_stored - 1)
             ref = ref.astype("uint8")
 
             buffer = ref.tobytes()
@@ -1402,7 +1410,7 @@ class TestJ2KEncoding:
 
         for bits_stored in range(1, 17):
             ref = self.ref3 * (2**bits_stored - 1)
-            ref = ref.clip(0, 2**16 - 1)
+            ref = ref.clip(0, 2**bits_stored - 1)
             ref = ref.astype("uint16")
 
             buffer = ref.tobytes()
@@ -1439,7 +1447,7 @@ class TestJ2KEncoding:
         atols.extend([8, 15, 30, 60, 2097151, 4194303, 8388607, 16777215])
         for bits_stored, atol in zip(range(1, 25), atols):
             ref = self.ref3 * (2**bits_stored - 1)
-            ref = ref.clip(0, 2**24 - 1)
+            ref = ref.clip(0, 2**bits_stored - 1)
             ref = ref.astype("uint32")
 
             buffer = ref.tobytes()
@@ -1479,7 +1487,9 @@ class TestJ2KEncoding:
         for bits_stored in range(1, 9):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
-            ref = ref.clip(-128, 127)
+            minimum = -2**(bits_stored - 1)
+            maximum = 2**(bits_stored - 1) - 1
+            ref = ref.clip(minimum, maximum)
             ref = ref.astype("int8")
 
             buffer = ref.tobytes()
@@ -1520,7 +1530,9 @@ class TestJ2KEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
-            ref = ref.clip(-(2**15), 2**15 - 1)
+            minimum = -2**(bits_stored - 1)
+            maximum = 2**(bits_stored - 1) - 1
+            ref = ref.clip(minimum, maximum)
             ref = ref.astype("int16")
 
             buffer = ref.tobytes()
@@ -1561,7 +1573,9 @@ class TestJ2KEncoding:
         for bits_stored, atol in zip(range(1, 25), atols):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
-            ref = ref.clip(-(2**23), 2**23 - 1)
+            minimum = -2**(bits_stored - 1)
+            maximum = 2**(bits_stored - 1) - 1
+            ref = ref.clip(minimum, maximum)
             ref = ref.astype("int32")
 
             buffer = ref.tobytes()
@@ -1575,7 +1589,7 @@ class TestJ2KEncoding:
                 **opts,
             )
             assert not np.array_equal(out, ref)
-            assert np.allclose(out, ref, atol=atol)
+            assert np.allclose(out, ref, atol=atol, rtol=0.05)
 
     def test_j2k_psnr(self):
         """Test compression using j2k_psnr"""

--- a/tests/pixels/test_encoder_pylibjpeg.py
+++ b/tests/pixels/test_encoder_pylibjpeg.py
@@ -1005,6 +1005,9 @@ class TestJ2KEncoding:
                 decoding_plugin="pylibjpeg",
                 **opts,
             )
+            if bits_stored == 24:
+                diff = np.absolute(out.astype("float") - ref.astype("float"))
+                print("Difference", diff.max())
             assert not np.array_equal(out, ref)
             assert np.allclose(out, ref, atol=atol, rtol=0.05)
 

--- a/tests/pixels/test_encoder_pylibjpeg.py
+++ b/tests/pixels/test_encoder_pylibjpeg.py
@@ -1136,8 +1136,8 @@ class TestJ2KEncoding:
         for bits_stored in range(1, 9):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
-            minimum = -2**(bits_stored - 1)
-            maximum = 2**(bits_stored - 1) - 1
+            minimum = -(2 ** (bits_stored - 1))
+            maximum = 2 ** (bits_stored - 1) - 1
             ref = ref.clip(minimum, maximum)
             ref = ref.astype("int8")
 
@@ -1176,8 +1176,8 @@ class TestJ2KEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
-            minimum = -2**(bits_stored - 1)
-            maximum = 2**(bits_stored - 1) - 1
+            minimum = -(2 ** (bits_stored - 1))
+            maximum = 2 ** (bits_stored - 1) - 1
             ref = ref.clip(minimum, maximum)
             ref = ref.astype("int16")
 
@@ -1217,8 +1217,8 @@ class TestJ2KEncoding:
         for bits_stored, atol in zip(range(1, 25), atols):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
-            minimum = -2**(bits_stored - 1)
-            maximum = 2**(bits_stored - 1) - 1
+            minimum = -(2 ** (bits_stored - 1))
+            maximum = 2 ** (bits_stored - 1) - 1
             ref = ref.clip(minimum, maximum)
             ref = ref.astype("int32")
 
@@ -1487,8 +1487,8 @@ class TestJ2KEncoding:
         for bits_stored in range(1, 9):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
-            minimum = -2**(bits_stored - 1)
-            maximum = 2**(bits_stored - 1) - 1
+            minimum = -(2 ** (bits_stored - 1))
+            maximum = 2 ** (bits_stored - 1) - 1
             ref = ref.clip(minimum, maximum)
             ref = ref.astype("int8")
 
@@ -1530,8 +1530,8 @@ class TestJ2KEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
-            minimum = -2**(bits_stored - 1)
-            maximum = 2**(bits_stored - 1) - 1
+            minimum = -(2 ** (bits_stored - 1))
+            maximum = 2 ** (bits_stored - 1) - 1
             ref = ref.clip(minimum, maximum)
             ref = ref.astype("int16")
 
@@ -1573,8 +1573,8 @@ class TestJ2KEncoding:
         for bits_stored, atol in zip(range(1, 25), atols):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
-            minimum = -2**(bits_stored - 1)
-            maximum = 2**(bits_stored - 1) - 1
+            minimum = -(2 ** (bits_stored - 1))
+            maximum = 2 ** (bits_stored - 1) - 1
             ref = ref.clip(minimum, maximum)
             ref = ref.astype("int32")
 

--- a/tests/pixels/test_encoder_pylibjpeg.py
+++ b/tests/pixels/test_encoder_pylibjpeg.py
@@ -1345,7 +1345,6 @@ class TestJ2KEncoding:
                 decoding_plugin="pylibjpeg",
                 **opts,
             )
-            diff = np.absolute(out.astype("float") - ref.astype("float"))
             assert not np.array_equal(out, ref)
             assert np.allclose(out, ref, atol=atol, rtol=0.05)
 

--- a/tests/pixels/test_encoder_pylibjpeg.py
+++ b/tests/pixels/test_encoder_pylibjpeg.py
@@ -992,7 +992,7 @@ class TestJ2KEncoding:
         }
         atols = [1, 1, 1, 1, 2, 2, 2, 2]
         atols.extend([2, 2, 2, 4, 5, 8, 10, 16])
-        atols.extend([23, 31, 52, 63, 116, 2928854, 7404089, 9687927])
+        atols.extend([23, 31, 52, 63, 116, 2928854, 7404089, 10080970])
         for bits_stored, atol in zip(range(1, 25), atols):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**bits_stored - 1)
@@ -1005,11 +1005,8 @@ class TestJ2KEncoding:
                 decoding_plugin="pylibjpeg",
                 **opts,
             )
-            if bits_stored == 24:
-                diff = np.absolute(out.astype("float") - ref.astype("float"))
-                print("Difference", diff.max())
             assert not np.array_equal(out, ref)
-            assert np.allclose(out, ref, atol=atol, rtol=0.05)
+            assert np.allclose(out, ref, atol=atol)
 
     def test_arr_u1_spp3(self):
         """Test unsigned bits allocated 8, bits stored (1, 8), samples per pixel 3"""
@@ -1216,7 +1213,7 @@ class TestJ2KEncoding:
 
         atols = [1, 1, 1, 2, 2, 2, 2, 2]
         atols.extend([2, 2, 2, 4, 5, 9, 11, 16])
-        atols.extend([25, 32, 46, 64, 111, 2928849, 7404094, 9687916])
+        atols.extend([25, 32, 46, 64, 111, 2928849, 7404094, 10080970])
         for bits_stored, atol in zip(range(1, 25), atols):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
@@ -1233,7 +1230,7 @@ class TestJ2KEncoding:
                 **opts,
             )
             assert not np.array_equal(out, ref)
-            assert np.allclose(out, ref, atol=atol, rtol=0.05)
+            assert np.allclose(out, ref, atol=atol)
 
     def test_buffer_u1_spp1(self):
         """Test unsigned bits allocated 8, bits stored (1, 8), samples per pixel 1"""
@@ -1332,7 +1329,7 @@ class TestJ2KEncoding:
 
         atols = [1, 1, 1, 1, 2, 2, 2, 2]
         atols.extend([2, 2, 2, 4, 5, 8, 10, 16])
-        atols.extend([23, 31, 52, 63, 116, 2928854, 7404089, 9687927])
+        atols.extend([23, 31, 52, 63, 116, 2928854, 7404089, 10080970])
         for bits_stored, atol in zip(range(1, 25), atols):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**bits_stored - 1)
@@ -1349,7 +1346,7 @@ class TestJ2KEncoding:
                 **opts,
             )
             assert not np.array_equal(out, ref)
-            assert np.allclose(out, ref, atol=atol, rtol=0.05)
+            assert np.allclose(out, ref, atol=atol)
 
     def test_buffer_u1_spp3(self):
         """Test unsigned bits allocated 8, bits stored (1, 8), samples per pixel 3"""
@@ -1571,7 +1568,7 @@ class TestJ2KEncoding:
 
         atols = [1, 1, 1, 2, 2, 2, 2, 2]
         atols.extend([2, 2, 2, 4, 5, 9, 11, 16])
-        atols.extend([25, 32, 46, 64, 111, 2928849, 7404094, 9687916])
+        atols.extend([25, 32, 46, 64, 111, 2928849, 7404094, 10080970])
         for bits_stored, atol in zip(range(1, 25), atols):
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
@@ -1591,7 +1588,7 @@ class TestJ2KEncoding:
                 **opts,
             )
             assert not np.array_equal(out, ref)
-            assert np.allclose(out, ref, atol=atol, rtol=0.05)
+            assert np.allclose(out, ref, atol=atol)
 
     def test_j2k_psnr(self):
         """Test compression using j2k_psnr"""

--- a/tests/test_fileset.py
+++ b/tests/test_fileset.py
@@ -1353,7 +1353,7 @@ class TestFileSet:
         assert 0xFFFF == item.RecordInUseFlag
         assert 0 == item.OffsetOfTheNextDirectoryRecord
         assert "ISO_IR 100" == item.SpecificCharacterSet
-        assert 516 == item.OffsetOfReferencedLowerLevelDirectoryEntity
+        assert length + (516 - 398) == item.OffsetOfReferencedLowerLevelDirectoryEntity
 
         item = seq[1]
         assert item.seq_item_tell == length + (516 - 398)


### PR DESCRIPTION
#### Describe the changes
The [windows tests have been failing](https://github.com/pydicom/pydicom/actions/runs/9066662441/job/24910056474) in the merge workflow but not triggering a failure.

I think the use of the multiline `run` command means if one fails then the result will still be OK if the final command succeeds. Fixed by switching to `bash` shell for all runners and fixing the failing tests in `pixels/test_encoder_pylibjpeg.py`:

* `TestJ2KEncoding.test_arr_u4_spp1`
* `TestJ2KEncoding.test_arr_u4_spp3`
* `TestJ2KEncoding.test_arr_i4_spp1`
* `TestJ2KEncoding.test_buffer_u4_spp1`
* `TestJ2KEncoding.test_buffer_i4_spp1`

I hadn't noticed how awful the lossy compression results are for 21+ bits...

[Passing run](https://github.com/pydicom/pydicom/actions/runs/9121022758/job/25079504933?pr=2058)

Also fixes [intermittent failure](https://github.com/pydicom/pydicom/actions/runs/9120310424/job/25077446726?pr=2058) in `test_fileset.py::TestFileSet::test_add_dataset` which I missed the first time I tried to fix that.

#### Tasks
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
