### PR TITLE
[MRG] Improve performance for non-default encoding

### DIFF
--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -1487,7 +1487,7 @@ class Dataset:
         for tag in taglist:
             yield self[tag]
 
-    def elements(self) -> Iterator[DataElement]:
+    def elements(self) -> Iterator[DataElement | RawDataElement]:
         """Yield the top-level elements of the :class:`Dataset`.
 
         Examples

--- a/src/pydicom/filereader.py
+++ b/src/pydicom/filereader.py
@@ -489,7 +489,7 @@ def read_dataset(
     except NotImplementedError as details:
         logger.error(details)
 
-    ds = Dataset(raw_data_elements)
+    ds = Dataset(raw_data_elements, parent_encoding=parent_encoding)
 
     encoding: str | MutableSequence[str]
     if 0x00080005 in raw_data_elements:
@@ -674,6 +674,9 @@ def _read_file_meta_info(fp: BinaryIO) -> FileMetaDataset:
             fp, is_implicit_VR=False, is_little_endian=True, stop_when=_not_group_0002
         )
     )
+    file_meta.set_original_encoding(
+        is_implicit_vr=False, is_little_endian=True, character_encoding=default_encoding
+    )
     if not file_meta._dict:
         return file_meta
 
@@ -691,6 +694,11 @@ def _read_file_meta_info(fp: BinaryIO) -> FileMetaDataset:
                 is_little_endian=True,
                 stop_when=_not_group_0002,
             )
+        )
+        file_meta.set_original_encoding(
+            is_implicit_vr=True,
+            is_little_endian=True,
+            character_encoding=default_encoding,
         )
 
     # Log if the Group Length doesn't match actual length

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -236,7 +236,7 @@ def correct_ambiguous_vr_element(
 
     Parameters
     ----------
-    elem : dataelem.DataElement
+    elem : dataelem.DataElement or dataelem.RawDataElement
         The element with an ambiguous VR.
     ds : dataset.Dataset
         The dataset containing `elem`.
@@ -250,7 +250,7 @@ def correct_ambiguous_vr_element(
 
     Returns
     -------
-    dataelem.DataElement
+    dataelem.DataElement or dataelem.RawDataElement
         The corrected element
     """
     ancestors = [ds] if ancestors is None else ancestors
@@ -754,6 +754,8 @@ def write_dataset(
         or dataset.original_character_set != dataset._character_set
     ):
         dataset = correct_ambiguous_vr(dataset, fp.is_little_endian)
+        # Use __getitem__ instead or get_item to force parsing of RawDataElements into DataElements,
+        # so we can re-encode them with the correct charset and encoding
         get_item = dataset.__getitem__
 
     dataset_encoding = cast(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1343,6 +1343,40 @@ class TestDataset:
         ds.set_original_encoding(True, True, None)
         assert ds.original_character_set == ["latin_1"]
 
+    def test_original_charset_is_equal_to_charset_after_dcmread(self):
+        default_encoding_test_file = get_testdata_file("liver_1frame.dcm")
+        non_default_encoding_test_file = get_testdata_file("CT_small.dcm")
+
+        default_encoding_ds = dcmread(default_encoding_test_file)
+        non_default_encoding_ds = dcmread(non_default_encoding_test_file)
+
+        assert default_encoding_ds.original_character_set == "iso8859"
+        assert (
+            default_encoding_ds.original_character_set
+            == default_encoding_ds._character_set
+        )
+        assert (
+            default_encoding_ds.ReferencedSeriesSequence[0].original_character_set
+            == default_encoding_ds.ReferencedSeriesSequence[0]._character_set
+        )
+        assert (
+            default_encoding_ds.file_meta.original_character_set
+            == default_encoding_ds.file_meta._character_set
+        )
+        assert non_default_encoding_ds.original_character_set == ["latin_1"]
+        assert (
+            non_default_encoding_ds.original_character_set
+            == non_default_encoding_ds._character_set
+        )
+        assert (
+            non_default_encoding_ds.OtherPatientIDsSequence[0].original_character_set
+            == non_default_encoding_ds.OtherPatientIDsSequence[0]._character_set
+        )
+        assert (
+            non_default_encoding_ds.file_meta.original_character_set
+            == non_default_encoding_ds.file_meta._character_set
+        )
+
     def test_remove_private_tags(self):
         """Test Dataset.remove_private_tags"""
         ds = Dataset()


### PR DESCRIPTION
#### Describe the changes
Hi,
I have a very common use case in my app where we read a dicom, edit some tags, and write it back.  
I noticed that for some of the users, CPU usage was significantly higher than other cases.  
I ran a profiler and noticed that `correct_ambigous_vr` usage was significantly higher than usual.  

When debugging, I noticed that `is_original_encoding` returns `False` for every dicom that has `SpecificCharacterSet` (originally) set to a value that is different than the default.  
This happens because Dataset._parent_encoding isn't being set at `dcmread`.

This PR introduces a few changes to mitigate it:
* `read_dataset` sets `parent_encoding` for the dataset it creates. This reduces calls to `correct_ambigous_vr` in the first place.
* `_read_file_meta` sets original encoding to remove unncessary calls to `correct_ambigous_vr` for every file meta.
* `correct_ambigous_vr` iterates over `.elements()` to avoid parsing of `RawDataElement`s.
* `write_dataset` parses data elements when write encoding is different. This kind of negates the change done to `correct_ambigous_vr`. It is more explicit, instead of being a side effect. I'm not sure this change and the change to `correct_ambigous_vr` are necessary, but I think that explicit is better than an implicit side effect so I kept it.


Not sure what test should be added here. I did verify the changes with this script:
```
import timeit
from io import BytesIO

from pydicom import dcmread, dcmwrite

p = './srdoc102/report05.dcm'
with open(p, 'rb') as f:
    ds_bytes = f.read()

ds1 = dcmread(BytesIO(ds_bytes))
ds_bytes1 = BytesIO()
dcmwrite(ds_bytes1, ds1)
assert ds_bytes1.getvalue() == ds_bytes

for _ in range(3):
    print(timeit.timeit('dcmwrite(BytesIO(), dcmread(BytesIO(ds_bytes)))', number=10000, globals=globals()))
    # print(timeit.timeit('dcmwrite(BytesIO(), ds1)', number=10000, globals=globals()))

```
Where the test dicom is taken from [OFFIS Structured Reports](https://dicom.offis.de/en/dicomscope/).
On my computer, the avg. time before the change is 7.53s and after 5.26s = ~30% better performance for this example. With real data, I see even better results.

Added a test to at least verify the functionality: Read charset is identical to the ds charset after dcmread.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
