### PR TITLE
[MRG] Add pixel data tutorial, various small improvements

### DIFF
--- a/doc/guides/index.rst
+++ b/doc/guides/index.rst
@@ -12,6 +12,7 @@ pydicom:
 
    user/index
    element_value_types
+   plugin_table
    decoding/index
    encoding/index
    cli/cli_guide

--- a/doc/guides/plugin_table.rst
+++ b/doc/guides/plugin_table.rst
@@ -1,0 +1,165 @@
+
+====================================================
+Plugins for Pixel Data Compression and Decompression
+====================================================
+
+
+.. _guide_decoding_plugins:
+
+Plugins for Decompression
+=========================
+
+The table below lists the plugins available for decompressing pixel data that's been compressed using the corresponding
+*Transfer Syntax UID*. No plugins are used for uncompressed pixel data.
+
+.. |chk|   unicode:: U+02713 .. CHECK MARK
+
++---------------------------------------------------+---------------------------------------------------------------------------+
+| Transfer Syntax                                   | Plugins                                                                   |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+| Name                    | UID                     | ``pylibjpeg``   | ``gdcm`` | ``pillow``      | ``pyjpegls`` | ``pydicom`` |
++=========================+=========================+=================+==========+=================+==============+=============+
+| *JPEG Baseline 8-bit*   | 1.2.840.10008.1.2.4.50  | |chk|\ :sup:`1` | |chk|    | |chk|           |              |             |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+| *JPEG Extended 12-bit*  | 1.2.840.10008.1.2.4.51  | |chk|\ :sup:`1` | |chk|    | |chk|           |              |             |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+| *JPEG Lossless P14*     | 1.2.840.10008.1.2.4.57  | |chk|\ :sup:`1` | |chk|    |                 |              |             |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+| *JPEG Lossless SV1*     | 1.2.840.10008.1.2.4.70  | |chk|\ :sup:`1` | |chk|    |                 |              |             |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+| *JPEG-LS Lossless*      | 1.2.840.10008.1.2.4.80  | |chk|\ :sup:`1` | |chk|    |                 | |chk|        |             |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+| *JPEG-LS Near Lossless* | 1.2.840.10008.1.2.4.81  | |chk|\ :sup:`1` | |chk|    |                 | |chk|        |             |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+| *JPEG 2000 Lossless*    | 1.2.840.10008.1.2.4.90  | |chk|\ :sup:`2` | |chk|    | |chk|\ :sup:`4` |              |             |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+| *JPEG 2000*             | 1.2.840.10008.1.2.4.91  | |chk|\ :sup:`2` | |chk|    | |chk|\ :sup:`4` |              |             |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+| *HTJ2K Lossless*        | 1.2.840.10008.1.2.4.201 | |chk|\ :sup:`2` |          |                 |              |             |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+| *HTJ2K Lossless RPCL*   | 1.2.840.10008.1.2.4.202 | |chk|\ :sup:`2` |          |                 |              |             |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+| *HTJ2K*                 | 1.2.840.10008.1.2.4.203 | |chk|\ :sup:`2` |          |                 |              |             |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+| *RLE Lossless*          | 1.2.840.10008.1.2.5     | |chk|\ :sup:`3` | |chk|    |                 |              | |chk|       |
++-------------------------+-------------------------+-----------------+----------+-----------------+--------------+-------------+
+
+| :sup:`1` with ``pylibjpeg-libjpeg``
+| :sup:`2` with ``pylibjpeg-openjpeg``
+| :sup:`3` with ``pylibjpeg-rle``
+| :sup:`4` with Pillow's *Jpeg2KImagePlugin*
+
+
+Plugins
+-------
+
+``pylibjpeg``
+.............
+
+Requires `pylibjpeg <https://github.com/pydicom/pylibjpeg>`_ and at least one of:
+
+* `pylibjpeg-libjpeg <https://github.com/pydicom/pylibjpeg-libjpeg>`_
+* `pylibjpeg-openjpeg <https://github.com/pydicom/pylibjpeg-openjpeg>`_
+* `pylibjpeg-rle <https://github.com/pydicom/pylibjpeg-rle>`_
+
+**Known limitations**
+
+* Maximum supported *Bits Stored* for JPEG 2000 and HTJ2K is 24
+
+``gdcm``
+........
+
+Requires `python-gdcm <https://github.com/tfmoraes/python-gdcm>`_.
+
+**Known limitations**
+
+* *JPEG Extended 12-bit* is only available if *Bits Allocated* is 8
+* *JPEG-LS Near Lossless* only if *Bits Stored* is at least 8 for a *Pixel Representation* of 1
+* *JPEG-LS Lossless* and *JPEG-LS Near Lossless* only if *Bits Stored* is not 6 or 7
+* Maximum supported *Bits Stored* is 16
+
+``pillow``
+..........
+
+Requires `Pillow <https://pillow.readthedocs.io/en/stable/>`_, with support for
+JPEG 2000 via Pillow's `Jpeg2KImagePlugin
+<https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg-2000>`_
+requiring `OpenJPEG <https://www.openjpeg.org/>`_.
+
+**Known limitations**
+
+* *JPEG Extended 12-bit* is only available if *Bits Allocated* is 8
+* *JPEG 2000 Lossless* and *JPEG 2000* are only available for a *Samples per Pixel* of
+  3 when *Bits Stored* is <= 8
+* Maximum supported *Bits Stored* is 16
+
+``pyjpegls``
+............
+
+Requires `pyjpegls <https://github.com/pydicom/pyjpegls>`_.
+
+``pydicom``
+...........
+
+Requires `pydicom <https://github.com/pydicom/pydicom>`_.
+
+**Known limitations**
+
+* Slower than the other plugins by 3-4x
+
+
+
+.. _guide_encoding_plugins:
+
+Plugins for Compression
+=======================
+
+.. currentmodule:: pydicom.pixels.encoders
+
++---------------------------------------------------+---------------+--------------------------------------------+
+| Transfer Syntax                                   | Plugins       | Encoding guide                             |
++-------------------------+-------------------------+               |                                            |
+| Name                    | UID                     |               |                                            |
++=========================+=========================+===============+============================================+
+| *JPEG-LS Lossless*      | 1.2.840.10008.1.2.4.80  | ``pyjpegls``  | :doc:`JPEG-LS</guides/encoding/jpeg_ls>`   |
++-------------------------+-------------------------+               |                                            |
+| *JPEG-LS Near Lossless* | 1.2.840.10008.1.2.4.81  |               |                                            |
++-------------------------+-------------------------+---------------+--------------------------------------------+
+| *JPEG 2000 Lossless*    | 1.2.840.10008.1.2.4.90  | ``pylibjpeg`` | :doc:`JPEG 2000</guides/encoding/jpeg_2k>` |
++-------------------------+-------------------------+               |                                            |
+| *JPEG 2000*             | 1.2.840.10008.1.2.4.91  |               |                                            |
++-------------------------+-------------------------+---------------+--------------------------------------------+
+| *RLE Lossless*          | 1.2.840.10008.1.2.5     | ``pylibjpeg`` | :doc:`RLE</guides/encoding/rle_lossless>`  |
+|                         |                         +---------------+                                            |
+|                         |                         | ``pydicom``   |                                            |
++-------------------------+-------------------------+---------------+--------------------------------------------+
+
+
+Plugins
+-------
+
+``pyjpegls``
+............
+
+Requires `pyjpegls <https://github.com/pydicom/pyjpegls>`_.
+
+
+``pylibjpeg``
+.............
+
+Requires `pylibjpeg <https://github.com/pydicom/pylibjpeg>`_ and
+`pylibjpeg-openjpeg <https://github.com/pydicom/pylibjpeg-openjpeg>`_.
+
+**Known limitations**
+
+* The maximum supported *Bits Stored* for JPEG 2000 is 24, however the results
+  for 20-24 are very poor when using lossy compression.
+
+``pydicom``
+...........
+
+Requires `pydicom <https://github.com/pydicom/pydicom>`_.
+
+**Known limitations**
+
+* Much slower than the other plugins

--- a/doc/guides/plugin_table.rst
+++ b/doc/guides/plugin_table.rst
@@ -147,8 +147,10 @@ Requires `pyjpegls <https://github.com/pydicom/pyjpegls>`_.
 ``pylibjpeg``
 .............
 
