### PR TITLE
[MRG] Add Dataset method and function to set Image Pixel elements using an ndarray

### DIFF
--- a/doc/reference/pixels.rst
+++ b/doc/reference/pixels.rst
@@ -34,6 +34,7 @@ Utility functions
    iter_pixels
    pack_bits
    pixel_array
+   set_pixel_data
    unpack_bits
 
 

--- a/doc/reference/pixels.utils.rst
+++ b/doc/reference/pixels.utils.rst
@@ -24,4 +24,5 @@ Pixel data related utility functions.
    pixel_array
    pixel_dtype
    reshape_pixel_array
+   set_pixel_data
    unpack_bits

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -212,7 +212,7 @@ Enhancements
 * Added ``pydicom.__concepts_version__`` attribute with the DICOM Standard version used to
   create the concepts dictionaries in ``pydicom.sr`` (:issue:`1021`)
 * Added the :meth:`Dataset.set_pixel_data()<pydicom.dataset.Dataset.set_pixel_data>` method
-  and :func:`~pydicom.pixels.utils.set_pixel_data` function for automatically setting a
+  and :func:`~pydicom.pixels.set_pixel_data` function for automatically setting a
   dataset's *Pixel Data* and related Image Pixel module elements using an
   :class:`~numpy.ndarray` (:issue:`50`)
 

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -210,7 +210,9 @@ Enhancements
   (if present, although it's non-conformant for it to be) (:issue:`2073`)
 * Added support for NumPy v2.0 (:issue:`2075`)
 * Added ``pydicom.__concepts_version__`` attribute with the DICOM Standard version used to
-  create the concepts dictionaries in ``pydicom.sr`` (:issue:`1021`)
+  create the concepts dictionaries in :mod:`pydicom.sr` (:issue:`1021`)
+* Refactored the interface for the concepts in :mod:`pydicom.sr` to simplify the access types
+  (:issue:`1454`)
 * Added the :meth:`Dataset.set_pixel_data()<pydicom.dataset.Dataset.set_pixel_data>` method
   and :func:`~pydicom.pixels.set_pixel_data` function for automatically setting a
   dataset's *Pixel Data* and related Image Pixel module elements using an

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -209,6 +209,10 @@ Enhancements
 * Added support for NumPy v2.0 (:issue:`2075`)
 * Added ``pydicom.__concepts_version__`` attribute with the DICOM Standard version used to
   create the concepts dictionaries in ``pydicom.sr`` (:issue:`1021`)
+* Added the :meth:`Dataset.set_pixel_data()<pydicom.dataset.Dataset.set_pixel_data>` method
+  and :func:`~pydicom.pixels.utils.set_pixel_data` function for automatically setting a
+  dataset's *Pixel Data* and related Image Pixel module elements using an
+  :class:`~numpy.ndarray` (:issue:`50`)
 
 
 Fixes

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -62,8 +62,8 @@ Changes
   ``pyjpegls`` or ``pylibjpeg`` with ``pylibjpeg-libjpeg`` can be used instead (:issue:`2008`).
 * Using Pillow with JPEG 2000 encoded > 8-bit multi-sample data (such as RGB) now raises an
   exception as Pillow cannot decode such data correctly (:issue:`2006`)
-* Added an exception if an :class:`~numpy.ndarray` is used to set *Pixel Data*
-  (:issue:`50`)
+* An exception will now be raised if an :class:`~numpy.ndarray` is used to set
+  *Pixel Data* (:issue:`50`)
 
 
 Removals

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -62,6 +62,8 @@ Changes
   ``pyjpegls`` or ``pylibjpeg`` with ``pylibjpeg-libjpeg`` can be used instead (:issue:`2008`).
 * Using Pillow with JPEG 2000 encoded > 8-bit multi-sample data (such as RGB) now raises an
   exception as Pillow cannot decode such data correctly (:issue:`2006`)
+* Added an exception if an :class:`~numpy.ndarray` is used to set *Pixel Data*
+  (:issue:`50`)
 
 
 Removals

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -512,6 +512,17 @@ class DataElement:
         Uses the element's VR in order to determine the conversion method and
         resulting type.
         """
+        if (
+            self.tag == 0x7FE00010
+            and config.have_numpy
+            and isinstance(val, numpy.ndarray)
+        ):
+            raise TypeError(
+                "The value for (7FE0,0010) 'Pixel Data' should be set using 'bytes' "
+                "not 'numpy.ndarray'. See the 'Dataset.set_pixel_data()' method for "
+                "an alternative that supports ndarrays."
+            )
+
         if self.VR == VR_.SQ:  # a sequence - leave it alone
             from pydicom.sequence import Sequence
 

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -519,7 +519,7 @@ class DataElement:
         ):
             raise TypeError(
                 "The value for (7FE0,0010) 'Pixel Data' should be set using 'bytes' "
-                "not 'numpy.ndarray'. See the 'Dataset.set_pixel_data()' method for "
+                "not 'numpy.ndarray'. See the Dataset.set_pixel_data() method for "
                 "an alternative that supports ndarrays."
             )
 

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2802,18 +2802,24 @@ class Dataset:
         .. versionadded:: 3.0
 
         The following :dcm:`Image Pixel<part03/sect_C.7.6.3.3.html#table_C.7-11c>`
-        module elements values will be updated or removed as necessary:
+        module elements values will be added, updated or removed as necessary:
 
-        * (0028,0002) *Samples per Pixel* from `photometric_interpretation`.
+        * (0028,0002) *Samples per Pixel* using a value corresponding to
+          `photometric_interpretation`.
+        * (0028,0104) *Photometric Interpretation* from `photometric_interpretation`.
+        * (0028,0006) *Planar Configuration* will be added and set to ``0`` if
+          *Samples per Pixel* is > 1, otherwise it will be removed.
         * (0028,0008) *Number of Frames* from the array :attr:`~numpy.ndarray.shape`,
           however it will be removed if `arr` only contains a single frame.
-        * (0028,0010) *Rows* and (0028,0011) *Column* from the array
+        * (0028,0010) *Rows* and (0028,0011) *Columns* from the array
           :attr:`~numpy.ndarray.shape`.
         * (0028,0100) *Bits Allocated* from the array :class:`~numpy.dtype`.
         * (0028,0101) *Bits Stored* and (0028,0102) *High Bit* from `bits_stored`.
         * (0028,0103) *Pixel Representation* from the array :class:`~numpy.dtype`.
-        * (0028,0006) *Planar Configuration* will be added and set to ``0`` if
-          *Samples per Pixel* is > 1, otherwise it will be removed.
+
+        In addition, the *Transfer Syntax UID* will be set to *Explicit VR Little
+        Endian* if it doesn't already exist or uses a compressed (encapsulated)
+        transfer syntax.
 
         Parameters
         ----------
@@ -2827,12 +2833,12 @@ class Dataset:
               such as RGB.
             * (frames, rows, columns, samples) for multi-frame, multi-sample data.
         photometric_interpretation : str
-            The value to use for (0028,0103) *Photometric Interpretation*. Supported
+            The value to use for (0028,0004) *Photometric Interpretation*. Valid
             values are ``"MONOCHROME1"``, ``"MONOCHROME2"``, ``"PALETTE COLOR"``,
             ``"RGB"``, ``"YBR_FULL"``, ``"YBR_FULL_422"``.
         bits_stored : int
             The value to use for (0028,0101) *Bits Stored*. Must be no greater than
-            the :attr:`~numpy.dtype.itemsize` of `arr`.
+            the number of bits used by the :attr:`~numpy.dtype.itemsize` of `arr`.
         """
         set_pixel_data(self, arr, photometric_interpretation, bits_stored)
 

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2795,6 +2795,8 @@ class Dataset:
         arr: "numpy.ndarray",
         photometric_interpretation: str,
         bits_stored: int,
+        *,
+        new_instance_uid: bool = True,
     ) -> None:
         """Use an :class:`~numpy.ndarray` to set the *Pixel Data* and related
         Image Pixel module elements.
@@ -2817,9 +2819,12 @@ class Dataset:
         * (0028,0101) *Bits Stored* and (0028,0102) *High Bit* from `bits_stored`.
         * (0028,0103) *Pixel Representation* from the array :class:`~numpy.dtype`.
 
-        In addition, the *Transfer Syntax UID* will be set to *Explicit VR Little
-        Endian* if it doesn't already exist or uses a compressed (encapsulated)
-        transfer syntax.
+        In addition:
+
+        * The *Transfer Syntax UID* will be set to *Explicit VR Little Endian* if
+          it doesn't already exist or uses a compressed (encapsulated) transfer syntax.
+        * If `new_instance_uid` is ``True`` (default) then the *SOP Instance UID*
+          will be added or updated.
 
         Parameters
         ----------
@@ -2839,8 +2844,22 @@ class Dataset:
         bits_stored : int
             The value to use for (0028,0101) *Bits Stored*. Must be no greater than
             the number of bits used by the :attr:`~numpy.dtype.itemsize` of `arr`.
+        new_instance_uid : bool, optional
+            If ``True`` (default) then add or update the (0008,0018) *SOP Instance
+            UID* element with a value generated using :func:`~pydicom.uid.generate_uid`.
+
+        Raises
+        ------
+        NotImplementedError
+            If the dataset has a big-endian *Transfer Syntax UID*.
         """
