### PR TITLE
[MRG] Shift bits when Bits Stored is less than Bits Allocated

### DIFF
--- a/doc/guides/decoding/decoder_options.rst
+++ b/doc/guides/decoding/decoder_options.rst
@@ -108,10 +108,10 @@ The following options may be used with both native (uncompressed) and encapsulat
 (compressed) transfer syntaxes when decoding to a NumPy :class:`~numpy.ndarray` or
 buffer-like object:
 
-  * `allow_excess_frames`: :class:`bool` - if ``True`` (default) and `src` contains
-    more frames of data than given by the value of (0028,0008) *Number of Frames* then
-    include those extra frames in the returned data, otherwise return only the number
-    of frames given by *Number of Frames*.
+* `allow_excess_frames`: :class:`bool` - if ``True`` (default) and `src` contains
+  more frames of data than given by the value of (0028,0008) *Number of Frames* then
+  include those extra frames in the returned data, otherwise return only the number
+  eof frames given by *Number of Frames*.
 
 The following options may be used with native (uncompressed) transfer syntaxes
 when decoding to a NumPy :class:`~numpy.ndarray`:

--- a/doc/guides/decoding/decoder_options.rst
+++ b/doc/guides/decoding/decoder_options.rst
@@ -94,12 +94,12 @@ Miscellaneous Options
 The following options may be used with both native (uncompressed) and encapsulated
 (compressed) transfer syntaxes when decoding to a NumPy :class:`~numpy.ndarray`:
 
-* `apply_shift_correction`: :class:`bool` - if ``True`` (default) and *Bits Stored*
+* `correct_unused_bits`: :class:`bool` - if ``True`` (default) and *Bits Stored*
   doesn't equal *Bits Allocated* then apply bit-shifting operations to correct
   for any misinterpretation due to the unused bits. For example, if *Bits Stored*
-  is 5, *Bits Allocated* is 8 and *Pixel Representation* is 1 then the 3 most
-  significant bits are unused. A raw value of ``0b00011001`` would be therefore
-  interpreted as the value 25 if `apply_shift_correction` is ``False`` instead
+  is 5 and *Bits Allocated* is 8 then the 3 most significant bits are unused.
+  A raw value of ``0b00011001`` with a *Pixel Representation* of 1 would therefore
+  be interpreted as the value 25 if `correct_unused_bits` is ``False`` instead
   of its correct value of -7. However, in most cases this correction shouldn't
   be necessary as the unused bits are typically filled with values that will
   produce the correct interpretation.

--- a/doc/guides/decoding/decoder_options.rst
+++ b/doc/guides/decoding/decoder_options.rst
@@ -91,6 +91,19 @@ processing applied after decoding to a NumPy :class:`~numpy.ndarray`:
 Miscellaneous Options
 =====================
 
+The following options may be used with both native (uncompressed) and encapsulated
+(compressed) transfer syntaxes when decoding to a NumPy :class:`~numpy.ndarray`:
+
+* `apply_shift_correction`: :class:`bool` if ``True`` (default) and *Bits Stored*
+  doesn't equal *Bits Allocated* then apply bit-shifting operations to correct
+  for any misinterpretation due to the unused bits. For example, if *Bits Stored*
+  is 5, *Bits Allocated* is 8 and *Pixel Representation* is 1 then the 3 most
+  significant bits are unused. A raw value of ``0b00011001`` would be therefore
+  interpreted as the value 25 if `apply_shift_correction` is ``False`` instead
+  of its correct value of -7. However, in most cases this correction shouldn't
+  be necessary as the unused bits are typically filled with values that will
+  produce the correct interpretation.
+
 The following options may be used with native (uncompressed) transfer syntaxes
 when decoding to a NumPy :class:`~numpy.ndarray`:
 

--- a/doc/guides/decoding/decoder_options.rst
+++ b/doc/guides/decoding/decoder_options.rst
@@ -94,7 +94,7 @@ Miscellaneous Options
 The following options may be used with both native (uncompressed) and encapsulated
 (compressed) transfer syntaxes when decoding to a NumPy :class:`~numpy.ndarray`:
 
