### PR TITLE
[MRG] Improve handling of Json inline binary UN. Fixes #2062

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -201,7 +201,8 @@ Enhancements
 * Added :meth:`Dataset.pixel_array_options()<pydicom.dataset.Dataset.pixel_array_options>`
   for controlling pixel data decoding when using :attr:`Dataset.pixel_array
   <pydicom.dataset.Dataset.pixel_array>` with the new :mod:`~pydicom.pixels` backend.
-
+* Improve support for reading and resolving inline binary data with `VR=UN` from Json
+  (:issue:`2062`).
 
 Fixes
 -----

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -286,6 +286,17 @@ class DataElement:
             dataset_class, tag, vr, value, value_key, bulk_data_uri_handler
         )
         elem_value = converter.get_element_values()
+
+        if (
+            vr == VR_.UN
+            and config.replace_un_with_known_vr
+            and isinstance(elem_value, bytes)
+        ):
+            raw = RawDataElement(
+                Tag(tag), vr, len(elem_value), elem_value, 0, True, True
+            )
+            elem_value = DataElement_from_raw(raw).value
+
         try:
             return cls(tag=tag, value=elem_value, VR=vr)
         except Exception as exc:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -340,6 +340,45 @@ class TestBinary:
         ds1 = Dataset.from_json(ds_json)
         assert ds == ds1
 
+    def test_inline_binary_un_sq(self):
+        # Test unknown VR with inline binary and a sequence
+        seq_item = Dataset()
+        seq_item.update(
+            {
+                "PatientPosition": "HFS",
+                "PatientSetupNumber": "1",
+                "SetupTechniqueDescription": "",
+            }
+        )
+        ds_ref = Dataset()
+        ds_ref.PatientSetupSequence = [seq_item]
+
+        ds_json = {
+            "300A0180": {
+                "vr": "UN",
+                "InlineBinary": "/v8A4B4AAAAYAABRBAAAAEhGUyAKMIIBAgAAADEgCjCyAQAAAAA=",
+            }
+        }
+        ds1 = Dataset.from_json(ds_json)
+        assert "PatientSetupSequence" in ds1
+        assert ds1 == ds_ref
+
+    def test_inline_binary_un_pad(self):
+        # Test unknown VR with inline binary and odd-length values
+        # The value ("HFS") is an odd length.
+        # The value is padded with a space before base64 encoding because
+        # UN uses implicit VR little endian.
+        # When reading back, the padding should be removed.
+        ds_json = {
+            "00185100": {
+                "vr": "UN",
+                "InlineBinary": "SEZTIA==",
+            }
+        }
+        ds1 = Dataset.from_json(ds_json)
+        assert "PatientPosition" in ds1
+        assert ds1.PatientPosition == "HFS"
+
     def test_invalid_inline_binary(self):
         msg = (
             "Invalid attribute value for data element '00091002' - the value "


### PR DESCRIPTION
#### Describe the changes

Adds handling of unknown VR with InlineBinary content. This fixes two issues:
- Sequences encoded in the unknown VR were not correctly read. (See #2062)
- Values encoded in the content were not correctly un-padded.

fixes #2062

Maybe it would be better to extend the constructor of `DataElement` to accept `value` as a bytes - the documentation for the class doesn't allow for this, but there seems to be some preliminary handling of UN in there.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
