### PR TITLE
[MRG] Add exception for pillow decoder with multi-byte multi-sample J2K

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -59,6 +59,8 @@ Changes
 * Using GDCM v3.0.23 or lower to decode JPEG-LS datasets with a *Bits Stored* of
   6 or 7 produces incorrect results, so attempting to do so now raises an exception.
   ``pyjpegls`` or ``pylibjpeg`` with ``pylibjpeg-libjpeg`` can be used instead (:issue:`2008`).
+* Using Pillow with JPEG 2000 encoded > 8-bit multi-sample data (such as RGB) now raises an
+  exception as Pillow cannot decode such data correctly (:issue:`2006`, :issue:`2059`)
 
 
 Removals

--- a/src/pydicom/pixels/decoders/pillow.py
+++ b/src/pydicom/pixels/decoders/pillow.py
@@ -85,6 +85,12 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytes:
     if 0 < precision <= 8:
         runner.set_option("bits_allocated", 8)
     elif 8 < precision <= 16:
+        # Pillow converts >= 9-bit RGB/YCbCr data to 8-bit
+        if runner.samples_per_pixel > 1:
+            raise ValueError(
+                f"Pillow cannot decode {precision}-bit multi-sample data correctly"
+            )
+
         runner.set_option("bits_allocated", 16)
     else:
         raise ValueError(

--- a/tests/pixels/test_decoder_pillow.py
+++ b/tests/pixels/test_decoder_pillow.py
@@ -32,6 +32,7 @@ from .pixels_reference import (
     J2KR_08_08_3_0_1F_YBR_RCT,
     JPGB_08_08_3_0_1F_RGB,  # has RGB component IDs
     JPGB_08_08_3_0_1F_YBR_FULL,  # has JFIF APP marker
+    J2KR_16_10_1_0_1F_M1,
 )
 
 
@@ -167,4 +168,21 @@ class TestOpenJpegDecoder:
         with pytest.raises(RuntimeError, match=msg):
             decoder.as_array(
                 ds, decoding_plugin="pillow", bits_stored=17, bits_allocated=32
+            )
+
+    def test_multisample_16bit_raises(self):
+        """Test that > 8-bit RGB datasets raise exception"""
+        decoder = get_decoder(JPEG2000Lossless)
+        ds = J2KR_16_10_1_0_1F_M1.ds
+
+        msg = (
+            "Unable to decode as exceptions were raised by all available plugins:\n"
+            r"  pillow: Pillow cannot decode 10-bit multi-sample data correctly"
+        )
+        with pytest.raises(RuntimeError, match=msg):
+            decoder.as_array(
+                ds,
+                decoding_plugin="pillow",
+                samples_per_pixel=3,
+                planar_configuration=0,
             )


### PR DESCRIPTION
#### Describe the changes
Pillow is unable to correctly decode multi-byte RGB J2K codestreams due to it's image mode limitations, so raise an exception instead of incorrectly decoding and giving a different more generic exception.

Closes #2006, closes #2059 (probably)

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