-* `apply_shift_correction`: :class:`bool` if ``True`` (default) and *Bits Stored*
+* `apply_shift_correction`: :class:`bool` - if ``True`` (default) and *Bits Stored*
   doesn't equal *Bits Allocated* then apply bit-shifting operations to correct
   for any misinterpretation due to the unused bits. For example, if *Bits Stored*
   is 5, *Bits Allocated* is 8 and *Pixel Representation* is 1 then the 3 most

--- a/doc/guides/decoding/decoder_options.rst
+++ b/doc/guides/decoding/decoder_options.rst
@@ -111,7 +111,7 @@ buffer-like object:
 * `allow_excess_frames`: :class:`bool` - if ``True`` (default) and `src` contains
   more frames of data than given by the value of (0028,0008) *Number of Frames* then
   include those extra frames in the returned data, otherwise return only the number
-  eof frames given by *Number of Frames*.
+  of frames given by *Number of Frames*.
 
 The following options may be used with native (uncompressed) transfer syntaxes
 when decoding to a NumPy :class:`~numpy.ndarray`:

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -236,6 +236,9 @@ Fixes
   <pydicom.dataset.Dataset.compress>` (:issue:`2013`).
 * Fixed :meth:`Dataset.decompress()<pydicom.dataset.Dataset.decompress>` not updating
   the *Pixel Data* element value until after saving (:issue:`2024`).
+* Fixed a rare issue with converting pixel data to an :class:`~numpy.ndarray` when
+  *Bits Stored* is less than *Bits Allocated* and the unused bits haven't been
+  set to an appropriate value for correct interpretation of the data.
 
 
 Deprecations

--- a/src/pydicom/pixels/decoders/base.py
+++ b/src/pydicom/pixels/decoders/base.py
@@ -69,7 +69,7 @@ class DecodeOptions(RunnerOptions, total=False):
     pixel_vr: str
     # Allow returning/yielding excess frames when found
     allow_excess_frames: bool
-    # (ndarray only) When *Bits Stored* != *Bits Allocated* peform bit shift
+    # (ndarray only) When *Bits Stored* != *Bits Allocated* perform bit shift
     #   operations to avoid using the unused bits
     apply_shift_correction: bool
 

--- a/tests/pixels/test_decoder_base.py
+++ b/tests/pixels/test_decoder_base.py
@@ -167,6 +167,7 @@ class TestDecodeRunner:
             "  transfer_syntax_uid: 1.2.840.10008.1.2.5\n"
             "  as_rgb: True\n"
             "  pixel_keyword: PixelData\n"
+            "  apply_shift_correction: True\n"
             "Decoders\n"
             "  foo"
         )
@@ -1275,14 +1276,39 @@ class TestDecoder_Array:
 
         assert idx == 2
 
-    def test_iter_native_view_only(self):
+    def test_iter_native_view_only(self, caplog):
         """Test as_array(view_only=True)"""
         decoder = get_decoder(ExplicitVRLittleEndian)
         reference = EXPL_16_1_10F
         ds = reference.ds
+        assert ds.BitsAllocated == 16
+        assert ds.BitsStored == 12
 
         assert isinstance(ds.PixelData, bytes)  # immutable
         func = decoder.iter_array(ds, view_only=True, raw=True)
+        msg = (
+            "Unable to return an ndarray that's a view on the original buffer when "
+            r"\(0028,0101\) 'Bits Stored' doesn't equal \(0028,0100\) 'Bits Allocated' "
+            "and 'apply_shift_correction=True'. In most cases you can pass "
+            "'apply_shift_correction=False' instead to get a view if the uncorrected "
+            "array is equivalent to the corrected one."
+        )
+        with caplog.at_level(logging.WARNING, logger="pydicom"):
+            arr, _ = next(func)
+            reference.test(arr, index=0)
+            assert arr.shape == reference.shape[1:]
+            assert arr.dtype == reference.dtype
+            assert arr.flags.writeable  # not a view due to bit-shift
+
+        for index, (arr, _) in enumerate(func):
+            reference.test(arr, index=index + 1)
+            assert arr.shape == reference.shape[1:]
+            assert arr.dtype == reference.dtype
+            assert arr.flags.writeable  # not a view due to bit-shift
+
+        func = decoder.iter_array(
+            ds, view_only=True, raw=True, apply_shift_correction=False
+        )
         for index, (arr, _) in enumerate(func):
             reference.test(arr, index=index)
             assert arr.shape == reference.shape[1:]
@@ -1324,6 +1350,7 @@ class TestDecoder_Array:
             number_of_frames=ds.get("NumberOfFrames", 1),
             planar_configuration=ds.get("PlanarConfiguration", 0),
             pixel_keyword="PixelData",
+            apply_shift_correction=False,
         )
         for index, (arr, _) in enumerate(func):
             reference.test(arr, index=index)

--- a/tests/pixels/test_decoder_base.py
+++ b/tests/pixels/test_decoder_base.py
@@ -1324,7 +1324,7 @@ class TestDecoder_Array:
         func = decoder.iter_array(ds, view_only=True, raw=True)
         msg = (
             "Unable to return an ndarray that's a view on the original buffer when "
-            r"\(0028,0101\) 'Bits Stored' doesn't equal \(0028,0100\) 'Bits Allocated' "
+            "(0028,0101) 'Bits Stored' doesn't equal (0028,0100) 'Bits Allocated' "
             "and 'apply_shift_correction=True'. In most cases you can pass "
             "'apply_shift_correction=False' instead to get a view if the uncorrected "
             "array is equivalent to the corrected one."
@@ -1335,6 +1335,7 @@ class TestDecoder_Array:
             assert arr.shape == reference.shape[1:]
             assert arr.dtype == reference.dtype
             assert arr.flags.writeable  # not a view due to bit-shift
+            assert msg in caplog.text
 
         for index, (arr, _) in enumerate(func):
             reference.test(arr, index=index + 1)

--- a/tests/pixels/test_decoder_base.py
+++ b/tests/pixels/test_decoder_base.py
@@ -168,7 +168,7 @@ class TestDecodeRunner:
             "  as_rgb: True\n"
             "  allow_excess_frames: True\n"
             "  pixel_keyword: PixelData\n"
-            "  apply_shift_correction: True\n"
+            "  correct_unused_bits: True\n"
             "Decoders\n"
             "  foo"
         )
@@ -1325,8 +1325,8 @@ class TestDecoder_Array:
         msg = (
             "Unable to return an ndarray that's a view on the original buffer when "
             "(0028,0101) 'Bits Stored' doesn't equal (0028,0100) 'Bits Allocated' "
-            "and 'apply_shift_correction=True'. In most cases you can pass "
-            "'apply_shift_correction=False' instead to get a view if the uncorrected "
+            "and 'correct_unused_bits=True'. In most cases you can pass "
+            "'correct_unused_bits=False' instead to get a view if the uncorrected "
             "array is equivalent to the corrected one."
         )
         with caplog.at_level(logging.WARNING, logger="pydicom"):
@@ -1344,7 +1344,7 @@ class TestDecoder_Array:
             assert arr.flags.writeable  # not a view due to bit-shift
 
         func = decoder.iter_array(
-            ds, view_only=True, raw=True, apply_shift_correction=False
+            ds, view_only=True, raw=True, correct_unused_bits=False
         )
         for index, (arr, _) in enumerate(func):
             reference.test(arr, index=index)
@@ -1387,7 +1387,7 @@ class TestDecoder_Array:
             number_of_frames=ds.get("NumberOfFrames", 1),
             planar_configuration=ds.get("PlanarConfiguration", 0),
             pixel_keyword="PixelData",
-            apply_shift_correction=False,
+            correct_unused_bits=False,
         )
         for index, (arr, _) in enumerate(func):
             reference.test(arr, index=index)

--- a/tests/pixels/test_processing.py
+++ b/tests/pixels/test_processing.py
@@ -222,26 +222,25 @@ class TestModalityLUT:
 
     def test_lut_sequence(self):
         """Test the LUT Sequence transform."""
+        # Unused bits don't match interpretation!
         ds = dcmread(MOD_16_SEQ)
+        assert ds.BitsAllocated == 16
+        assert ds.BitsStored == 12
         seq = ds.ModalityLUTSequence[0]
         assert [4096, -2048, 16] == seq.LUTDescriptor
+
         arr = ds.pixel_array
         assert -2048 == arr.min()
-        assert 4095 == arr.max()
-        out = apply_modality_lut(arr, ds)
+        assert 2047 == arr.max()
 
-        # IV > 2047 -> LUT[4095]
-        mapped_pixels = arr > 2047
-        assert seq.LUTData[-1] == out[mapped_pixels][0]
-        assert (seq.LUTData[-1] == out[mapped_pixels]).all()
+        out = apply_modality_lut(arr, ds)
         assert out.flags.writeable
         assert out.dtype == np.uint16
-
-        assert [65535, 65535, 49147, 49147, 65535] == list(out[0, 50:55])
-        assert [65535, 65535, 65535, 65535, 65535] == list(out[50, 50:55])
-        assert [65535, 65535, 65535, 65535, 65535] == list(out[100, 50:55])
-        assert [65535, 65535, 49147, 49147, 65535] == list(out[150, 50:55])
-        assert [65535, 65535, 49147, 49147, 65535] == list(out[200, 50:55])
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[0, 50:55])
+        assert [65535, 0, 0, 65535, 65535] == list(out[50, 50:55])
+        assert [65535, 0, 0, 0, 65535] == list(out[100, 50:55])
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[150, 50:55])
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[200, 50:55])
         assert 39321 == out[185, 340]
         assert 45867 == out[185, 385]
         assert 52428 == out[228, 385]
@@ -288,21 +287,16 @@ class TestModalityLUT:
         seq.LUTData = pack("<4096H", *seq.LUTData)
         arr = ds.pixel_array
         assert -2048 == arr.min()
-        assert 4095 == arr.max()
-        out = apply_modality_lut(arr, ds)
+        assert 2047 == arr.max()
 
-        # IV > 2047 -> LUT[4095]
-        mapped_pixels = arr > 2047
-        assert 65535 == out[mapped_pixels][0]
-        assert (65535 == out[mapped_pixels]).all()
+        out = apply_modality_lut(arr, ds)
         assert out.flags.writeable
         assert out.dtype == np.uint16
-
-        assert [65535, 65535, 49147, 49147, 65535] == list(out[0, 50:55])
-        assert [65535, 65535, 65535, 65535, 65535] == list(out[50, 50:55])
-        assert [65535, 65535, 65535, 65535, 65535] == list(out[100, 50:55])
-        assert [65535, 65535, 49147, 49147, 65535] == list(out[150, 50:55])
-        assert [65535, 65535, 49147, 49147, 65535] == list(out[200, 50:55])
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[0, 50:55])
+        assert [65535, 0, 0, 65535, 65535] == list(out[50, 50:55])
+        assert [65535, 0, 0, 0, 65535] == list(out[100, 50:55])
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[150, 50:55])
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[200, 50:55])
         assert 39321 == out[185, 340]
         assert 45867 == out[185, 385]
         assert 52428 == out[228, 385]
@@ -1247,7 +1241,7 @@ class TestApplyWindowing:
         assert [4096, -2048, 16] == seq.LUTDescriptor
         arr = ds.pixel_array
         assert -2048 == arr.min()
-        assert 4095 == arr.max()
+        assert 2047 == arr.max()
 
         arr = ds.pixel_array
         assert 2047 == arr[16, 60]


### PR DESCRIPTION
#### Describe the changes
When *Bits Stored* < *Bits Allocated* [the unused bits are supposed to be ignored](https://dicom.nema.org/medical/dicom/current/output/chtml/part05/chapter_8.html#sect_8.1):

> For example, in Pixel Data with 16 bits (2 bytes) allocated, 12 bits stored, and bit 11 specified as the high bit, one pixel sample is encoded in each 16-bit word, with the 4 most significant bits of each word not containing Pixel Data. See [Annex D](https://dicom.nema.org/medical/dicom/current/output/chtml/part05/chapter_D.html) for other examples of the basic encoding schemes.
> ...
> Receiving applications may not assume anything about the contents of unused bits, and in particular may not assume that they are zero, or that they contain sign extension bits.

However in > 99% of cases this is irrelevant because applications typically fill these unused bits with values that result in the correct interpretation of the data. This PR fixes the other < 1% at the cost of applying 2 bit-shifting operations on the 99% that doesn't need it.

Closes #2026

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/0f526943-e293-4b97-8b6f-1dcfa4bb2843/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