-        set_pixel_data(self, arr, photometric_interpretation, bits_stored)
+        set_pixel_data(
+            self,
+            arr,
+            photometric_interpretation,
+            bits_stored,
+            new_instance_uid=new_instance_uid,
+        )
 
     def _set_pixel_representation(self, elem: DataElement) -> None:
         """Set the `_pixel_rep` attribute for the current dataset and child

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -67,7 +67,9 @@ from pydicom.fileutil import path_from_pathlike, PathType
 from pydicom.misc import warn_and_log
 from pydicom.pixels import compress, convert_color_space, decompress, pixel_array
 from pydicom.pixels.utils import (
-    reshape_pixel_array, get_image_pixel_ids, set_pixel_data
+    reshape_pixel_array,
+    get_image_pixel_ids,
+    set_pixel_data,
 )
 from pydicom.tag import Tag, BaseTag, tag_in_exception, TagType, TAG_PIXREP
 from pydicom.uid import PYDICOM_IMPLEMENTATION_UID, UID

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -1855,7 +1855,7 @@ class Dataset:
         encoding_plugin: str = "",
         encapsulate_ext: bool = False,
         *,
-        new_instance_uid: bool = True,
+        generate_instance_uid: bool = True,
         jls_error: int | None = None,
         j2k_cr: list[float] | None = None,
         j2k_psnr: list[float] | None = None,
@@ -1899,7 +1899,7 @@ class Dataset:
         * (7FE0,0001) *Extended Offset Table*
         * (7FE0,0002) *Extended Offset Table Lengths*
 
-        If `new_instance_uid` is ``True`` (default) then a new (0008,0018) *SOP
+        If `generate_instance_uid` is ``True`` (default) then a new (0008,0018) *SOP
         Instance UID* value will be generated.
 
         **Supported Transfer Syntax UIDs**
@@ -1924,7 +1924,7 @@ class Dataset:
 
         .. versionchanged:: 3.0
 
-            Added the `jls_error`, `j2k_cr`, `j2k_psnr` and `new_instance_uid`
+            Added the `jls_error`, `j2k_cr`, `j2k_psnr` and `generate_instance_uid`
             keyword parameters.
 
         Examples
@@ -1959,7 +1959,7 @@ class Dataset:
             If ``False`` (default) then an extended offset table
             will be added if needed for large amounts of compressed *Pixel
             Data*, otherwise just the basic offset table will be used.
-        new_instance_uid : bool, optional
+        generate_instance_uid : bool, optional
             If ``True`` (default) then generate a new (0008,0018) *SOP Instance UID*
             value for the dataset using :func:`~pydicom.uid.generate_uid`, otherwise
             keep the original value.
@@ -1992,7 +1992,7 @@ class Dataset:
             arr,
             encoding_plugin=encoding_plugin,
             encapsulate_ext=encapsulate_ext,
-            new_instance_uid=new_instance_uid,
+            generate_instance_uid=generate_instance_uid,
             jls_error=jls_error,
             j2k_cr=j2k_cr,
             j2k_psnr=j2k_psnr,
@@ -2004,7 +2004,7 @@ class Dataset:
         handler_name: str = "",
         *,
         as_rgb: bool = True,
-        new_instance_uid: bool = True,
+        generate_instance_uid: bool = True,
         decoding_plugin: str = "",
         **kwargs: Any,
     ) -> None:
@@ -2030,12 +2030,12 @@ class Dataset:
           *Pixel Data* element will be set to ``False``.
         * Any :dcm:`image pixel<part03/sect_C.7.6.3.html>` module elements may be
           modified as required to match the uncompressed *Pixel Data*.
-        * If `new_instance_uid` is ``True`` (default) then a new (0008,0018) *SOP
+        * If `generate_instance_uid` is ``True`` (default) then a new (0008,0018) *SOP
           Instance UID* value will be generated.
 
         .. versionchanged:: 3.0
 
-            Added the `as_rgb` and `new_instance_uid` keyword parameters.
+            Added the `as_rgb` and `generate_instance_uid` keyword parameters.
 
         .. deprecated:: 3.0
 
@@ -2050,7 +2050,7 @@ class Dataset:
             :mod:`~pydicom.pixels` **backend only.** If ``True`` (default) then
             convert pixel data with a YCbCr :ref:`photometric interpretation
             <photometric_interpretation>` such as ``"YBR_FULL_422"`` to RGB.
-        new_instance_uid : bool, optional
+        generate_instance_uid : bool, optional
             If ``True`` (default) then generate a new (0008,0018) *SOP Instance UID*
             value for the dataset using :func:`~pydicom.uid.generate_uid`, otherwise
             keep the original value.
@@ -2089,7 +2089,7 @@ class Dataset:
         decompress(
             self,
             as_rgb=as_rgb,
-            new_instance_uid=new_instance_uid,
+            generate_instance_uid=generate_instance_uid,
             **opts,
         )
 
@@ -2796,7 +2796,7 @@ class Dataset:
         photometric_interpretation: str,
         bits_stored: int,
         *,
-        new_instance_uid: bool = True,
+        generate_instance_uid: bool = True,
     ) -> None:
         """Use an :class:`~numpy.ndarray` to set the *Pixel Data* and related
         Image Pixel module elements.