-Requires `pylibjpeg <https://github.com/pydicom/pylibjpeg>`_ and
-`pylibjpeg-openjpeg <https://github.com/pydicom/pylibjpeg-openjpeg>`_.
+Requires `pylibjpeg <https://github.com/pydicom/pylibjpeg>`_ as well as
+`pylibjpeg-openjpeg <https://github.com/pydicom/pylibjpeg-openjpeg>`_ for JPEG 2000
+compression and `pylibjpeg-rle <https://github.com/pydicom/pylibjpeg-rle>`_ for
+*RLE Lossless*.
 
 **Known limitations**
 

--- a/doc/guides/user/base_element.rst
+++ b/doc/guides/user/base_element.rst
@@ -22,14 +22,13 @@ A :class:`~dataset.Dataset` can be created directly, but you'll
 usually get one by reading an existing DICOM dataset from file using
 :func:`~pydicom.filereader.dcmread`::
 
-    >>> import pydicom
-    >>> from pydicom.data import get_testdata_file
-    >>> # Returns the path to one of pydicom's example DICOM datasets
-    >>> path: str = get_testdata_file("rtplan.dcm")
+    >>> from pydicom import dcmread, examples
+    >>> # Returns the path to pydicom's examples.rt_plan dataset
+    >>> path = examples.get_path("rt_plan")
     >>> print(path)
-    '/path/to/pydicom/data/test_files/rtplan.dcm'
+    PosixPath('/path/to/pydicom/data/test_files/rtplan.dcm')
     >>> # Read the DICOM dataset at `path`
-    >>> ds = pydicom.dcmread(path)
+    >>> ds = dcmread(path)
 
 You can display the contents of the entire dataset using ``str(ds)`` or with::
 

--- a/doc/guides/user/working_with_pixel_data.rst
+++ b/doc/guides/user/working_with_pixel_data.rst
@@ -29,9 +29,8 @@ The only exception to this is :dcm:`Parametric Map Storage
 
 By default *pydicom* reads in pixel data as the raw bytes found in the file::
 
-  >>> from pydicom import dcmread
-  >>> from pydicom.data import get_testdata_file
-  >>> path = get_testdata_file("MR_small.dcm")  # the path to an example dataset
+  >>> from pydicom import dcmread, examples
+  >>> path = examples.get_path("mr")  # The path to the examples.mr dataset
   >>> ds = dcmread(path)
   >>> ds.PixelData # doctest: +ELLIPSIS
   b'\x89\x03\xfb\x03\xcb\x04\xeb\x04\xf9\x02\x94\x01\x7f...

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,7 +9,6 @@ pydicom documentation
    :caption: Getting started
 
    tutorials/installation
-   old/getting_started
 
 .. toctree::
    :maxdepth: 2
@@ -43,12 +42,16 @@ Getting Started
 If you're new to *pydicom* then start here:
 
 * :doc:`Installation<tutorials/installation>` |
+  :doc:`Plugins for Pixel Data</guides/plugin_table>` |
   :doc:`What Python types do I use for each VR<guides/element_value_types>`
 * **Basics**: :doc:`Dataset: read, access, modify, write</tutorials/dataset_basics>`
 * **Intermediate**:
-  :doc:`Compressing Pixel Data</tutorials/pixel_data/compressing>` |
   :doc:`Waveform decoding and encoding</tutorials/waveforms>` |
   :doc:`DICOM File-sets and DICOMDIR</tutorials/filesets>`
+* **Pixel Data**:
+  :doc:`Introduction & accessing</tutorials/pixel_data/introduction>` |
+  :doc:`Creating new Pixel Data</tutorials/pixel_data/creation>` |
+  :doc:`Compression and decompression</tutorials/pixel_data/compressing>`
 
 
 :doc:`User Guide <guides/user/index>`

--- a/doc/reference/examples.rst
+++ b/doc/reference/examples.rst
@@ -3,6 +3,7 @@
 Example Datasets (:mod:`pydicom.examples`)
 ==========================================
 
+.. module:: pydicom.examples
 .. currentmodule:: pydicom.examples
 
 The ``examples`` module contains the following DICOM datasets:
@@ -36,6 +37,14 @@ The ``examples`` module contains the following DICOM datasets:
 +-------------------+---------------------------------------+----------------------+
 
 
+As well as the utility function:
+
+.. autosummary::
+   :toctree: generated/
+
+   get_path
+
+
 Usage
 -----
 
@@ -60,3 +69,9 @@ Because of this, best practice is to assign the returned dataset to a local
 variable::
 
    >>> ds = examples.ct
+
+The :func:`~pydicom.examples.get_path` function can be used to return the path
+to an example dataset as a :class:`pathlib.Path` instance::
+
+   >>> examples.get_path("ct")
+   PosixPath('/home/user/pydicom/src/pydicom/data/test_files/CT_small.dcm')

--- a/doc/reference/pixels.rst
+++ b/doc/reference/pixels.rst
@@ -14,6 +14,7 @@ Image processing functions
 
    apply_color_lut
    apply_modality_lut
+   apply_rescale
    apply_voi_lut
    apply_voi
    apply_windowing

--- a/doc/tutorials/dataset_basics.rst
+++ b/doc/tutorials/dataset_basics.rst
@@ -16,26 +16,25 @@ If you haven't installed *pydicom* yet, follow the instructions in our
 Getting the path to the example dataset
 =======================================
 
-In the tutorial we're going to be using a DICOM dataset included with
+In the tutorial we're going to be using one of the example DICOM datasets included with
 *pydicom*: :gh:`CT_small.dcm<pydicom/blob/main/src/pydicom/data/test_files/CT_small.dcm>`.
-You can get the file path to the dataset by using the :func:`~pydicom.data.get_testdata_file`
-function to return the path as a :class:`str` (your path may vary)::
+You can get the file path to the dataset by using the :func:`~pydicom.examples.get_path`
+function to return the path as a :class:`pathlib.Path` (your path may vary)::
 
-    >>> from pydicom.data import get_testdata_file
-    >>> path = get_testdata_file("CT_small.dcm")
+    >>> from pydicom import examples
+    >>> path = examples.get_path("ct")
     >>> path
-    '/path/to/pydicom/data/test_files/CT_small.dcm'
+    PosixPath('/path/to/pydicom/data/test_files/CT_small.dcm')
 
 Reading
 =======
 
-To read the DICOM dataset at a given file path we use
-:func:`~pydicom.filereader.dcmread`, which returns a
+To read the DICOM dataset at a given file path (as a :class:`str` or :class:`pathlib.Path`)
+we use :func:`~pydicom.filereader.dcmread`, which returns a
 :class:`~pydicom.dataset.FileDataset` instance::
 
-    >>> from pydicom import dcmread
-    >>> from pydicom.data import get_testdata_file
-    >>> path = get_testdata_file("CT_small.dcm")
+    >>> from pydicom import dcmread, examples
+    >>> path = get_path("ct")
     >>> ds = dcmread(path)
 
 :func:`~pydicom.filereader.dcmread` can also handle file-likes::
@@ -57,7 +56,7 @@ exception:
 
 .. code-block:: pycon
 
-    >>> no_meta_path = get_testdata_file('no_meta.dcm')
+    >>> no_meta_path = examples.get_path('no_meta')
     >>> ds = dcmread(no_meta_path)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>

--- a/doc/tutorials/filesets.rst
+++ b/doc/tutorials/filesets.rst
@@ -112,8 +112,7 @@ To load an existing File-set just pass a DICOMDIR
 
     >>> from pydicom import dcmread
     >>> from pydicom.fileset import FileSet
-    >>> from pydicom.data import get_testdata_file
-    >>> path = get_testdata_file("DICOMDIR")
+    >>> path = examples.get_path("dicomdir")  # The path to the examples.dicomdir dataset
     >>> ds = dcmread(path)
     >>> fs = FileSet(ds)  # or FileSet(path)
 
@@ -461,7 +460,7 @@ so we don't accidentally modify it:
     >>> from shutil import copytree, copyfile
     >>> t = TemporaryDirectory()
     >>> dst = Path(t.name)
-    >>> src = Path(get_testdata_file("DICOMDIR")).parent
+    >>> src = examples.get_path("dicomdir").parent
     >>> copyfile(src / "DICOMDIR", dst / "DICOMDIR")
     >>> copytree(src / "77654033", dst / "77654033")
     >>> copytree(src / "98892001", dst / "98892001")

--- a/doc/tutorials/index.rst
+++ b/doc/tutorials/index.rst
@@ -11,7 +11,7 @@ New to *pydicom*? Then these tutorials should get you up and running.
 
    installation
    dataset_basics
-   pixel_data/compressing
+   pixel_data/index
    waveforms
    filesets
    sr_basics

--- a/doc/tutorials/pixel_data/compressing.rst
+++ b/doc/tutorials/pixel_data/compressing.rst
@@ -5,9 +5,9 @@
 .. currentmodule:: pydicom
 
 
-In part 1 of this tutorial you learnt how to :doc:`access the pixel data
+In part 1 of this tutorial you learned how to :doc:`access the pixel data
 </tutorials/pixel_data/introduction>` as either the raw :class:`bytes` or a NumPy
