### PR TITLE
[MRG] Restrict colour space conversion to uint8 arrays

### DIFF
--- a/src/pydicom/pixels/processing.py
+++ b/src/pydicom/pixels/processing.py
@@ -626,9 +626,9 @@ def convert_color_space(
     Parameters
     ----------
     arr : numpy.ndarray
-        The image(s) as a :class:`numpy.ndarray` with
-        :attr:`~numpy.ndarray.shape` (frames, rows, columns, 3)
-        or (rows, columns, 3).
+        The image(s) as :class:`numpy.ndarray` with :attr:`~numpy.ndarray.shape`
+        (frames, rows, columns, 3) or (rows, columns, 3) and a 'uint8'
+        :class:`~numpy.dtype` (unsigned 8-bit).
     current : str
         The current color space, should be a valid value for (0028,0004)
         *Photometric Interpretation*. One of ``'RGB'``, ``'YBR_FULL'``,
@@ -639,12 +639,15 @@ def convert_color_space(
         ``'YBR_FULL_422'``.
     per_frame : bool, optional
         If ``True`` and the input array contains multiple frames then process
-        each frame individually to reduce memory usage. Default ``False``.
+        each frame individually and update `arr` in-place to reduce memory
+        usage. Default ``False``.
 
     Returns
     -------
     numpy.ndarray
-        The image(s) converted to the desired color space.
+        The image(s) converted to the desired color space. If `per_frame` is
+        ``False`` (the default) then a new :class:``~numpy.ndarray` will be
+        returned, otherwise `arr` will be updated in-place.
 
     References
     ----------
@@ -655,6 +658,11 @@ def convert_color_space(
       <https://www.ijg.org/files/T-REC-T.871-201105-I!!PDF-E.pdf>`_),
       Section 7
     """
+    if arr.dtype != np.dtype("u1"):
+        raise ValueError(
+            f"Invalid ndarray.dtype '{arr.dtype}' for color space conversion, "
+            "must be 'uint8' or an equivalent"
+        )
 
     def _no_change(arr: "np.ndarray") -> "np.ndarray":
         return arr

--- a/tests/pixels/test_processing.py
+++ b/tests/pixels/test_processing.py
@@ -65,14 +65,14 @@ class TestConvertColourSpace:
         with pytest.raises(
             NotImplementedError, match="Conversion from TEST to RGB is not suppo"
         ):
-            convert_color_space(None, "TEST", "RGB")
+            convert_color_space(np.ones((1, 2), dtype="u1"), "TEST", "RGB")
 
     def test_unknown_desired_raises(self):
         """Test an unknown desdired color space raises exception."""
         with pytest.raises(
             NotImplementedError, match="Conversion from RGB to TEST is not suppo"
         ):
-            convert_color_space(None, "RGB", "TEST")
+            convert_color_space(np.ones((1, 2), dtype="u1"), "RGB", "TEST")
 
     @pytest.mark.parametrize(
         "current, desired",
@@ -86,7 +86,7 @@ class TestConvertColourSpace:
     )
     def test_current_is_desired(self, current, desired):
         """Test that the array is unchanged when current matches desired."""
-        arr = np.ones((2, 3))
+        arr = np.ones((2, 3), dtype="u1")
         assert np.array_equal(arr, convert_color_space(arr, current, desired))
 
     def test_rgb_ybr_rgb_single_frame(self):
@@ -197,6 +197,22 @@ class TestConvertColourSpace:
         assert (191, 128, 128) == tuple(ybr[1, 75, 50, :])
         assert (63, 128, 128) == tuple(ybr[1, 85, 50, :])
         assert (0, 128, 128) == tuple(ybr[1, 95, 50, :])
+
+    def test_unsuitable_dtype_raises(self):
+        """Test that non u1 dtypes raise an exception."""
+        msg = (
+            "Invalid ndarray.dtype 'int8' for color space conversion, "
+            "must be 'uint8' or an equivalent"
+        )
+        with pytest.raises(ValueError, match=msg):
+            convert_color_space(np.ones((2, 3), dtype="i1"), "RGB", "YBR_FULL")
+
+        msg = (
+            "Invalid ndarray.dtype 'uint16' for color space conversion, "
+            "must be 'uint8'"
+        )
+        with pytest.raises(ValueError, match=msg):
+            convert_color_space(np.ones((2, 3), dtype="u2"), "RGB", "YBR_FULL")
 
 
 @pytest.mark.skipif(not HAVE_NP, reason="Numpy is not available")


### PR DESCRIPTION
#### Describe the changes
The RGB <-> YCbCr colour space conversion is only valid for 8-bit unsigned data, so raise an exception if that's not the case. Added to prevent the default YCbCr to RGB transform when decoding/decompressing if it's not appropriate.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