@@ -2823,7 +2823,7 @@ class Dataset:
 
         * The *Transfer Syntax UID* will be set to *Explicit VR Little Endian* if
           it doesn't already exist or uses a compressed (encapsulated) transfer syntax.
-        * If `new_instance_uid` is ``True`` (default) then the *SOP Instance UID*
+        * If `generate_instance_uid` is ``True`` (default) then the *SOP Instance UID*
           will be added or updated.
 
         Parameters
@@ -2844,7 +2844,7 @@ class Dataset:
         bits_stored : int
             The value to use for (0028,0101) *Bits Stored*. Must be no greater than
             the number of bits used by the :attr:`~numpy.dtype.itemsize` of `arr`.
-        new_instance_uid : bool, optional
+        generate_instance_uid : bool, optional
             If ``True`` (default) then add or update the (0008,0018) *SOP Instance
             UID* element with a value generated using :func:`~pydicom.uid.generate_uid`.
 
@@ -2858,7 +2858,7 @@ class Dataset:
             arr,
             photometric_interpretation,
             bits_stored,
-            new_instance_uid=new_instance_uid,
+            generate_instance_uid=generate_instance_uid,
         )
 
     def _set_pixel_representation(self, elem: DataElement) -> None:

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2825,7 +2825,7 @@ class Dataset:
               such as RGB.
             * (frames, rows, columns, samples) for multi-frame, multi-sample data.
         photometric_interpretation : str
-            The value to use for (0028,0103) *Photometric Interpretation*. Valid
+            The value to use for (0028,0103) *Photometric Interpretation*. Supported
             values are ``"MONOCHROME1"``, ``"MONOCHROME2"``, ``"PALETTE COLOR"``,
             ``"RGB"``, ``"YBR_FULL"``, ``"YBR_FULL_422"``.
         bits_stored : int

--- a/src/pydicom/pixels/__init__.py
+++ b/src/pydicom/pixels/__init__.py
@@ -18,5 +18,6 @@ from pydicom.pixels.utils import (
     iter_pixels,
     pack_bits,
     pixel_array,
+    set_pixel_data,
     unpack_bits,
 )

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -1744,7 +1744,8 @@ def set_pixel_data(
     photometric_interpretation: str,
     bits_stored: int,
 ) -> None:
-    """Set a dataset's *Pixel Data* and related Image Pixel module elements.
+    """Use an :class:`~numpy.ndarray` to set a dataset's *Pixel Data* and related
+    Image Pixel module elements.
 
     .. versionadded:: 3.0
 