-:class:`~numpy.ndarray` and in part 2 you learnt how to :doc:`create new pixel data
+:class:`~numpy.ndarray` and in part 2 you learned how to :doc:`create new pixel data
 </tutorials/pixel_data/creation>` and add it to a :class:`~pydicom.dataset.Dataset`.
 In this final part you'll learn how to compress and decompress datasets containing
 *Pixel Data*.
@@ -18,13 +18,13 @@ Installing using pip:
 
 .. code-block:: bash
 
-    python -m pip install -U pydicom numpy matplotlib pylibjpeg[all] pyjpegls
+    python -m pip install -U pydicom numpy pylibjpeg[all] pyjpegls
 
 Installing on conda:
 
 .. code-block:: bash
 
-    conda install numpy matplotlib
+    conda install numpy
     conda install -c conda-forge pydicom
     pip install pylibjpeg[all] pyjpegls
 
@@ -139,7 +139,7 @@ the plugin name via the `encoding_plugin` argument:
     >>> ds.compress(RLELossless, encoding_plugin='pylibjpeg')
 
 The RLE compression method is well supported by DICOM applications and can
-compress a wide range of images, however it usually less efficient than the JPEG
+compress a wide range of images, however it's usually less efficient than the JPEG
 family of compression schemes. More information on performing compression with
 *RLE Lossless* can be found in the :doc:`RLE encoding guide</guides/encoding/rle_lossless>`.
 
@@ -156,7 +156,7 @@ well supported by third-party applications, so keep that in mind if you decide t
 
 **Lossless compression**
 
-Performing lossless compression is straight-forward::
+Performing lossless compression is straightforward::
 
     >>> from pydicom import examples
     >>> from pydicom.uid import JPEGLSLossless
@@ -238,7 +238,7 @@ order to simplify its usage.
 
 **Lossless compression**
 
-As with RLE and JPEG-LS, performing lossless compression is straight-forward::
+As with RLE and JPEG-LS, performing lossless compression is straightforward::
 
     >>> from pydicom import examples
     >>> from pydicom.uid import JPEG2000Lossless
@@ -419,7 +419,7 @@ to RGB by default. This can be disabled by passing ``as_rgb=False``::
 Conclusion
 ==========
 
-In part 3 of this tutorial you've learnt how to use *pydicom* to compress and decompress
+In part 3 of this tutorial you've learned how to use *pydicom* to compress and decompress
 datasets and how to encapsulate pixel data that has been compressed by third-party
 packages. Having made it to the end of the pixel data tutorial you should now be
 comfortable using *pydicom* to perform pixel data related tasks.

--- a/doc/tutorials/pixel_data/compressing.rst
+++ b/doc/tutorials/pixel_data/compressing.rst
@@ -163,7 +163,7 @@ Performing lossless compression is straight-forward::
     >>> ds = examples.ct
     >>> ds.compress(JPEGLSLossless)
 
-**Lossy compresion**
+**Lossy compression**
 
 Lossy compression is a bit more complicated, especially when the pixel data
 uses signed integers. First up though, we'll use an example with unsigned pixel data.

--- a/doc/tutorials/pixel_data/creation.rst
+++ b/doc/tutorials/pixel_data/creation.rst
@@ -4,7 +4,7 @@
 
 .. currentmodule:: pydicom
 
-In part 1 of this tutorial you learnt how to :doc:`access the pixel data
+In part 1 of this tutorial you learned how to :doc:`access the pixel data
 </tutorials/pixel_data/introduction>` as either the raw :class:`bytes` or a NumPy
 :class:`~numpy.ndarray`. In this part we'll be creating pixel data from
 scratch and adding it to a :class:`~pydicom.dataset.Dataset`. We'll be creating
@@ -325,7 +325,7 @@ The example below demonstrates creating *Float Pixel Data*::
 Conclusion and next steps
 -------------------------
 
