### PR TITLE
[MRG] Fix writing elements like LUT Descriptor when VR is SS

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -251,6 +251,8 @@ Fixes
   a private block (:issue:`2025`)
 * Fixed non-unique keywords for the concept codes in ``pydicom.sr`` (:issue:`1388`)
 * Fixed keywords using Python identifiers in ``pydicom.sr`` (:issue:`1273`)
+* Fixed being unable to write *LUT Descriptor* when the VR is **SS** and the first
+  value is greater than 32767 (:issue:`2081`)
 
 
 Deprecations

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -528,8 +528,8 @@ class DataElement:
             return self._convert(val[0])
 
         # Some ambiguous VR elements ignore the VR for part of the value
-        # e.g. LUT Descriptor is 'US or SS' and VM 3, but the first value
-        #   is always US
+        # e.g. LUT Descriptor is 'US or SS' and VM 3, but the first and
+        #   third values are always US (the third should be <= 16, so SS is OK)
         if self.tag in _LUT_DESCRIPTOR_TAGS and val:
 
             def _skip_conversion(val: Any) -> Any:

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -366,7 +366,7 @@ def write_numbers(fp: DicomIO, elem: DataElement, struct_format: str) -> None:
             # Some ambiguous VR elements ignore the VR for part of the value
             # e.g. LUT Descriptor is 'US or SS' and VM 3, but the first value
             # is always US
-            if elem.tag in _LUT_DESCRIPTOR_TAGS:
+            if struct_format == "h" and elem.tag in _LUT_DESCRIPTOR_TAGS:
                 fp.write(pack(f"{endianChar}H", value[0]))
                 value = value[1:]
 

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -10,7 +10,12 @@ import zlib
 
 from pydicom import config
 from pydicom.charset import default_encoding, convert_encodings, encode_string
-from pydicom.dataelem import DataElement_from_raw, DataElement, RawDataElement
+from pydicom.dataelem import (
+    DataElement_from_raw,
+    DataElement,
+    RawDataElement,
+    _LUT_DESCRIPTOR_TAGS,
+)
 from pydicom.dataset import Dataset, validate_file_meta, FileMetaDataset
 from pydicom.filebase import DicomFile, DicomBytesIO, DicomIO, WriteableBuffer
 from pydicom.fileutil import path_from_pathlike, PathType
@@ -345,11 +350,11 @@ def write_numbers(fp: DicomIO, elem: DataElement, struct_format: str) -> None:
     struct_format : str
         The character format as used by the struct module.
     """
-    endianChar = "><"[fp.is_little_endian]
     value = elem.value
-    if value is None or value == "":
+    if value in (None, "", []):
         return  # don't need to write anything for no or empty value
 
+    endianChar = "><"[fp.is_little_endian]
     format_string = endianChar + struct_format
     try:
         try:
@@ -358,10 +363,16 @@ def write_numbers(fp: DicomIO, elem: DataElement, struct_format: str) -> None:
         except AttributeError:  # is a single value - the usual case
             fp.write(pack(format_string, value))
         else:
-            for val in cast(Iterable[Any], value):
-                fp.write(pack(format_string, val))
-    except Exception as e:
-        raise OSError(f"{str(e)}\nfor data_element:\n{str(elem)}")
+            # Some ambiguous VR elements ignore the VR for part of the value
+            # e.g. LUT Descriptor is 'US or SS' and VM 3, but the first value
+            # is always US
+            if elem.tag in _LUT_DESCRIPTOR_TAGS:
+                fp.write(pack(f"{endianChar}H", value[0]))
+                value = value[1:]
+
+            fp.write(pack(f"{endianChar}{len(value)}{struct_format}", *value))
+    except Exception as exc:
+        raise OSError(f"{exc}\nfor data_element:\n{elem}")
 
 
 def write_OBvalue(fp: DicomIO, elem: DataElement) -> None:

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -351,7 +351,7 @@ def write_numbers(fp: DicomIO, elem: DataElement, struct_format: str) -> None:
         The character format as used by the struct module.
     """
     value = elem.value
-    if value in (None, "", []):
+    if value is None or value == "":
         return  # don't need to write anything for no or empty value
 
     endianChar = "><"[fp.is_little_endian]

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -364,8 +364,8 @@ def write_numbers(fp: DicomIO, elem: DataElement, struct_format: str) -> None:
             fp.write(pack(format_string, value))
         else:
             # Some ambiguous VR elements ignore the VR for part of the value
-            # e.g. LUT Descriptor is 'US or SS' and VM 3, but the first value
-            # is always US
+            # e.g. LUT Descriptor is 'US or SS' and VM 3, but the first and
+            #   third values are always US (the third should be <= 16, so SS is OK)
             if struct_format == "h" and elem.tag in _LUT_DESCRIPTOR_TAGS and value:
                 fp.write(pack(f"{endianChar}H", value[0]))
                 value = value[1:]

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -366,7 +366,7 @@ def write_numbers(fp: DicomIO, elem: DataElement, struct_format: str) -> None:
             # Some ambiguous VR elements ignore the VR for part of the value
             # e.g. LUT Descriptor is 'US or SS' and VM 3, but the first value
             # is always US
-            if struct_format == "h" and elem.tag in _LUT_DESCRIPTOR_TAGS:
+            if struct_format == "h" and elem.tag in _LUT_DESCRIPTOR_TAGS and value:
                 fp.write(pack(f"{endianChar}H", value[0]))
                 value = value[1:]
 

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -2683,7 +2683,14 @@ class TestWriteNumbers:
         assert fp.getvalue() == b"\x00\x80\x00\x00\x10\x00"
 
         fp = DicomBytesIO()
+        fp.is_little_endian = True
+        elem = DataElement(0x00283002, "SS", [])
+        write_numbers(fp, elem, "h")
+        assert fp.getvalue() == b""
+
+        fp = DicomBytesIO()
         fp.is_little_endian = False
+        elem = DataElement(0x00283002, "SS", [32768, 0, 16])
         write_numbers(fp, elem, "h")
         assert fp.getvalue() == b"\x80\x00\x00\x00\x00\x10"
 

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -2674,6 +2674,19 @@ class TestWriteNumbers:
         write_numbers(fp, elem, fmt)
         assert fp.getvalue() == b"\x00\x01"
 
+    def test_write_lut_descriptor(self):
+        """Test writing LUT Descriptor"""
+        fp = DicomBytesIO()
+        fp.is_little_endian = True
+        elem = DataElement(0x00283002, "SS", [32768, 0, 16])
+        write_numbers(fp, elem, "h")
+        assert fp.getvalue() == b"\x00\x80\x00\x00\x10\x00"
+
+        fp = DicomBytesIO()
+        fp.is_little_endian = False
+        write_numbers(fp, elem, "h")
+        assert fp.getvalue() == b"\x80\x00\x00\x00\x00\x10"
+
 
 class TestWriteOtherVRs:
     """Tests for writing the 'O' VRs like OB, OW, OF, etc."""


### PR DESCRIPTION
#### Describe the changes
* Always writes the first value for elements such as *LUT Descriptor* using **US**
* Fixes validation for setting elements such as *LUT Descriptor*
* Closes #2081

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/d70dcfb0-a852-42f2-80b5-88367ff4ce04/artifacts/0/doc/_build/html/release_notes/index.html)
- [x] Unit tests passing and overall coverage the same or better