@@ -1783,19 +1784,25 @@ def set_pixel_data(
         The value to use for (0028,0101) *Bits Stored*. Must be no greater than
         the :attr:`~numpy.dtype.itemsize` of `arr`.
     """
+    from pydicom.pixels.common import PhotometricInterpretation as PI
+
+
     if "FloatPixelData" in ds or "DoubleFloatPixelData" in ds:
         raise AttributeError(
             "The dataset has (7FE0,0008) 'Float Pixel Data' or (7FE0,0009) "
-            "'Double Float Pixel Data' elements which must be deleted "
+            "'Double Float Pixel Data' elements which must first be deleted "
         )
 
     # The aim is to minimise the required args while guaranteeing conformance
     # Make no changes to the dataset until after validation checks have passed
     changes: dict[str, tuple[str, Any]] = {}
 
-    shape = arr.shape
-    dtype = arr.dtype
-    ndim = arr.ndim
+    shape, ndim, dtype = arr.shape, arr.ndim, arr.dtype
+    if dtype.kind not in ('u', 'i') or dtype.itemsize not in (1, 2):
+        raise ValueError(
+            f"Unsupported ndarray dtype '{dtype}', must be int8, int16, uint8 or "
+            "uint16"
+        )
 
     # Use `photometric_interpretation` to determine *Samples Per Pixel*
     # Don't support retired (such as CMYK) or inappropriate values (such as YBR_RCT)
@@ -1816,30 +1823,33 @@ def set_pixel_data(
         )
 
     if nr_samples == 1:
-        changes["SamplesPerPixel"] = ("+", 1)
-        changes["PlanarConfiguration"] = ("-", None)
+        if ndim not in (2, 3):
+            raise ValueError(
+                f"Invalid ndarray number of dimensions for grayscale data '{ndim}', "
+                "must be 2 or 3"
+            )
+
         # ndim = 3 is (frames, rows, columns), else (rows, columns)
-        changes["NumberOfFrames"] = ("+", shape[0]) if ndim = 3 else ("-", None)
+        changes["NumberOfFrames"] = ("+", shape[0]) if ndim == 3 else ("-", None)
         changes["Rows"] = ("+", shape[1] if ndim == 3 else shape[0])
         changes["Columns"] = ("+", shape[2] if ndim == 3 else shape[1])
     else:
+        if ndim not in (3, 4):
+            raise ValueError(
+                f"Invalid ndarray number of dimensions for multi-sample data '{ndim}', "
+                "must be 3 or 4"
+            )
+
         if shape[-1] != nr_samples:
             raise ValueError(
                 f"Mismatch between the array shape {shape} and the "
                 f"'photometric_interpretation' value '{photometric_interpretation}'"
             )
 
-        changes["SamplesPerPixel"] = ("+", shape[-1])
-        changes["PlanarConfiguration"] = ("+", 0)
         # ndim = 3 is (rows, columns, samples), else (frames, rows, columns, samples)
-        changes["NumberOfFrames"] = ("-", None) if ndim = 3 else ("+", shape[0])
+        changes["NumberOfFrames"] = ("-", None) if ndim == 3 else ("+", shape[0])
         changes["Rows"] = ("+", shape[0] if ndim == 3 else shape[1])
         changes["Columns"] = ("+", shape[1] if ndim == 3 else shape[2])
-
-    if dtype.kind not in ('u', 'i') or dtype.itemsize not in (8, 16):
-        raise ValueError(
-            f"Unsupported ndarray dtype '{dtype}', must be int8, int16, uint8 or uint16"
-        )
 
     # Check values in `arr` are in the range allowed by `bits_stored`
     actual_min, actual_max = arr.min(), arr.max()
@@ -1852,14 +1862,17 @@ def set_pixel_data(
             f"{allowed_max}]"
         )
 
-    if not 0 < bits_stored <= dtype.itemsize:
+    if not 0 < bits_stored <= dtype.itemsize * 8:
         raise ValueError(
-            "'bits_stored' must be greater than 0 and less than or equal to the "
-            f"ndarray's itemsize '{arr.dtype.itemsize}'"
+            f"Invalid 'bits_stored' value '{bits_stored}', must be greater than 0 and "
+            "less than or equal to the number of bits for the ndarray's itemsize "
+            f"'{arr.dtype.itemsize * 8}'"
         )
 
+    changes["SamplesPerPixel"] = ("+", nr_samples)
+    changes["PlanarConfiguration"] = ("+", 0) if nr_samples > 1 else ("-", None)
     changes["PhotometricInterpretation"] = ("+", photometric_interpretation)
-    changes["BitsAllocated"] = ("+", dtype.itemsize)
+    changes["BitsAllocated"] = ("+", dtype.itemsize * 8)
     changes["BitsStored"] = ("+", bits_stored)
     changes["HighBit"] = ("+", bits_stored - 1)
     changes["PixelRepresentation"] = ("+", 0 if dtype.kind == "u" else 1)

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -246,7 +246,7 @@ def compress(
     *,
     encoding_plugin: str = "",
     encapsulate_ext: bool = False,
-    new_instance_uid: bool = True,
+    generate_instance_uid: bool = True,
     jls_error: int | None = None,
     j2k_cr: list[float] | None = None,
     j2k_psnr: list[float] | None = None,
@@ -290,7 +290,7 @@ def compress(
     * (7FE0,0001) *Extended Offset Table*
     * (7FE0,0002) *Extended Offset Table Lengths*
 
-    If `new_instance_uid` is ``True`` (default) then a new (0008,0018) *SOP
+    If `generate_instance_uid` is ``True`` (default) then a new (0008,0018) *SOP
     Instance UID* value will be generated.
 
     **Supported Transfer Syntax UIDs**
@@ -348,7 +348,7 @@ def compress(
         If ``False`` (default) then an extended offset table
         will be added if needed for large amounts of compressed *Pixel
         Data*, otherwise just the basic offset table will be used.
-    new_instance_uid : bool, optional
+    generate_instance_uid : bool, optional
         If ``True`` (default) then generate a new (0008,0018) *SOP Instance UID*
         value for the dataset using :func:`~pydicom.uid.generate_uid`, otherwise
         keep the original value.
@@ -458,7 +458,7 @@ def compress(
 
     ds.file_meta.TransferSyntaxUID = uid
 
-    if new_instance_uid:
+    if generate_instance_uid:
         instance_uid = generate_uid()
         ds.SOPInstanceUID = instance_uid
         ds.file_meta.MediaStorageSOPInstanceUID = instance_uid
@@ -470,7 +470,7 @@ def decompress(
     ds: "Dataset",
     *,
     as_rgb: bool = True,
-    new_instance_uid: bool = True,
+    generate_instance_uid: bool = True,
     decoding_plugin: str = "",
     **kwargs: Any,
 ) -> "Dataset":
@@ -498,7 +498,7 @@ def decompress(
       *Pixel Data* element will be set to ``False``.
     * Any :dcm:`image pixel<part03/sect_C.7.6.3.html>` module elements may be
       modified as required to match the uncompressed *Pixel Data*.
-    * If `new_instance_uid` is ``True`` (default) then a new (0008,0018) *SOP
+    * If `generate_instance_uid` is ``True`` (default) then a new (0008,0018) *SOP
       Instance UID* value will be generated.
 
     Parameters
@@ -512,7 +512,7 @@ def decompress(
         if ``True`` (default) then convert pixel data with a YCbCr
         :ref:`photometric interpretation<photometric_interpretation>` such as
         ``"YBR_FULL_422"`` to RGB.
-    new_instance_uid : bool, optional
+    generate_instance_uid : bool, optional
         If ``True`` (default) then generate a new (0008,0018) *SOP Instance UID*
         value for the dataset using :func:`~pydicom.uid.generate_uid`, otherwise
         keep the original value.
@@ -600,7 +600,7 @@ def decompress(
     # Update the transfer syntax
     ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
 
-    if new_instance_uid:
+    if generate_instance_uid:
         instance_uid = generate_uid()
         ds.SOPInstanceUID = instance_uid
         ds.file_meta.MediaStorageSOPInstanceUID = instance_uid
@@ -1744,7 +1744,7 @@ def set_pixel_data(
     photometric_interpretation: str,
     bits_stored: int,
     *,
-    new_instance_uid: bool = True,
+    generate_instance_uid: bool = True,
 ) -> None:
     """Use an :class:`~numpy.ndarray` to set a dataset's *Pixel Data* and related
     Image Pixel module elements.
@@ -1772,7 +1772,7 @@ def set_pixel_data(
     * The *Transfer Syntax UID* will be set to *Explicit VR Little
       Endian* if it doesn't already exist or uses a compressed (encapsulated)
       transfer syntax.
-    * If `new_instance_uid` is ``True`` (default) then the *SOP Instance UID*
+    * If `generate_instance_uid` is ``True`` (default) then the *SOP Instance UID*
       will be added or updated.
 
     Parameters
@@ -1795,7 +1795,7 @@ def set_pixel_data(
     bits_stored : int
         The value to use for (0028,0101) *Bits Stored*. Must be no greater than
         the number of bits used by the :attr:`~numpy.dtype.itemsize` of `arr`.
-    new_instance_uid : bool, optional
+    generate_instance_uid : bool, optional
         If ``True`` (default) then add or update the (0008,0018) *SOP Instance
         UID* element with a value generated using :func:`~pydicom.uid.generate_uid`.
     """
@@ -1936,7 +1936,7 @@ def set_pixel_data(
     if not tsyntax or tsyntax.is_compressed:
         ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
 
-    if new_instance_uid:
+    if generate_instance_uid:
         instance_uid = generate_uid()
         ds.SOPInstanceUID = instance_uid
         ds.file_meta.MediaStorageSOPInstanceUID = instance_uid

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -1793,8 +1793,7 @@ def set_pixel_data(
             "'Double Float Pixel Data' elements which must first be deleted "
         )
 
-    # The aim is to minimise the required args while guaranteeing conformance
-    # Make no changes to the dataset until after validation checks have passed
+    # Make no changes to the dataset until after validation checks have passed!
     changes: dict[str, tuple[str, Any]] = {}
 
     shape, ndim, dtype = arr.shape, arr.ndim, arr.dtype

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -1573,7 +1573,9 @@ class TestCompressRLE:
         assert ds.SOPInstanceUID == ds.file_meta.MediaStorageSOPInstanceUID
 
         ds = dcmread(EXPL_16_16_1F.path)
-        compress(ds, RLELossless, encoding_plugin="pydicom", generate_instance_uid=False)
+        compress(
+            ds, RLELossless, encoding_plugin="pydicom", generate_instance_uid=False
+        )
         assert ds.SOPInstanceUID == original
         assert ds.SOPInstanceUID == ds.file_meta.MediaStorageSOPInstanceUID
 

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -1568,12 +1568,12 @@ class TestCompressRLE:
         ds = dcmread(EXPL_16_16_1F.path)
         original = ds.SOPInstanceUID
 
-        compress(ds, RLELossless, encoding_plugin="pydicom", new_instance_uid=True)
+        compress(ds, RLELossless, encoding_plugin="pydicom", generate_instance_uid=True)
         assert ds.SOPInstanceUID != original
         assert ds.SOPInstanceUID == ds.file_meta.MediaStorageSOPInstanceUID
 
         ds = dcmread(EXPL_16_16_1F.path)
-        compress(ds, RLELossless, encoding_plugin="pydicom", new_instance_uid=False)
+        compress(ds, RLELossless, encoding_plugin="pydicom", generate_instance_uid=False)
         assert ds.SOPInstanceUID == original
         assert ds.SOPInstanceUID == ds.file_meta.MediaStorageSOPInstanceUID
 
@@ -1884,12 +1884,12 @@ class TestDecompress:
         ds = dcmread(RLE_8_3_1F.path)
         original = ds.SOPInstanceUID
 
-        decompress(ds, decoding_plugin="pydicom", new_instance_uid=True)
+        decompress(ds, decoding_plugin="pydicom", generate_instance_uid=True)
         assert ds.SOPInstanceUID != original
         assert ds.SOPInstanceUID == ds.file_meta.MediaStorageSOPInstanceUID
 
         ds = dcmread(RLE_8_3_1F.path)
-        decompress(ds, decoding_plugin="pydicom", new_instance_uid=False)
+        decompress(ds, decoding_plugin="pydicom", generate_instance_uid=False)
         assert ds.SOPInstanceUID == original
         assert ds.SOPInstanceUID == ds.file_meta.MediaStorageSOPInstanceUID
 
@@ -2306,7 +2306,7 @@ class TestSetPixelData:
         assert np.array_equal(ds.pixel_array, arr)
 
     def test_sop_instance(self):
-        """Test new_instance_uid kwarg"""
+        """Test generate_instance_uid kwarg"""
         ds = Dataset()
         ds.SOPInstanceUID = "1.2.3.4"
 
@@ -2314,6 +2314,6 @@ class TestSetPixelData:
         uid = ds.SOPInstanceUID
         assert uid != "1.2.3.4"
         set_pixel_data(
-            ds, np.zeros((3, 5, 3), dtype="u1"), "RGB", 8, new_instance_uid=False
+            ds, np.zeros((3, 5, 3), dtype="u1"), "RGB", 8, generate_instance_uid=False
         )
         assert ds.SOPInstanceUID == uid

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -44,6 +44,7 @@ from pydicom.uid import (
     EnhancedMRImageStorage,
     ExplicitVRLittleEndian,
     ExplicitVRBigEndian,
+    ImplicitVRLittleEndian,
     UncompressedTransferSyntaxes,
     RLELossless,
     JPEG2000Lossless,
@@ -2242,6 +2243,23 @@ class TestSetPixelData:
         assert elem.is_undefined_length is False
 
         assert np.array_equal(pixel_array(ds, raw=True), arr)
+
+    def test_transfer_syntax(self):
+        """Test setting the transfer syntax"""
+        ds = Dataset()
+
+        set_pixel_data(ds, np.zeros((3, 5, 3), dtype="u1"), "RGB", 8)
+        assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
+
+        del ds.file_meta.TransferSyntaxUID
+
+        ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
+        set_pixel_data(ds, np.zeros((3, 5, 3), dtype="u1"), "RGB", 8)
+        assert ds.file_meta.TransferSyntaxUID == ImplicitVRLittleEndian
+
+        ds.file_meta.TransferSyntaxUID = JPEG2000Lossless
+        set_pixel_data(ds, np.zeros((3, 5, 3), dtype="u1"), "RGB", 8)
+        assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
 
     def test_dataset_set_pixel_data(self):
         """Functionality test for Dataset.set_pixel_data()"""

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -1912,28 +1912,354 @@ class TestSetPixelData:
 
     def test_unsupported_dtype_raises(self):
         """Test exception raised if dtype is unsupported"""
-        ds = Dataset()
 
         msg = (
             r"Unsupported ndarray dtype 'uint32', must be int8, int16, uint8 or uint16"
         )
         with pytest.raises(ValueError, match=msg):
-            set_pixel_data(ds, np.zeros((10, 10), dtype="uint32"), "MONOCHROME1", 8)
+            set_pixel_data(
+                Dataset(), np.zeros((10, 10), dtype="uint32"), "MONOCHROME1", 8
+            )
 
         msg = (
             r"Unsupported ndarray dtype 'float32', must be int8, int16, uint8 or uint16"
         )
         with pytest.raises(ValueError, match=msg):
-            set_pixel_data(ds, np.zeros((10, 10), dtype="float32"), "MONOCHROME1", 8)
+            set_pixel_data(
+                Dataset(), np.zeros((10, 10), dtype="float32"), "MONOCHROME1", 8
+            )
 
     def test_unsupported_photometric_interpretation_raises(self):
         """Test exception raised if dtype is unsupported"""
-        ds = Dataset()
 
         msg = "Unsupported 'photometric_interpretation' value 'YBR_RCT'"
         with pytest.raises(ValueError, match=msg):
-            set_pixel_data(ds, np.zeros((10, 10), dtype="int8"), "YBR_RCT", 8)
+            set_pixel_data(Dataset(), np.zeros((10, 10), dtype="int8"), "YBR_RCT", 8)
 
     def test_unsupported_dimension_raises(self):
         """Test exception raised if array dimensions are unsupported"""
-        pass
+
+        msg = "An ndarray with 'MONOCHROME1' data must have 2 or 3 dimensions, not 4"
+        with pytest.raises(ValueError, match=msg):
+            set_pixel_data(
+                Dataset(), np.zeros((2, 10, 10, 3), dtype="int8"), "MONOCHROME1", 8
+            )
+
+        msg = "An ndarray with 'RGB' data must have 3 or 4 dimensions, not 2"
+        with pytest.raises(ValueError, match=msg):
+            set_pixel_data(Dataset(), np.zeros((10, 10), dtype="int8"), "RGB", 8)
+
+    def test_invalid_samples_raises(self):
+        """Test mismatch between array shape and photometric interpretation raises"""
+        msg = (
+            r"An ndarray with 'RGB' data must have shape \(rows, columns, 3\) or "
+            r"\(frames, rows, columns, 3\), not \(10, 10, 10\)"
+        )
+        with pytest.raises(ValueError, match=msg):
+            set_pixel_data(Dataset(), np.zeros((10, 10, 10), dtype="int8"), "RGB", 8)
+
+    def test_invalid_bits_stored_raises(self):
+        """Test bits_stored outside [1, 16] raises an exception"""
+        msg = (
+            "Invalid 'bits_stored' value '0', must be greater than 0 and "
+            "less than or equal to the number of bits for the ndarray's itemsize "
+            "'8'"
+        )
+        with pytest.raises(ValueError, match=msg):
+            set_pixel_data(Dataset(), np.ones((3, 3), dtype="u1"), "MONOCHROME1", 0)
+
+        msg = (
+            "Invalid 'bits_stored' value '9', must be greater than 0 and "
+            "less than or equal to the number of bits for the ndarray's itemsize "
+            "'8'"
+        )
+        with pytest.raises(ValueError, match=msg):
+            set_pixel_data(Dataset(), np.ones((3, 3), dtype="u1"), "MONOCHROME1", 9)
+
+        msg = (
+            "Invalid 'bits_stored' value '0', must be greater than 0 and "
+            "less than or equal to the number of bits for the ndarray's itemsize "
+            "'16'"
+        )
+        with pytest.raises(ValueError, match=msg):
+            set_pixel_data(Dataset(), np.ones((3, 3), dtype="u2"), "MONOCHROME1", 0)
+
+        msg = (
+            "Invalid 'bits_stored' value '17', must be greater than 0 and "
+            "less than or equal to the number of bits for the ndarray's itemsize "
+            "'16'"
+        )
+        with pytest.raises(ValueError, match=msg):
+            set_pixel_data(Dataset(), np.ones((3, 3), dtype="u2"), "MONOCHROME1", 17)
+
+    def test_invalid_arr_range_raises(self):
+        """Test the range of values in the array matches bits_stored"""
+        arr = np.zeros((10, 10), dtype="uint8")
+        # The array will overflow 256 -> 0 if bits_stored 8
+        for bits_stored in range(1, 8):
+            amin, amax = 0, 2**bits_stored - 1
+            arr[0, 0] = amax + 1
+
+            msg = (
+                rf"The range of values in the ndarray \[0, {amax + 1}\] is "
+                r"greater than that allowed by the 'bits_stored' value \[0, "
+                rf"{amax}\]"
+            )
+            with pytest.raises(ValueError, match=msg):
+                set_pixel_data(Dataset(), arr, "MONOCHROME1", bits_stored)
+
+        arr = np.zeros((10, 10), dtype="uint16")
+        for bits_stored in range(1, 16):
+            amin, amax = 0, 2**bits_stored - 1
+            arr[0, 0] = amax + 1
+
+            msg = (
+                rf"The range of values in the ndarray \[0, {amax + 1}\] is "
+                r"greater than that allowed by the 'bits_stored' value \[0, "
+                rf"{amax}\]"
+            )
+            with pytest.raises(ValueError, match=msg):
+                set_pixel_data(Dataset(), arr, "MONOCHROME1", bits_stored)
+
+        arr = np.zeros((10, 10), dtype="int8")
+        for bits_stored in range(1, 8):
+            amin, amax = -(2 ** (bits_stored - 1)), 2 ** (bits_stored - 1) - 1
+            arr[0, 0] = amax + 1
+            arr[0, 1] = amin - 1
+
+            msg = (
+                rf"The range of values in the ndarray \[{amin - 1}, {amax + 1}\] is "
+                rf"greater than that allowed by the 'bits_stored' value \[{amin}, "
+                rf"{amax}\]"
+            )
+            with pytest.raises(ValueError, match=msg):
+                set_pixel_data(Dataset(), arr, "MONOCHROME1", bits_stored)
+
+        arr = np.zeros((10, 10), dtype="int16")
+        for bits_stored in range(1, 16):
+            amin, amax = -(2 ** (bits_stored - 1)), 2 ** (bits_stored - 1) - 1
+            arr[0, 0] = amax + 1
+            arr[0, 1] = amin - 1
+
+            msg = (
+                rf"The range of values in the ndarray \[{amin - 1}, {amax + 1}\] is "
+                rf"greater than that allowed by the 'bits_stored' value \[{amin}, "
+                rf"{amax}\]"
+            )
+            with pytest.raises(ValueError, match=msg):
+                set_pixel_data(Dataset(), arr, "MONOCHROME1", bits_stored)
+
+    def test_grayscale_8bit_unsigned(self):
+        """Test setting unsigned 8-bit grayscale pixel data"""
+        ds = Dataset()
+        ds.PlanarConfiguration = 1
+        ds.NumberOfFrames = 2
+
+        arr = np.zeros((3, 5), dtype="u1")
+        arr[0, 0] = 127
+        set_pixel_data(ds, arr, "MONOCHROME1", 7)
+
+        assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
+        assert ds.Rows == 3
+        assert ds.Columns == 5
+        assert ds.SamplesPerPixel == 1
+        assert ds.PhotometricInterpretation == "MONOCHROME1"
+        assert ds.PixelRepresentation == 0
+        assert ds.BitsAllocated == 8
+        assert ds.BitsStored == 7
+        assert ds.HighBit == 6
+        assert "NumberOfFrames" not in ds
+        assert "PlanarConfiguration" not in ds
+
+        elem = ds["PixelData"]
+        assert elem.VR == "OB"
+        assert len(elem.value) == 16
+        assert elem.is_undefined_length is False
+        assert ds._pixel_array is None
+        assert ds._pixel_id == {}
+
+        assert np.array_equal(ds.pixel_array, arr)
+
+    def test_grayscale_8bit_signed(self):
+        """Test setting signed 8-bit grayscale pixel data"""
+        ds = Dataset()
+        ds.PlanarConfiguration = 1
+        ds.NumberOfFrames = 2
+
+        arr = np.zeros((3, 5), dtype="i1")
+        arr[0, 0] = 127
+        arr[0, 1] = -128
+        set_pixel_data(ds, arr, "MONOCHROME1", 8)
+
+        assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
+        assert ds.Rows == 3
+        assert ds.Columns == 5
+        assert ds.SamplesPerPixel == 1
+        assert ds.PhotometricInterpretation == "MONOCHROME1"
+        assert ds.PixelRepresentation == 1
+        assert ds.BitsAllocated == 8
+        assert ds.BitsStored == 8
+        assert ds.HighBit == 7
+
+        elem = ds["PixelData"]
+        assert elem.VR == "OB"
+        assert len(elem.value) == 16
+
+        assert np.array_equal(ds.pixel_array, arr)
+
+    def test_grayscale_16bit_unsigned(self):
+        """Test setting unsigned 16-bit grayscale pixel data"""
+        ds = Dataset()
+        ds.PlanarConfiguration = 1
+        ds.NumberOfFrames = 2
+
+        arr = np.zeros((3, 5), dtype="u2")
+        arr[0, 0] = 65535
+        set_pixel_data(ds, arr, "MONOCHROME1", 16)
+
+        assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
+        assert ds.Rows == 3
+        assert ds.Columns == 5
+        assert ds.SamplesPerPixel == 1
+        assert ds.PhotometricInterpretation == "MONOCHROME1"
+        assert ds.PixelRepresentation == 0
+        assert ds.BitsAllocated == 16
+        assert ds.BitsStored == 16
+        assert ds.HighBit == 15
+
+        elem = ds["PixelData"]
+        assert elem.VR == "OW"
+        assert len(elem.value) == 30
+
+        assert np.array_equal(ds.pixel_array, arr)
+
+    def test_grayscale_16bit_signed(self):
+        """Test setting signed 16-bit grayscale pixel data"""
+        ds = Dataset()
+        ds.PlanarConfiguration = 1
+        ds.NumberOfFrames = 2
+
+        arr = np.zeros((3, 5), dtype="i2")
+        arr[0, 0] = 32767
+        arr[0, 1] = -32768
+        set_pixel_data(ds, arr, "MONOCHROME1", 16)
+
+        assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
+        assert ds.Rows == 3
+        assert ds.Columns == 5
+        assert ds.SamplesPerPixel == 1
+        assert ds.PhotometricInterpretation == "MONOCHROME1"
+        assert ds.PixelRepresentation == 1
+        assert ds.BitsAllocated == 16
+        assert ds.BitsStored == 16
+        assert ds.HighBit == 15
+
+        elem = ds["PixelData"]
+        assert elem.VR == "OW"
+        assert len(elem.value) == 30
+
+        assert np.array_equal(ds.pixel_array, arr)
+
+    def test_grayscale_multiframe(self):
+        """Test setting multiframe pixel data"""
+        ds = Dataset()
+
+        arr = np.zeros((10, 3, 5), dtype="u1")
+        arr[0, 0, 0] = 127
+        arr[9, 0, 0] = 255
+        set_pixel_data(ds, arr, "MONOCHROME1", 8)
+
+        assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
+        assert ds.Rows == 3
+        assert ds.Columns == 5
+        assert ds.SamplesPerPixel == 1
+        assert ds.PhotometricInterpretation == "MONOCHROME1"
+        assert ds.PixelRepresentation == 0
+        assert ds.BitsAllocated == 8
+        assert ds.BitsStored == 8
+        assert ds.HighBit == 7
+        assert ds.NumberOfFrames == 10
+        assert "PlanarConfiguration" not in ds
+
+        elem = ds["PixelData"]
+        assert elem.VR == "OB"
+        assert len(elem.value) == 150
+        assert elem.is_undefined_length is False
+
+        assert np.array_equal(ds.pixel_array, arr)
+
+    def test_rgb_8bit_unsigned(self):
+        """Test setting unsigned 8-bit RGB pixel data"""
+        ds = Dataset()
+        ds.NumberOfFrames = 2
+
+        arr = np.zeros((3, 5, 3), dtype="u1")
+        arr[0, 0] = [127, 255, 0]
+        set_pixel_data(ds, arr, "RGB", 8)
+
+        assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
+        assert ds.Rows == 3
+        assert ds.Columns == 5
+        assert ds.SamplesPerPixel == 3
+        assert ds.PhotometricInterpretation == "RGB"
+        assert ds.PixelRepresentation == 0
+        assert ds.BitsAllocated == 8
+        assert ds.BitsStored == 8
+        assert ds.HighBit == 7
+        assert ds.PlanarConfiguration == 0
+        assert "NumberOfFrames" not in ds
+
+        elem = ds["PixelData"]
+        assert elem.VR == "OB"
+        assert len(elem.value) == 46
+
+        assert np.array_equal(ds.pixel_array, arr)
+
+    def test_rgb_YBR_FULL_422(self):
+        """Test setting multiframe pixel data"""
+        ref = dcmread(EXPL_8_3_1F_YBR422.path)
+        arr = pixel_array(ref, raw=True)
+
+        ds = Dataset()
+        set_pixel_data(ds, arr, "YBR_FULL_422", 8)
+
+        assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
+        assert ds.Rows == ref.Rows
+        assert ds.Columns == ref.Columns
+        assert ds.SamplesPerPixel == ref.SamplesPerPixel
+        assert ds.PhotometricInterpretation == "YBR_FULL_422"
+        assert ds.PixelRepresentation == ref.PixelRepresentation
+        assert ds.BitsAllocated == ref.BitsAllocated
+        assert ds.BitsStored == ref.BitsStored
+        assert ds.HighBit == ref.HighBit
+        assert ds.PlanarConfiguration == ref.PlanarConfiguration
+
+        elem = ds["PixelData"]
+        assert elem.VR == "OB"
+        assert len(elem.value) == (
+            ds.Rows * ds.Columns * ds.BitsAllocated // 8 * ds.SamplesPerPixel // 3 * 2
+        )
+        assert elem.is_undefined_length is False
+
+        assert np.array_equal(pixel_array(ds, raw=True), arr)
+
+    def test_dataset_set_pixel_data(self):
+        """Functionality test for Dataset.set_pixel_data()"""
+        ref = dcmread(EXPL_8_3_1F_YBR422.path)
+        arr = ref.pixel_array
+
+        ds = Dataset()
+        ds.set_pixel_data(arr, "RGB", 8)
+
+        assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
+        assert ds.Rows == ref.Rows
+        assert ds.Columns == ref.Columns
+        assert ds.SamplesPerPixel == ref.SamplesPerPixel
+        assert ds.PhotometricInterpretation == "RGB"
+        assert ds.PixelRepresentation == ref.PixelRepresentation
+        assert ds.BitsAllocated == ref.BitsAllocated
+        assert ds.BitsStored == ref.BitsStored
+        assert ds.HighBit == ref.HighBit
+        assert ds.PlanarConfiguration == ref.PlanarConfiguration
+
+        assert np.array_equal(ds.pixel_array, arr)

--- a/tests/test_dataelem.py
+++ b/tests/test_dataelem.py
@@ -1232,3 +1232,22 @@ class TestDataElementValidation:
             DataElement(0x00410001, vr, value, validation_mode=config.WARN)
         with pytest.raises(ValueError, match=msg):
             DataElement(0x00410001, vr, value, validation_mode=config.RAISE)
+
+    @pytest.mark.skipif(not config.have_numpy, reason="Numpy is not available")
+    def test_pixel_data_ndarray_raises(self):
+        """Test exception raised if setting PixelData using ndarray"""
+        import numpy as np
+
+        ds = Dataset()
+        ds.PixelData = b"\x00\x01"
+        assert ds.PixelData == b"\x00\x01"
+
+        msg = (
+            r"The value for \(7FE0,0010\) 'Pixel Data' should be set using 'bytes' "
+            r"not 'numpy.ndarray'. See the Dataset.set_pixel_data\(\) method for "
+            "an alternative that supports ndarrays."
+        )
+        with pytest.raises(TypeError, match=msg):
+            ds.PixelData = np.ones((3, 4), dtype="u1")
+
+        assert ds.PixelData == b"\x00\x01"


### PR DESCRIPTION
#### Describe the changes
* Adds `set_pixel_data()` which sets the Image Pixel module elements using an `ndarray`
* Adds `Dataset.set_pixel_data()` which wraps `set_pixel_data()`
* Adds an exception to DataElement if setting *Pixel Data* directly using an `ndarray`

Closes #50, finally :fireworks: :champagne: :pinata: 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/719e19d7-1963-4830-9478-0a43c4e3f84a/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