-In part 2 of this tutorial you've learnt how to create and add a variety of different pixel
+In part 2 of this tutorial you've learned how to create and add a variety of different pixel
 data to a :class:`~pydicom.dataset.Dataset` using an :class:`~numpy.ndarray`. In the final
 part you'll learn how to :doc:`compress and decompress datasets
 </tutorials/pixel_data/compressing>` containing pixel data.

--- a/doc/tutorials/pixel_data/creation.rst
+++ b/doc/tutorials/pixel_data/creation.rst
@@ -1,0 +1,331 @@
+=============================================
+*Pixel Data* - Part 2: Creation of pixel data
+=============================================
+
+.. currentmodule:: pydicom
+
+In part 1 of this tutorial you learnt how to :doc:`access the pixel data
+</tutorials/pixel_data/introduction>` as either the raw :class:`bytes` or a NumPy
+:class:`~numpy.ndarray`. In this next part we'll be creating pixel data from
+scratch and adding it to a :class:`~pydicom.dataset.Dataset`. We'll be creating
+uncompressed datasets with the following types of *Pixel Data*:
+
+* Grayscale with 8-bit unsigned integers
+* Multi-frame RGB with 8-bit unsigned integers
+* Grayscale with 12-bit signed integers
+* Grayscale with 32-bit floats (for *Float Pixel Data*)
+
+
+**Prerequisites**
+
+Installing using pip:
+
+.. code-block:: bash
+
+    python -m pip install -U pydicom numpy matplotlib pylibjpeg[all]
+
+Installing on conda:
+
+.. code-block:: bash
+
+    conda install numpy matplotlib
+    conda install -c conda-forge pydicom
+    pip install pylibjpeg[all]
+
+
+Creating *Pixel Data*
+---------------------
+
+We'll be using NumPy to create an array containing the pixel data and converting
+it to little-endian ordered :class:`bytes` using :meth:`ndarray.tobytes()
+<numpy.ndarray.tobytes>`. This is the function we'll be using to create the array::
+
+    import numpy as np
+
+    def draw_circle(shape: tuple[int, int], dtype: str, value: int) -> np.ndarray:
+        """Return an ndarray containing a circle."""
+        (rows, columns), radius = shape, min(shape) // 2
+
+        x0, y0 = columns // 2, rows // 2
+        x = np.linspace(0, columns, columns)
+        y = np.linspace(0, rows, rows)[:, None]
+
+        # Create a boolean array where values inside the radius are True
+        arr = (x - x0)**2 + (y - y0)**2 <= radius**2
+
+        # Convert to the required `dtype` and set the maximum `value`
+        return arr.astype(dtype) * value
+
+
+The datasets we'll be creating don't meet the requirements of any DICOM
+:dcm:`IOD<part03/chapter_A.html>` and so aren't conformant DICOM SOP instances, but
+they're sufficient to demonstrate how to create and add pixel data to a
+:class:`~pydicom.dataset.Dataset` using *pydicom*. To create pixel data for an
+actual dataset you should check the requirements of the specific IOD you're working
+with, as many IODs place restrictions on the allowed values for elements such
+as *Bits Stored*, *Photometric Interpretation* and others.
+
+Grayscale with 8-bit unsigned integers
+......................................
+
+The first example uses a single frame of grayscale *Pixel Data* with 8-bit unsigned integers:
+
+* For 8-bit pixel values *Bits Stored* is ``8``
+* *Bits Allocated* must be a multiple of 8 and not less than *Bits Stored*
+* For unsigned integers *Pixel Representation* must be ``0``
+* For 8-bit unsigned integers all pixel values must be in the `closed interval
+  <https://en.wikipedia.org/wiki/Interval_(mathematics)>`_ [0,  2\ :sup:`8` - 1]
+* For pixel data that uses a single sample per pixel, *Samples per Pixel* is ``1``
+* The *Photometric Interpretation* should be appropriate for a single sample per pixel
+* If *Bits Allocated* is <= 8 then *Pixel Data* uses a VR of **OB**
+
+The :dcm:`VR<part05/sect_6.2.html>` for *Pixel Data* may be **OB** or **OW** depending
+on the value of *Bits Allocated*. *pydicom* will set this automatically when
+writing the :class:`~pydicom.dataset.Dataset` to file as long as *Bits Allocated* has
+been set, but for completeness we'll be setting it manually.
+
+The example has two different sets of *Pixel Data*; one with an even number of bytes
+and one with an odd number. The :dcm:`DICOM Standard<part05/chapter_8.html>` requires
+odd length *Pixel Data* have trailing padding sufficient to make it an even length,
+so the latter case demonstrates how to do so.
+
+Because we'll be using NumPy to create the data we need an array with a :class:`~numpy.dtype`
+appropriate for our chosen pixel data properties. For unsigned 8-bit integers
+the obvious choice is ``uint8`` as it can contain the values with the minimum
+amount of memory usage and can be converted directly to a suitable *Pixel Data*
+:class:`bytes` value with :meth:`ndarray.tobytes()<numpy.ndarray.tobytes>`.
+If instead we were to use something like ``uint16`` we would double the memory usage
+and require either setting ``ds.BitsAllocated = 16`` (and roughly doubling the
+final size of the dataset) or keeping *Bits Stored* as ``8`` and stripping out the
+unused bytes with ``ds.PixelData == arr.tobytes()[1::2]``.
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+
+    from pydicom import Dataset, FileMetaDataset
+    from pydicom.uid import ExplicitVRLittleEndian
+
+    ds = Dataset()
+    ds.file_meta = FileMetaDataset()
+    ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+
+    ds.BitsAllocated = 8  # 8-bit containers
+    ds.BitsStored = 8  # 8-bits used
+    ds.HighBit = ds.BitsStored - 1
+    ds.PixelRepresentation = 0  # unsigned
+
+    ds.SamplesPerPixel = 1
+    ds.PhotometricInterpretation = "MONOCHROME2"
+
+    ## Even number of bytes
+    # Create a 480 x 320, 8-bit unsigned array
+    arr = draw_circle((320, 480), "uint8", 255)
+    assert arr.size % 2 == 0
+
+    # No padding needed
+    ds.PixelData = arr.tobytes()
+    ds["PixelData"].VR = "OB"
+    ds.Rows = arr.shape[0]  # 320 pixels
+    ds.Columns = arr.shape[1]  # 480 pixels
+
+    plt.imshow(ds.pixel_array)
+    plt.show()
+
+    ## Odd number of bytes
+    # Create a 31 x 63, 8-bit unsigned array
+    arr = draw_circle((63, 31), "uint8", 255)
+    assert arr.size % 2 == 1
+
+    # Trailing padding required to make the length an even number of bytes
+    ds.PixelData = b"".join((arr.tobytes(), b"\x00"))
+    ds["PixelData"].VR = "OB"
+    ds.Rows = arr.shape[0]
+    ds.Columns = arr.shape[1]
+
+    plt.imshow(ds.pixel_array)
+    plt.show()
+
+
+**Experimentation**
+
+Modify the example to use the following and see what effects they have on the
+displayed images:
+
+* Set *Bits Allocated* and *Bits Stored* to ``16`` and ``ds.Columns = arr.shape[1] // 2``
+* Set ``ds.Rows = arr.shape[1]`` and ``ds.Columns = arr.shape[0]``
+
+
+Multi-frame RGB with 8-bit unsigned integers
+............................................
+
+The second example uses multi-frame RGB *Pixel Data* with 8-bit unsigned integers:
+
+* *Samples per Pixel* has changed to ``3``, because there are 3 channels; R, G and B.
+* *Photometric Interpretation* has changed to ``"RGB"`` to match the image type
+* *Planar Configuration* has been added as it's required when *Samples per Pixel* > 1
+* *Number of Frames* has been added as it's required when there are multiple frames
+
+The *Planar Configuration* value is set as ``0``, which means each pixel is encoded
+separately then all the encoded pixels are concatenated together. This matches how
+:meth:`~numpy.ndarray.tobytes()` will encode an array that's ordered as
+(rows, columns, samples) or (frames, rows, columns, samples) as it is here.
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+
+    from pydicom import Dataset, FileMetaDataset
+    from pydicom.pixels import iter_pixels
+    from pydicom.uid import ExplicitVRLittleEndian
+
+    ds = Dataset()
+    ds.file_meta = FileMetaDataset()
+    ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+
+    ds.BitsAllocated = 8  # 8-bit containers
+    ds.BitsStored = 8  # 8-bits used
+    ds.HighBit = ds.BitsStored - 1
+    ds.PixelRepresentation = 0  # unsigned
+
+    ds.SamplesPerPixel = 3
+    ds.PhotometricInterpretation = "RGB"
+    ds.PlanarConfiguration = 0
+    ds.NumberOfFrames = 2
+
+    # Create 2 frames of 480 x 320 x 3, 8-bit unsigned array
+    arr = np.empty((2, 320, 480, 3), dtype="uint8")
+    # Frame 1
+    arr[0, ..., 0] = draw_circle((320, 480), "uint8", 255)
+    arr[0, ..., 1] = draw_circle((320, 480), "uint8", 127)
+    arr[0, ..., 2] = draw_circle((320, 480), "uint8", 0)
+
+    # Frame 2
+    arr[1, ..., 0] = draw_circle((320, 480), "uint8", 0)
+    arr[1, ..., 1] = draw_circle((320, 480), "uint8", 127)
+    arr[1, ..., 2] = draw_circle((320, 480), "uint8", 255)
+
+    ds.PixelData = b"".join((arr.tobytes(), b"\x00")) if arr.size % 2 else arr.tobytes()
+    ds["PixelData"].VR = "OB"
+    ds.Rows = arr.shape[1]
+    ds.Columns = arr.shape[2]
+
+    # Display the frames
+    im = plt.imshow(np.zeros((ds.Rows, ds.Columns, 3), dtype="uint8"))
+    for frame in iter_pixels(ds):
+        im.set_data(frame)
+        plt.pause(1)
+
+
+**Experimentation**
+
+* A *Planar Configuration* value of ``1`` means each color channel is encoded
+  separately and then the results concatenated together. Try setting
+  ``ds.PlanarConfiguration = 1`` and seeing what effect it has.
+* By default *pydicom* will :doc:`return any extra frames</guides/decoding/decoder_options>`
+  it finds in the *Pixel Data*. Set ``ds.NumberOfFrames = 1`` and see what effect it has,
+  then pass ``allow_excess_frames=False`` to :func:`~pydicom.pixels.iter_pixels` and compare
+  the results.
+
+
+Grayscale with 12-bit signed integers
+.....................................
+
+The final *Pixel Data* example uses a single channel of 12-bit signed integers:
+
+* For 12-bit pixel values *Bits Stored* is ``12`` and *Bits Allocated* should be at least ``16``
+* For signed integers *Pixel Representation* must be ``1``
+* For 12-bit signed integers all pixels must have values in the `closed interval
+  <https://en.wikipedia.org/wiki/Interval_(mathematics)>`_ [-2\ :sup:`11`, 2\ :sup:`11` - 1]
+* If *Bits Allocated* is > 8 then *Pixel Data* uses a VR of **OW**
+
+We need a :class:`~numpy.dtype` sufficient for containing 12-bit integers, so
+to minimize memory usage we'll go with ``int16`` and use a *Bits Allocated* value
+of ``16`` to match.
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+
+    from pydicom import Dataset, FileMetaDataset
+    from pydicom.uid import ExplicitVRLittleEndian
+
+    ds = Dataset()
+    ds.file_meta = FileMetaDataset()
+    ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+
+    ds.BitsAllocated = 16  # 16-bits allocated
+    ds.BitsStored = 12  # 12-bits used; interval is [-2048, 2047]
+    ds.HighBit = ds.BitsStored - 1
+    ds.PixelRepresentation = 1  # signed
+
+    ds.SamplesPerPixel = 1
+    ds.PhotometricInterpretation = "MONOCHROME2"
+
+    # Create a 480 x 320, 16-bit signed array
+    arr = draw_circle((320, 480), "int16", -2048)
+
+    ds.PixelData = arr.tobytes()
+    ds["PixelData"].VR = "OW"
+    ds.Rows = arr.shape[0]
+    ds.Columns = arr.shape[1]
+
+    plt.imshow(ds.pixel_array)
+    plt.show()
+
+
+**Experimentation**
+
+Set *Pixel Representation* to 0 and see what effect it has on the value of the
+pixels in the circle.
+
+
+Creating *Float Pixel Data* and *Double Float Pixel Data*
+---------------------------------------------------------
+
+The creation of *Float Pixel Data* or *Double Float Pixel Data* is very similar to
+that of *Pixel Data*, the main differences being:
+
+* *Bits Allocated* and *Bits Stored* are always 32 for *Float Pixel Data* and 64
+  for *Double Float Pixel Data*
+* The *Pixel Representation* element should not be present
+* The VR doesn't need to be set manually
+
++---------------------------+--------+------------------+---------------+-----------------------+
+| Element                   | VR     | *Bits Allocated* | *Bits Stored* | :class:`~numpy.dtype` |
++===========================+========+==================+===============+=======================+
+| *Float Pixel Data*        | **OF** | 32               | 32            | ``float32``           |
++---------------------------+--------+------------------+---------------+-----------------------+
+| *Double Float Pixel Data* | **OD** | 64               | 64            | ``float64``           |
++---------------------------+--------+------------------+---------------+-----------------------+
+
+The example below demonstrates creating *Float Pixel Data*::
+
+    from pydicom import Dataset, FileMetaDataset
+    from pydicom.uid import ExplicitVRLittleEndian
+
+    ds = Dataset()
+    ds.file_meta = FileMetaDataset()
+    ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+
+    ds.BitsAllocated = 32
+    ds.BitsStored = 32
+    ds.HighBit = ds.BitsStored - 1
+    ds.SamplesPerPixel = 1
+    ds.PhotometricInterpretation = "MONOCHROME2"
+
+    # Create a 480 x 320, 32-bit float array
+    arr = draw_circle((320, 480), "float32", 1024.58)
+
+    ds.FloatPixelData = arr.tobytes()
+    ds.Rows = arr.shape[0]
+    ds.Columns = arr.shape[1]
+
+
+Conclusion and next steps
+-------------------------
+
+In part 2 of this tutorial you've learnt how to create and add a variety of different pixel
+data to a :class:`~pydicom.dataset.Dataset` using an :class:`~numpy.ndarray`. In the final
+part you'll learn how to :doc:`compress and decompress datasets
+</tutorials/pixel_data/compressing>` containing pixel data.

--- a/doc/tutorials/pixel_data/creation.rst
+++ b/doc/tutorials/pixel_data/creation.rst
@@ -6,7 +6,7 @@
 
 In part 1 of this tutorial you learnt how to :doc:`access the pixel data
 </tutorials/pixel_data/introduction>` as either the raw :class:`bytes` or a NumPy
-:class:`~numpy.ndarray`. In this next part we'll be creating pixel data from
+:class:`~numpy.ndarray`. In this part we'll be creating pixel data from
 scratch and adding it to a :class:`~pydicom.dataset.Dataset`. We'll be creating
 uncompressed datasets with the following types of *Pixel Data*:
 
@@ -168,8 +168,8 @@ The second example uses multi-frame RGB *Pixel Data* with 8-bit unsigned integer
 
 The *Planar Configuration* value is set as ``0``, which means each pixel is encoded
 separately then all the encoded pixels are concatenated together. This matches how
-:meth:`~numpy.ndarray.tobytes()` will encode an array that's ordered as
-(rows, columns, samples) or (frames, rows, columns, samples) as it is here.
+:meth:`ndarray.tobytes()<numpy.ndarray.tobytes>` will encode an array that's ordered as
+(rows, columns, samples) or (frames, rows, columns, samples).
 
 .. code-block:: python
 

--- a/doc/tutorials/pixel_data/index.rst
+++ b/doc/tutorials/pixel_data/index.rst
@@ -1,0 +1,11 @@
+
+============
+*Pixel Data*
+============
+
+.. toctree::
+   :maxdepth: 1
+
+   introduction
+   creation
+   compressing

--- a/doc/tutorials/pixel_data/introduction.rst
+++ b/doc/tutorials/pixel_data/introduction.rst
@@ -81,6 +81,14 @@ Other things to keep in mind with compressed transfer syntaxes are:
 * The compressed frames are then :func:`encapsulated<pydicom.encaps.encapsulate>`
   and the encapsulated data used to set the *Pixel Data* value
 
+To access the encapsulated frames you can use :func:`~pydicom.encaps.get_frame`
+or the :func:`~pydicom.encaps.generate_frames` iterator::
+
+    >>> from pydicom.encaps import get_frame
+    >>> frame = get_frame(ds.PixelData, 0, number_of_frames=1)
+    >>> print(len(frame))
+    152294
+
 The next example uses an uncompressed *Transfer Syntax UID*::
 
     >>> ds = examples.ct
@@ -383,7 +391,7 @@ describing the corresponding :class:`~numpy.ndarray`.
 
 This is especially useful for non-conformant datasets where the :dcm:`Image Pixel
 <part03/sect_C.7.6.3.html>` module elements have values that don't match the
-actual pixel data (especially for *Number of Frames* and *Photometric Interpretation*).
+actual pixel data (such as *Number of Frames* or *Photometric Interpretation*).
 
 
 Conclusion and next steps

--- a/doc/tutorials/pixel_data/introduction.rst
+++ b/doc/tutorials/pixel_data/introduction.rst
@@ -1,0 +1,395 @@
+=================================================
+*Pixel Data* - Part 1: Introduction and accessing
+=================================================
+
+.. currentmodule:: pydicom
+
+This is part 1 of the tutorial on using *pydicom* with DICOM *Pixel Data*. It covers:
+
+* An introduction to DICOM pixel data
+* Converting pixel data to a NumPy :class:`~numpy.ndarray`
+* Customizing the conversion process
+
+It's assumed that you're already familiar with the :doc:`dataset basics
+<../dataset_basics>`.
+
+
+**Prerequisites**
+
+Installing using pip:
+
+.. code-block:: bash
+
+    python -m pip install -U pydicom numpy matplotlib pylibjpeg[all]
+
+Installing on conda:
+
+.. code-block:: bash
+
+    conda install numpy matplotlib
+    conda install -c conda-forge pydicom
+    pip install pylibjpeg[all]
+
+
+Introduction
+------------
+
+Many DICOM SOP classes contain bulk pixel data, which typically represents medical
+imagery or 2D slices of a 3D volume. This data is most commonly found in
+the *Pixel Data* element, however it may be in *Float Pixel Data* or *Double Float
+Pixel Data* instead, depending on the SOP class. The table below lists these
+possible pixel data containing elements, although it's important to note that
+only one may be present in any given dataset.
+
++-------------+---------------------+----------------------+------------------+
+| Tag         | Description         | Keyword              | VR               |
++=============+=====================+======================+==================+
+| (7FE0,0008) | *Float Pixel Data*  | FloatPixelData       | **OF**           |
++-------------+---------------------+----------------------+------------------+
+| (7FE0,0009) | *Double Pixel Data* | DoubleFloatPixelData | **OD**           |
++-------------+---------------------+----------------------+------------------+
+| (7FE0,0010) | *Pixel Data*        | PixelData            | **OB** or **OW** |
++-------------+---------------------+----------------------+------------------+
+
+All three elements use **O*** :dcm:`VRs<part05/sect_6.2.html>` (such as **OB** and
+**OD**), which in *pydicom* are :doc:`stored as</guides/element_value_types>`
+(and should be set using) :class:`bytes`::
+
+    >>> from pydicom import examples
+    >>> ds = examples.jpeg2k
+    >>> ds.group_dataset(0x7FE0)
+    (7FE0,0010) Pixel Data                          OB: Array of 152326 elements
+    >>> ds.PixelData[:50] # doctest: +ELLIPSIS
+    b'\xfe\xff\x00\xe0\x00\x00\x00\x00\xfe\xff\x00\xe0\x00\x00\x01\x00\xffO\xffQ...
+
+If the dataset's been written using the :dcm:`DICOM File Format<part10/chapter_7.html>`
+it should have a *Transfer Syntax UID* element which describes how the pixel data
+is encoded and whether it's undergone compression::
+
+    >>> tsyntax = ds.file_meta.TransferSyntaxUID
+    >>> tsyntax.name
+    'JPEG 2000 Image Compression (Lossless Only)'
+    >>> tsyntax.is_compressed
+    True
+
+In the example above the *Transfer Syntax UID* indicates that the pixel data has
+been compressed using the :dcm:`JPEG 2000 <part05/sect_A.4.4.html>` compression method.
+Other things to keep in mind with compressed transfer syntaxes are:
+
+* Only datasets that use the *Pixel Data* element may be compressed
+* Each frame of pixel data is compressed separately
+* The compressed frames are then :func:`encapsulated<pydicom.encaps.encapsulate>`
+  and the encapsulated data used to set the *Pixel Data* value
+
+The next example uses an uncompressed *Transfer Syntax UID*::
+
+    >>> ds = examples.ct
+    >>> tsyntax = ds.file_meta.TransferSyntaxUID
+    >>> tsyntax.name
+    'Explicit VR Little Endian'
+    >>> tsyntax.is_compressed
+    False
+
+The pixel data in this dataset uses `little-endian byte ordering
+<https://en.wikipedia.org/wiki/Endianness>`_ and is uncompressed. Uncompressed
+transfer syntaxes never use encapsulation and may use any one of the
+three pixel data elements, although *Pixel Data* is the most common.
+
+A dataset with pixel data should always contain group ``0x0028`` :dcm:`Image Pixel
+<part03/sect_C.7.6.3.html>` module elements, which are needed to properly interpret
+the encoded pixel data byte stream::
+
+    >>> ds.group_dataset(0x0028)
+    (0028,0002) Samples per Pixel                   US: 1
+    (0028,0004) Photometric Interpretation          CS: 'MONOCHROME2'
+    (0028,0010) Rows                                US: 128
+    (0028,0011) Columns                             US: 128
+    (0028,0030) Pixel Spacing                       DS: [0.661468, 0.661468]
+    (0028,0100) Bits Allocated                      US: 16
+    (0028,0101) Bits Stored                         US: 16
+    (0028,0102) High Bit                            US: 15
+    (0028,0103) Pixel Representation                US: 1
+    ...
+
+An explanation of what these elements represent can be found in the
+:doc:`glossary</guides/glossary>`, but briefly, the above indicates that this
+dataset contains a single grayscale image with dimensions 128 x 128 and that each
+pixel should be interpreted as a 2-byte signed integer.
+
+
+Converting to an :class:`~numpy.ndarray`
+----------------------------------------
+
+Properly interpreting all the possible variations of a dataset's pixel data requires
+a lot of specific domain knowledge, not just of DICOM but also the various
+JPEG compression schemes. For this reason *pydicom* offers a number of methods
+for converting the pixel data to a NumPy :class:`~numpy.ndarray`, the most high-level
+of which are the :func:`~pydicom.pixels.pixel_array` and :func:`~pydicom.pixels.iter_pixels`
+functions::
+
+    import matplotlib.pyplot as plt
+
+    from pydicom import examples
+    from pydicom.pixels import pixel_array
+
+    # Get an example dataset as a FileDataset instance
+    ds = examples.ct
+
+    # Convert the pixel data to an ndarray
+    arr = pixel_array(ds)
+    assert arr.shape == (128, 128)
+    assert str(arr.dtype) == "int16"
+
+    # Display the pixel data using matplotlib
+    plt.imshow(arr, cmap="gray")
+    plt.show()
+
+This will convert the entire pixel data to an :class:`~numpy.ndarray` before using
+`matplotlib <https://matplotlib.org/>`_ to display it. If the dataset has multiple
+frames but you're only interested in a particular one, then you can use the `index` parameter
+to return it::
+
+    from pydicom import examples
+    from pydicom.pixels import pixel_array
+
+    # Get an example multi-frame dataset
+    ds = examples.rt_dose
+    assert ds.NumberOfFrames == '15'
+
+    # Return all frames
+    arr = pixel_array(ds)
+    assert arr.shape == (15, 10, 10)
+
+    # Return only the first frame
+    arr = pixel_array(ds, index=0)
+    assert arr.shape == (10, 10)
+
+:func:`~pydicom.pixels.iter_pixels` can be used to iterate through either all
+the available frames or those specified by the `indices` parameter::
+
+    from pydicom import examples
+    from pydicom.pixels import iter_pixels
+
+    # Iterate through all frames
+    for arr in iter_pixels(examples.rt_dose):
+        assert arr.shape == (10, 10)
+
+    # Iterate through the first 3 even frames
+    for arr in iter_pixels(examples.rt_dose, indices=[1, 3, 5]):
+        assert arr.shape == (10, 10)
+
+Controlling decoding
+....................
+
+The default decoding options for :func:`~pydicom.pixels.pixel_array` and
+:func:`~pydicom.pixels.iter_pixels` have been chosen to return the pixel data in
+its most commonly used form; for multi-sample data this means RGB is returned
+by default. Datasets with pixel data in `YCbCr <https://en.wikipedia.org/wiki/YCbCr>`_
+color space are converted using :func:`~pydicom.pixels.convert_color_space` prior
+to the array being returned. If you'd like to skip this conversion and return the
+data as found in the dataset you can pass ``raw=True``::
+
+    import matplotlib.pyplot as plt
+
+    from pydicom import examples
+    from pydicom.pixels import pixel_array
+
+    ds = examples.ybr_color
+    assert ds.PhotometricInterpretation == "YBR_FULL_422"
+
+    ybr = pixel_array(ds, index=0, raw=True)
+    rgb = pixel_array(ds, index=0)
+
+    fig, (im1, im2) = plt.subplots(1, 2)
+    im1.imshow(ybr)
+    im1.set_title("Original (in YCbCr)")
+    im2.imshow(rgb)
+    im2.set_title("Converted (in RGB)")
+    plt.show()
+
+Further customization of the returned :class:`~numpy.ndarray` is possible by
+passing one or more :doc:`decoding options</guides/decoding/decoder_options>` to
+:func:`~pydicom.pixels.pixel_array` and :func:`~pydicom.pixels.iter_pixels`.
+
+
+Compressed transfer syntaxes
+............................
+
+When converting datasets with a compressed transfer syntax, one or more additional
+packages are needed to perform the actual decompression (via their corresponding decoding
+plugins). By default, all available plugins will be tried and the first successful
+one will have its results returned::
+
+    from pydicom import examples
+    from pydicom.pixels import pixel_array
+
+    ds = examples.jpeg2k
+
+    # Returns the results from the first successful decoding plugin
+    arr = pixel_array(ds)
+
+If no plugins are available for the given transfer syntax due to missing dependencies
+you'll get an exception:
+
+.. code-block:: pytb
+
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File ".../pydicom/pixels/utils.py", line 1386, in pixel_array
+        return decoder.as_array(
+               ^^^^^^^^^^^^^^^^^
+      File ".../pydicom/pixels/decoders/base.py", line 971, in as_array
+        self._validate_plugins(decoding_plugin),
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      File ".../pydicom/pixels/common.py", line 249, in _validate_plugins
+        raise RuntimeError(
+    RuntimeError: Unable to decompress 'JPEG 2000 Image Compression (Lossless Only)' pixel data because all plugins are missing dependencies:
+    	gdcm - requires gdcm>=3.0.10
+    	pylibjpeg - requires pylibjpeg>=2.0 and pylibjpeg-openjpeg>=2.0
+    	pillow - requires numpy and pillow>=10.0
+
+While the resulting :class:`~numpy.ndarray` for lossless compression methods should
+be identical no matter which plugin is used, there may be slight differences for lossy
+compression methods. To ensure consistency you can use the `decoding_plugin` argument
+to use the specified :doc:`decompression plugin</guides/plugin_table>`::
+
+    from pydicom import examples
+    from pydicom.pixels import pixel_array
+
+    ds = examples.jpeg2k
+
+    # Return the results from the 'pylibjpeg' decoding plugin
+    arr = pixel_array(ds, decoding_plugin="pylibjpeg")
+
+And of course if the specified plugin isn't available you'll get an exception::
+
+    >>> from pydicom import examples
+    >>> from pydicom.pixels import pixel_array
+    >>> pixel_array(examples.jpeg2k, decoding_plugin="pillow")
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File ".../pydicom/pixels/utils.py", line 1386, in pixel_array
+        return decoder.as_array(
+               ^^^^^^^^^^^^^^^^^
+      File ".../pydicom/pixels/decoders/base.py", line 971, in as_array
+        self._validate_plugins(decoding_plugin),
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      File ".../pydicom/pixels/common.py", line 230, in _validate_plugins
+        raise RuntimeError(
+    RuntimeError: Unable to decompress 'JPEG 2000 Image Compression (Lossless Only)' pixel data because the specified plugin is missing dependencies:
+        pillow - requires numpy and pillow>=10.0
+
+
+Minimizing memory usage
+.......................
+
+Sometimes a dataset's pixel data may be very large due to it having a large number
+of frames and you'd like to avoid having the entire thing read into memory.
+By passing the path to the dataset (as :class:`str` or :class:`pathlib.Path`) to
+:func:`~pydicom.pixels.pixel_array` only the :dcm:`Image Pixel
+<part03/sect_C.7.6.3.html>` module elements and the minimum amount of required
+pixel data will be loaded::
+
+    from pydicom import examples
+    from pydicom.pixels import pixel_array
+
+    # Get the path to the 'examples.rt_dose' dataset
+    path = examples.get_path("rt_dose")
+
+    # Return the first frame of the pixel data
+    arr = pixel_array(path, index=0)
+
+The same is true for :func:`~pydicom.pixels.iter_pixels`::
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    from pydicom import examples
+    from pydicom.pixels import iter_pixels
+
+    # Get the path to the 'examples.ybr_color' dataset
+    path = examples.get_path("ybr_color")
+
+    # Create an empty ndarray and use it to initialize the display
+    im = plt.imshow(np.zeros((ds.Rows, ds.Columns), dtype="u1"))
+
+    # Iterate through the frames and update the display
+    for frame in iter_pixels(path):
+        im.set_data(frame)
+        plt.pause(0.033)
+
+If you're supplying a path to :func:`~pydicom.pixels.pixel_array`
+or :func:`~pydicom.pixels.iter_pixels` and you need access to the :dcm:`Image Pixel
+<part03/sect_C.7.6.3.html>` elements to perform image processing operations on
+the array (such as :func:`rescale<pydicom.pixels.apply_rescale>` or
+:func:`windowing<pydicom.pixels.apply_windowing>`) you can access them by passing
+an empty :class:`~pydicom.dataset.Dataset` instance via the `ds_out` argument,
+or alternatively by using :func:`~pydicom.filereader.dcmread` with
+``stop_before_pixels=True``::
+
+    from pydicom import Dataset, examples
+    from pydicom.pixels import pixel_array, apply_rescale
+
+    # Get the path to the 'examples.ct' dataset
+    path = examples.get_path("ct")
+
+    ds = Dataset()
+    arr = pixel_array(path, ds_out=ds)
+
+    assert ds.RescaleIntercept == "-1024.0"
+    assert ds.RescaleSlope == "1.0"
+
+    # Convert raw CT values to Hounsfield units
+    hu = apply_rescale(arr, ds)
+
+
+Converting to an :class:`~numpy.ndarray` with metadata
+------------------------------------------------------
+
+While :func:`~pydicom.pixels.pixel_array` and :func:`~pydicom.pixels.iter_pixels`
+should cover most use cases, you may want more information about the returned
+:class:`~numpy.ndarray`, such as what color space it's in. The :meth:`Decoder.as_array()
+<pydicom.pixels.decoders.base.Decoder.as_array>` and :meth:`Decoder.iter_array()
+<pydicom.pixels.decoders.base.Decoder.iter_array>` methods provide mid-level access
+to *pydicom's* pixel data decoding functionality while still handling most of the complexity
+of conversion to an array. More importantly, they return or yield a tuple of
+(:class:`~numpy.ndarray`, :class:`dict`), where the :class:`dict` contains metadata
+describing the corresponding :class:`~numpy.ndarray`.
+
+.. warning::
+
+    The :class:`~pydicom.pixels.decoders.base.Decoder` class should not be used
+    directly, instead use the class instance returned by :func:`~pydicom.pixels.get_decoder`.
+
+.. code-block:: python
+
+    from pydicom import examples
+    from pydicom.pixels import get_decoder
+
+    ds = examples.ybr_color
+    assert ds.PhotometricInterpretation == "YBR_FULL_422"
+
+    # Get the 'Decoder' instance required to decode the dataset's pixel data
+    decoder = get_decoder(ds.file_meta.TransferSyntaxUID)
+
+    # Converts the pixel data to an ndarray in the original color space
+    arr, meta = decoder.as_array(ds, raw=True, index=0)
+    assert (meta["rows"], meta["columns"], meta["samples_per_pixel"]) == arr.shape
+    assert meta["photometric_interpretation"] == "YBR_FULL_422"
+
+    # Converts the pixel data to an ndarray in RGB color space
+    arr, meta = decoder.as_array(ds, index=0)
+    assert meta["photometric_interpretation"] == "RGB"
+
+This is especially useful for non-conformant datasets where the :dcm:`Image Pixel
+<part03/sect_C.7.6.3.html>` module elements have values that don't match the
+actual pixel data (especially for *Number of Frames* and *Photometric Interpretation*).
+
+
+Conclusion and next steps
+-------------------------
+
+In part 1 of this tutorial you've been introduced to DICOM's pixel data and learnt how to
+use *pydicom* to access it, convert it to an :class:`~numpy.ndarray` and how to
+control the conversion process. In the next part you'll learn how to
+:doc:`create your own pixel data from scratch</tutorials/pixel_data/creation>`.

--- a/doc/tutorials/pixel_data/introduction.rst
+++ b/doc/tutorials/pixel_data/introduction.rst
@@ -397,7 +397,7 @@ actual pixel data (such as *Number of Frames* or *Photometric Interpretation*).
 Conclusion and next steps
 -------------------------
 
-In part 1 of this tutorial you've been introduced to DICOM's pixel data and learnt how to
+In part 1 of this tutorial you've been introduced to DICOM's pixel data and learned how to
 use *pydicom* to access it, convert it to an :class:`~numpy.ndarray` and how to
 control the conversion process. In the next part you'll learn how to
 :doc:`create your own pixel data from scratch</tutorials/pixel_data/creation>`.

--- a/src/pydicom/__init__.py
+++ b/src/pydicom/__init__.py
@@ -29,7 +29,7 @@ Quick Start
 """
 
 from pydicom.dataelem import DataElement
-from pydicom.dataset import Dataset, FileDataset
+from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
 import pydicom.examples
 from pydicom.filereader import dcmread
 from pydicom.filewriter import dcmwrite
@@ -42,6 +42,7 @@ __all__ = [
     "DataElement",
     "Dataset",
     "FileDataset",
+    "FileMetaDataset",
     "Sequence",
     "dcmread",
     "dcmwrite",

--- a/src/pydicom/encaps.py
+++ b/src/pydicom/encaps.py
@@ -221,9 +221,8 @@ def generate_fragmented_frames(
         ``seek()`` methods. If the latter then the final position depends on
         how many fragmented frames have been yielded.
     number_of_frames : int, optional
-        Required for multi-frame data when the Basic Offset Table is empty,
-        the Extended Offset Table has not been supplied and there are
-        multiple frames. This should be the value of (0028,0008) *Number of
+        Required when the Basic Offset Table is empty and the Extended Offset Table
+        has not been supplied. This should be the value of (0028,0008) *Number of
         Frames* or the expected number of frames in the encapsulated data.
     extended_offsets : tuple[list[int], list[int]] or tuple[bytes, bytes], optional
         The (offsets, lengths) of the Extended Offset Table as taken from
@@ -413,10 +412,9 @@ def generate_frames(
         ``seek()`` methods. If the latter then the final offset position depends
         on the number of yielded frames.
     number_of_frames : int, optional
-        Required for multi-frame data when the Basic Offset Table is empty,
-        the Extended Offset Table has not been supplied and there are
-        multiple frames. This should be the value of (0028,0008) *Number of
-        Frames* or the expected number of frames in the encapsulated data.
+        Required when the Basic Offset Table is empty and the Extended Offset
+        Table has not been supplied. This should be the value of (0028,0008) *Number
+        of Frames* or the expected number of frames in the encapsulated data.
     extended_offsets : tuple[list[int], list[int]] or tuple[bytes, bytes], optional
         The (offsets, lengths) of the Extended Offset Table as taken from
         (7FE0,0001) *Extended Offset Table* and (7FE0,0002) *Extended Offset

--- a/src/pydicom/examples/__init__.py
+++ b/src/pydicom/examples/__init__.py
@@ -1,6 +1,7 @@
 """Module to support importing the datasets used by the documentation."""
 
 from typing import Any, cast
+from pathlib import Path
 
 from pydicom.data import get_testdata_file
 from pydicom.filereader import dcmread
@@ -23,9 +24,22 @@ _DATASETS: dict[str, str] = {
 }
 
 
+def _get_path(name: str) -> Path:
+    """Return the path to the example dataset with the attribute name `name` as
+    :class:`pathlib.Path`.
+    """
+    if name in _DATASETS:
+        return Path(_DATASETS[name])
+
+    raise ValueError(f"No example dataset exists with the name '{name}'")
+
+
 def __getattr__(name: str) -> Any:
     """Return module level attributes."""
     if name in _DATASETS:
         return dcmread(_DATASETS[name], force=True)
+
+    if name == "get_path":
+        return _get_path
 
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/src/pydicom/pixels/__init__.py
+++ b/src/pydicom/pixels/__init__.py
@@ -5,6 +5,7 @@ from pydicom.pixels.encoders.base import get_encoder
 from pydicom.pixels.processing import (
     apply_color_lut,
     apply_modality_lut,
+    apply_rescale,
     apply_voi_lut,
     apply_voi,
     apply_windowing,

--- a/src/pydicom/pixels/processing.py
+++ b/src/pydicom/pixels/processing.py
@@ -646,7 +646,7 @@ def convert_color_space(
     -------
     numpy.ndarray
         The image(s) converted to the desired color space. If `per_frame` is
-        ``False`` (the default) then a new :class:``~numpy.ndarray` will be
+        ``False`` (the default) then a new :class:`~numpy.ndarray` will be
         returned, otherwise `arr` will be updated in-place.
 
     References

--- a/tests/pixels/test_common.py
+++ b/tests/pixels/test_common.py
@@ -581,7 +581,10 @@ class TestCoderBase:
         assert coder._validate_plugins() == {}
 
         coder = CoderBase(RLELossless, decoder=True)
-        msg = "Unable to decode because all plugins are missing dependencies:"
+        msg = (
+            "Unable to decompress 'RLE Lossless' pixel data because all plugins "
+            "are missing dependencies:"
+        )
         with pytest.raises(RuntimeError, match=msg):
             coder._validate_plugins()
 
@@ -596,8 +599,8 @@ class TestCoderBase:
         coder._available = {}
         coder._unavailable["foo"] = ("numpy", "pylibjpeg", "gdcm")
         msg = (
-            "Unable to use the 'foo' plugin because it's missing "
-            "dependencies - requires numpy, pylibjpeg and gdcm"
+            "Unable to decompress 'RLE Lossless' pixel data because the specified "
+            "plugin is missing dependencies:\n\tfoo - requires numpy, pylibjpeg and gdcm"
         )
         with pytest.raises(RuntimeError, match=msg):
             coder._validate_plugins("foo")

--- a/tests/pixels/test_decoder_pylibjpeg.py
+++ b/tests/pixels/test_decoder_pylibjpeg.py
@@ -259,6 +259,16 @@ class TestLibJpegDecoder:
                 arr, as_rgb=True, plugin="pylibjpeg", index=index
             )
 
+    def test_iter_planar_configuration(self):
+        """Test iter_pixels() with planar configuration."""
+        ds = dcmread(JPGB_08_08_3_0_120F_YBR_FULL_422.path)
+        decoder = get_decoder(ds.file_meta.TransferSyntaxUID)
+        ds.PlanarConfiguration = 1
+
+        # Always 0 when converting to an ndarray
+        for _, meta in decoder.iter_array(ds, decoding_plugin="pylibjpeg"):
+            assert meta["planar_configuration"] == 0
+
 
 @pytest.mark.skipif(SKIP_OJ, reason="Test is missing dependencies")
 class TestOpenJpegDecoder:

--- a/tests/pixels/test_encoder_base.py
+++ b/tests/pixels/test_encoder_base.py
@@ -1423,7 +1423,7 @@ class TestEncodeRunner_Encode:
         assert enc.is_available
         msg = (
             "Unable to compress the pixel data using 'RLE Lossless' because the "
-            "specified plugin is missing dependencies\n\tpylibjpeg - requires numpy, "
+            "specified plugin is missing dependencies:\n\tpylibjpeg - requires numpy, "
             "pylibjpeg>=2.0 and pylibjpeg-rle>=2.0"
         )
         with pytest.raises(RuntimeError, match=msg):

--- a/tests/pixels/test_encoder_base.py
+++ b/tests/pixels/test_encoder_base.py
@@ -1422,9 +1422,9 @@ class TestEncodeRunner_Encode:
         enc = RLELosslessEncoder
         assert enc.is_available
         msg = (
-            "Unable to use the 'pylibjpeg' plugin because it's missing "
-            "dependencies - requires numpy, pylibjpeg>=2.0 and "
-            "pylibjpeg-rle>=2.0"
+            "Unable to compress the pixel data using 'RLE Lossless' because the "
+            "specified plugin is missing dependencies\n\tpylibjpeg - requires numpy, "
+            "pylibjpeg>=2.0 and pylibjpeg-rle>=2.0"
         )
         with pytest.raises(RuntimeError, match=msg):
             enc.encode(EXPL_16_16_1F.ds, encoding_plugin="pylibjpeg")

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -1449,6 +1449,7 @@ class TestCompressRLE:
         with pytest.raises(AttributeError, match=msg):
             compress(ds, RLELossless, encoding_plugin="pydicom")
 
+    @pytest.mark.skipif(not HAVE_NP, reason="Numpy not available")
     def test_already_compressed(self):
         """Test compressing an already compressed dataset."""
         ds = dcmread(RLE_8_3_1F.path)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,7 @@
 """Tests for the examples module."""
 
+from pathlib import Path
+
 import pytest
 
 import pydicom
@@ -40,3 +42,13 @@ class TestExamples:
         assert ct is ct  # noqa
         assert isinstance(ct, FileDataset)
         assert ct.PatientName == "CompressedSamples^CT1"
+
+    def test_get_path(self):
+        """Test get_path()"""
+        path = examples.get_path("ct")
+        assert isinstance(path, Path)
+        assert path.name == "CT_small.dcm"
+
+        msg = "No example dataset exists with the name 'foo'"
+        with pytest.raises(ValueError, match=msg):
+            examples.get_path("foo")


### PR DESCRIPTION
#### Describe the changes
* Adds pixel data tutorial
* Adds `examples.get_path()` and updates documentation to use it instead of `get_testdata_path()`
* Various small user improvements, mostly better exception messages
* Fixes planar configuration not being set properly with `Decoder.iter_pixels()`
* Adds a check of dataset compression state to `decompress()`

Closes #2031

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] [Documentation updated](https://output.circle-artifacts.com/output/job/c78281b4-e177-4fc4-8b0f-1d7c7622fbcc/artifacts/0/doc/_build/html/index.html) (if relevant)
- [x] Unit tests passing and overall coverage the same or better
