### PR TITLE
[MRG] Account for JP2 header if present

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -203,6 +203,8 @@ Enhancements
   <pydicom.dataset.Dataset.pixel_array>` with the new :mod:`~pydicom.pixels` backend.
 * Improve support for reading and resolving inline binary data with `VR=UN` from Json
   (:issue:`2062`).
+* :func:`~pydicom.pixels.utils.get_j2k_parameters` now takes into account the JP2 header
+  (if present, although it's non-conformant for it to be) (:issue:`2073`)
 
 Fixes
 -----

--- a/src/pydicom/pixels/decoders/pillow.py
+++ b/src/pydicom/pixels/decoders/pillow.py
@@ -81,7 +81,6 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytes:
     # The precision from the J2K codestream is more appropriate because the
     #   decoder will use it to create the output integers
     precision = runner.get_option("j2k_precision", runner.bits_stored)
-    print(precision)
     # pillow's pixel container size is based on precision
     if 0 < precision <= 8:
         runner.set_option("bits_allocated", 8)

--- a/src/pydicom/pixels/decoders/pillow.py
+++ b/src/pydicom/pixels/decoders/pillow.py
@@ -81,6 +81,7 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytes:
     # The precision from the J2K codestream is more appropriate because the
     #   decoder will use it to create the output integers
     precision = runner.get_option("j2k_precision", runner.bits_stored)
+    print(precision)
     # pillow's pixel container size is based on precision
     if 0 < precision <= 8:
         runner.set_option("bits_allocated", 8)

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -778,7 +778,7 @@ def get_image_pixel_ids(ds: "Dataset") -> dict[str, int]:
     return {kw: id(getattr(ds, kw, None)) for kw in keywords}
 
 
-def get_j2k_parameters(codestream: bytes) -> dict[str, object]:
+def get_j2k_parameters(codestream: bytes) -> dict[str, Any]:
     """Return a dict containing JPEG 2000 component parameters.
 
     .. versionadded:: 2.1
@@ -796,7 +796,7 @@ def get_j2k_parameters(codestream: bytes) -> dict[str, object]:
         Available parameters are ``{"precision": int, "is_signed": bool}``.
     """
     offset = 0
-    info = {"jp2": False}
+    info: dict[str, Any] = {"jp2": False}
 
     # Account for the JP2 header (if present)
     # The first box is always 12 bytes long

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -806,8 +806,8 @@ def get_j2k_parameters(codestream: bytes) -> dict[str, object]:
         offset = 12
         # Iterate through the boxes, looking for the jp2c box
         while offset < total_length:
-            length = int.from_bytes(codestream[offset:offset + 4], byteorder="big")
-            if codestream[offset + 4:offset + 8] == b"\x6A\x70\x32\x63":
+            length = int.from_bytes(codestream[offset : offset + 4], byteorder="big")
+            if codestream[offset + 4 : offset + 8] == b"\x6A\x70\x32\x63":
                 # The offset to the start of the J2K codestream
                 offset += 8
                 break
@@ -816,11 +816,11 @@ def get_j2k_parameters(codestream: bytes) -> dict[str, object]:
 
     try:
         # First 2 bytes must be the SOC marker - if not then wrong format
-        if codestream[offset: offset + 2] != b"\xff\x4f":
+        if codestream[offset : offset + 2] != b"\xff\x4f":
             return {}
 
         # SIZ is required to be the second marker - Figure A-3 in 15444-1
-        if codestream[offset + 2:offset + 4] != b"\xff\x51":
+        if codestream[offset + 2 : offset + 4] != b"\xff\x51":
             return {}
 
         # See 15444-1 A.5.1 for format of the SIZ box and contents

--- a/tests/pixels/test_decoder_pillow.py
+++ b/tests/pixels/test_decoder_pillow.py
@@ -158,7 +158,11 @@ class TestOpenJpegDecoder:
     def test_u4_raises(self):
         """Test decoding greyscale with bits stored > 16 raises exception."""
         decoder = get_decoder(JPEG2000Lossless)
-        ds = J2KR_08_08_3_0_1F_YBR_RCT.ds
+        ds = dcmread(J2KR_08_08_3_0_1F_YBR_RCT.path)
+        # Manually edit the precision in the J2K codestream
+        data = bytearray(ds.PixelData)
+        data[1716:1717] = b"\x10"
+        ds.PixelData = bytes(data)
 
         msg = (
             "Unable to decode as exceptions were raised by all available plugins:\n"
@@ -166,9 +170,7 @@ class TestOpenJpegDecoder:
             "to 16 are supported"
         )
         with pytest.raises(RuntimeError, match=msg):
-            decoder.as_array(
-                ds, decoding_plugin="pillow", bits_stored=17, bits_allocated=32
-            )
+            decoder.as_array(ds, decoding_plugin="pillow")
 
     def test_multisample_16bit_raises(self):
         """Test that > 8-bit RGB datasets raise exception"""

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -1181,12 +1181,14 @@ class TestGetJ2KParameters:
             params = get_j2k_parameters(base + bytes([ii]))
             assert ii - 127 == params["precision"]
             assert params["is_signed"]
+            assert params["jp2"] is False
 
         # Unsigned
         for ii in range(7, 16):
             params = get_j2k_parameters(base + bytes([ii]))
             assert ii + 1 == params["precision"]
             assert not params["is_signed"]
+            assert params["jp2"] is False
 
     def test_not_j2k(self):
         """Test result when no JPEG2K SOF marker present"""
@@ -1206,16 +1208,10 @@ class TestGetJ2KParameters:
     def test_jp2(self):
         """Test result when JP2 file format is used."""
         ds = J2KR_08_08_3_0_1F_YBR_RCT.ds
-
-        msg = (
-            "The JPEG 2000 encoded pixel data uses a JP2 file format header, which "
-            "is non-conformant. See Annex A.4.4 in Part 5 of the DICOM Standard."
-        )
-        with pytest.warns(UserWarning, match=msg):
-            info = get_j2k_parameters(get_frame(ds.PixelData, 0))
-
+        info = get_j2k_parameters(get_frame(ds.PixelData, 0))
         assert info["precision"] == 8
         assert info["is_signed"] is False
+        assert info["jp2"] is True
 
 
 class TestGetNrFrames:

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -1203,6 +1203,20 @@ class TestGetJ2KParameters:
         assert {} == get_j2k_parameters(b"")
         assert {} == get_j2k_parameters(b"\xff\x4f\xff\x51" + b"\x00" * 20)
 
+    def test_jp2(self):
+        """Test result when JP2 file format is used."""
+        ds = J2KR_08_08_3_0_1F_YBR_RCT.ds
+
+        msg = (
+            "The JPEG 2000 encoded pixel data uses a JP2 file format header, which "
+            "is non-conformant. See Annex A.4.4 in Part 5 of the DICOM Standard."
+        )
+        with pytest.warns(UserWarning, match=msg):
+            info = get_j2k_parameters(get_frame(ds.PixelData, 0))
+
+        assert info["precision"] == 8
+        assert info["is_signed"] is False
+
 
 class TestGetNrFrames:
     """Tests for get_nr_frames()."""


### PR DESCRIPTION
#### Describe the changes
* Accounts for a non-conformant JP2 header when decoding JPEG 2000

Closes #2073

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/8368c399-3c06-4707-a16d-094ee1d6b5e4/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
