### PR TITLE
[MRG] Add FileDataset.buffer attribute, general fixes for datasets read from buffer-likes

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -61,9 +61,12 @@ Changes
   6 or 7 produces incorrect results, so attempting to do so now raises an exception.
   ``pyjpegls`` or ``pylibjpeg`` with ``pylibjpeg-libjpeg`` can be used instead (:issue:`2008`).
 * Using Pillow with JPEG 2000 encoded > 8-bit multi-sample data (such as RGB) now raises an
-  exception as Pillow cannot decode such data correctly (:issue:`2006`)
+  exception as Pillow cannot decode such data correctly (:issue:`2006`).
 * An exception will now be raised if an :class:`~numpy.ndarray` is used to set
-  *Pixel Data* (:issue:`50`)
+  *Pixel Data* (:issue:`50`).
+* Added :attr:`FileDataset.buffer<pydicom.dataset.FileDataset.buffer>` and changed
+  :attr:`FileDataset.filename<pydicom.dataset.FileDataset.filename>` to only be the
+  filename the dataset was read from (if any) (:issue:`1937`).
 
 
 Removals
@@ -258,11 +261,13 @@ Fixes
   *Bits Stored* is less than *Bits Allocated* and the unused bits haven't been
   set to an appropriate value for correct interpretation of the data.
 * Fixed a ``RecursionError`` when using :func:`copy.deepcopy` with a dataset containing
-  a private block (:issue:`2025`)
-* Fixed non-unique keywords for the concept codes in ``pydicom.sr`` (:issue:`1388`)
-* Fixed keywords using Python identifiers in ``pydicom.sr`` (:issue:`1273`)
+  a private block (:issue:`2025`).
+* Fixed non-unique keywords for the concept codes in ``pydicom.sr`` (:issue:`1388`).
+* Fixed keywords using Python identifiers in ``pydicom.sr`` (:issue:`1273`).
 * Fixed being unable to write *LUT Descriptor* when the VR is **SS** and the first
-  value is greater than 32767 (:issue:`2081`)
+  value is greater than 32767 (:issue:`2081`).
+* Fixed *Deflated Explicit VR Little Endian* datasets not working correctly with ``codify``
+  (:issue:`1937`).
 
 
 Deprecations

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -1055,11 +1055,12 @@ class Dataset:
             if elem.value is None and elem.length != 0:
                 from pydicom.filereader import read_deferred_data_element
 
+                src = self.filename or self.buffer
+                if self.filename and self.buffer:
+                    src = self.buffer
+
                 elem = read_deferred_data_element(
-                    self.fileobj_type,
-                    self.filename or self.buffer,
-                    self.timestamp,
-                    elem,
+                    self.fileobj_type, src, self.timestamp, elem
                 )
 
             if tag != BaseTag(0x00080005):
@@ -3245,7 +3246,7 @@ class FileDataset(Dataset):
         buffer-like object.
     buffer : ReadableBuffer | None
         The buffer-like object the :class:`FileDataset` was read from, or
-        ``None`` if the dataset has not been read from a file or file-like.
+        ``None`` if the dataset has been read from a file or file-like.
     fileobj_type
         The type of object the :class:`FileDataset` was read from.
     timestamp : float | None
@@ -3261,7 +3262,6 @@ class FileDataset(Dataset):
         file_meta: "FileMetaDataset | None" = None,
         is_implicit_VR: bool = True,
         is_little_endian: bool = True,
-        path: PathType = "",
     ) -> None:
         """Initialize a :class:`FileDataset` read from a DICOM file.
 

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -1056,7 +1056,11 @@ class Dataset:
                 from pydicom.filereader import read_deferred_data_element
 
                 src = self.filename or self.buffer
-                if self.filename and self.buffer:
+                if (
+                    self.filename
+                    and self.buffer
+                    and not getattr(self.buffer, "closed", False)
+                ):
                     src = self.buffer
 
                 elem = read_deferred_data_element(

--- a/src/pydicom/filebase.py
+++ b/src/pydicom/filebase.py
@@ -75,6 +75,9 @@ class DicomIO:
         # The buffer-like object being wrapped
         self._buffer = buffer
 
+        # The filename associated with the buffer-like
+        self._name: str | None = getattr(self._buffer, "name", None)
+
         # It's more efficient to replace the existing class methods
         #   instead of wrapping them
         if hasattr(buffer, "read"):
@@ -147,11 +150,15 @@ class DicomIO:
         self._implicit_vr = value
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the value of the :attr:`~pydicom.filebase.DicomIO.parent`'s
-        ``name`` attribute, or ``"<no filename>"`` if no such attribute.
+        ``name`` attribute, or ``None`` if no such attribute.
         """
-        return getattr(self._buffer, "name", "<no filename>")
+        return self._name
+
+    @name.setter
+    def name(self, name: str) -> None:
+        self._name = name
 
     @property
     def parent(self) -> ReadableBuffer | WriteableBuffer:

--- a/src/pydicom/util/codify.py
+++ b/src/pydicom/util/codify.py
@@ -487,9 +487,9 @@ def do_codify(args: argparse.Namespace) -> None:
         save_as_filename = args.save_as
     else:
         base, _ = os.path.splitext(filename)
-        save_as_filename = base + "_from_codify" + ".dcm"
-    save_line = f"\nds.save_as(r'{save_as_filename}', enforce_file_format=True)"
-    code_str += save_line
+        save_as_filename = f"{base}_from_codify.dcm"
+
+    code_str += f"\nds.save_as(r'{save_as_filename}', enforce_file_format=True)"
 
     # Write the code lines to specified file or to standard output
     # For test_util, captured output .name throws error, ignore it:

--- a/src/pydicom/util/codify.py
+++ b/src/pydicom/util/codify.py
@@ -487,9 +487,9 @@ def do_codify(args: argparse.Namespace) -> None:
         save_as_filename = args.save_as
     else:
         base, _ = os.path.splitext(filename)
-        save_as_filename = f"{base}_from_codify.dcm"
-
-    code_str += f"\nds.save_as(r'{save_as_filename}', enforce_file_format=True)"
+        save_as_filename = base + "_from_codify" + ".dcm"
+    save_line = f"\nds.save_as(r'{save_as_filename}', enforce_file_format=True)"
+    code_str += save_line
 
     # Write the code lines to specified file or to standard output
     # For test_util, captured output .name throws error, ignore it:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2239,38 +2239,156 @@ class TestFileDataset:
 
         assert expected_diff == set(dir(di)) - set(dir(ds))
 
-    def test_copy_filedataset(self):
+    def test_copy_filelike_open(self):
+        f = open(get_testdata_file("CT_small.dcm"), "rb")
+        ds = pydicom.dcmread(f)
+        assert not f.closed
+
+        ds_copy = copy.copy(ds)
+        assert ds.PatientName == ds_copy.PatientName
+        assert ds.filename.endswith("CT_small.dcm")
+        assert ds.buffer is None
+        assert ds_copy.filename.endswith("CT_small.dcm")
+        assert ds_copy.buffer is None
+        assert ds_copy == ds
+        assert ds_copy.fileobj_type == ds.fileobj_type
+
+        f.close()
+
+    def test_copy_filelike_closed(self):
+        f = open(get_testdata_file("CT_small.dcm"), "rb")
+        ds = pydicom.dcmread(f)
+        f.close()
+        assert f.closed
+
+        ds_copy = copy.copy(ds)
+        assert ds.PatientName == ds_copy.PatientName
+        assert ds.filename.endswith("CT_small.dcm")
+        assert ds.buffer is None
+        assert ds_copy.filename.endswith("CT_small.dcm")
+        assert ds_copy.buffer is None
+        assert ds_copy == ds
+        assert ds_copy.fileobj_type == ds.fileobj_type
+
+    def test_copy_buffer_open(self):
+        with open(get_testdata_file("CT_small.dcm"), "rb") as fb:
+            data = fb.read()
+        buff = io.BytesIO(data)
+        ds = pydicom.dcmread(buff)
+
+        ds_copy = copy.copy(ds)
+        assert ds.filename is None
+        assert ds.buffer is buff
+        assert ds_copy.filename is None
+        assert ds_copy == ds
+        # Shallow copy, the two buffers share the same object
+        assert ds_copy.buffer is ds.buffer
+        assert not ds.buffer.closed
+        assert ds_copy.fileobj_type == ds.fileobj_type
+
+    def test_copy_buffer_closed(self):
         with open(get_testdata_file("CT_small.dcm"), "rb") as fb:
             data = fb.read()
         buff = io.BytesIO(data)
         ds = pydicom.dcmread(buff)
         buff.close()
-        msg = (
-            "The 'filename' attribute of the dataset is a "
-            "file-like object and will be set to None"
-        )
-        with pytest.warns(UserWarning, match=msg):
-            ds_copy = copy.copy(ds)
-        assert ds.filename is not None
-        assert ds_copy.filename is None
+        assert buff.closed
+
+        ds_copy = copy.copy(ds)
         assert ds_copy == ds
 
-    def test_deepcopy_filedataset(self):
+        assert ds.filename is None
+        assert ds.buffer is buff
+        assert ds.buffer.closed
+
+        assert ds_copy.filename is None
+        assert ds_copy.buffer is buff
+        assert ds_copy.buffer.closed
+
+        # Shallow copy, the two buffers share the same object
+        assert ds_copy.buffer is ds.buffer
+        assert ds_copy.fileobj_type == ds.fileobj_type
+
+    def test_deepcopy_filelike_open(self):
+        f = open(get_testdata_file("CT_small.dcm"), "rb")
+        ds = pydicom.dcmread(f)
+        assert not f.closed
+
+        ds_copy = copy.deepcopy(ds)
+        assert ds.PatientName == ds_copy.PatientName
+        assert ds.filename.endswith("CT_small.dcm")
+        assert ds.buffer is None
+        assert ds_copy.filename.endswith("CT_small.dcm")
+        assert ds_copy.buffer is None
+        assert ds_copy == ds
+        assert ds_copy.fileobj_type == ds.fileobj_type
+
+        f.close()
+
+    def test_deepcopy_filelike_closed(self):
+        f = open(get_testdata_file("CT_small.dcm"), "rb")
+        ds = pydicom.dcmread(f)
+        f.close()
+        assert f.closed
+
+        ds_copy = copy.deepcopy(ds)
+        assert ds.PatientName == ds_copy.PatientName
+        assert ds.filename.endswith("CT_small.dcm")
+        assert ds.buffer is None
+        assert ds_copy.filename.endswith("CT_small.dcm")
+        assert ds_copy.buffer is None
+        assert ds_copy == ds
+        assert ds_copy.fileobj_type == ds.fileobj_type
+
+    def test_deepcopy_buffer_open(self):
+        # regression test for #1147
+        with open(get_testdata_file("CT_small.dcm"), "rb") as fb:
+            data = fb.read()
+        buff = io.BytesIO(data)
+        ds = pydicom.dcmread(buff)
+        assert not buff.closed
+
+        ds_copy = copy.deepcopy(ds)
+        assert ds_copy == ds
+
+        assert ds.filename is None
+        assert ds.buffer is buff
+        assert not ds.buffer.closed
+
+        assert ds_copy.filename is None
+        assert isinstance(ds_copy.buffer, io.BytesIO)
+        assert not ds_copy.buffer.closed
+
+        # Deep copy, the two buffers should not be the same object, but equal otherwise
+        assert ds.buffer is not ds_copy.buffer
+        assert ds.buffer.getvalue() == ds_copy.buffer.getvalue()
+
+    def test_deepcopy_buffer_closed(self):
         # regression test for #1147
         with open(get_testdata_file("CT_small.dcm"), "rb") as fb:
             data = fb.read()
         buff = io.BytesIO(data)
         ds = pydicom.dcmread(buff)
         buff.close()
+        assert buff.closed
         msg = (
-            "The 'filename' attribute of the dataset is a "
-            "file-like object and will be set to None"
+            "The ValueError exception 'I/O operation on closed file.' occurred trying "
+            "to deepcopy the buffer-like the dataset was read from, the 'buffer' "
+            "attribute will be set to 'None' in the copied object"
         )
         with pytest.warns(UserWarning, match=msg):
             ds_copy = copy.deepcopy(ds)
-        assert ds.filename is not None
-        assert ds_copy.filename is None
+
         assert ds_copy == ds
+
+        # Deep copy, the two buffers should not be the same object but
+        #   cannot copy a closed IOBase object
+        assert ds.filename is None
+        assert ds.buffer is buff
+        assert ds.buffer.closed
+
+        assert ds_copy.filename is None
+        assert ds_copy.buffer is None
 
     def test_equality_with_different_metadata(self):
         ds = dcmread(get_testdata_file("CT_small.dcm"))
@@ -2289,9 +2407,12 @@ class TestFileDataset:
         ds = FileDataset(
             filename_or_obj="", dataset={}, file_meta=file_meta, preamble=b"\0" * 128
         )
+        assert ds.filename == ""
+        assert ds.buffer is None
 
         ds2 = copy.deepcopy(ds)
         assert ds2.filename == ""
+        assert ds2.buffer is None
 
     def test_deepcopy_dataset_subclass(self):
         """Regression test for #1813."""
@@ -2314,6 +2435,22 @@ class TestFileDataset:
 
         ds3 = copy.deepcopy(ds2)
         assert ds3 == ds
+
+    def test_buffer(self):
+        """Test the buffer attribute."""
+        with open(get_testdata_file("CT_small.dcm"), "rb") as fb:
+            buffer = io.BytesIO(fb.read())
+
+        ds = dcmread(buffer)
+        assert ds.filename is None
+        assert ds.buffer is buffer
+        assert ds.fileobj_type == io.BytesIO
+
+        # Deflated datasets get inflated to a DicomBytesIO() buffer
+        ds = dcmread(get_testdata_file("image_dfl.dcm"))
+        assert ds.filename.endswith("image_dfl.dcm")
+        assert isinstance(ds.buffer, DicomBytesIO)
+        assert ds.fileobj_type == DicomBytesIO
 
 
 class TestDatasetOverlayArray:

--- a/tests/test_filebase.py
+++ b/tests/test_filebase.py
@@ -256,7 +256,9 @@ class TestDicomIO:
             DicomIO(Reader()).write(b"")
 
         fp = DicomIO(Reader())
-        assert fp.name == "<no filename>"
+        assert fp.name is None
+        fp.name = "foo"
+        assert fp.name == "foo"
         fp.close()  # no exceptions
 
     def test_init_good_buffer(self):

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -285,6 +285,8 @@ class TestReader:
         # If we can read anything else, the decompression must have been ok.
         ds = dcmread(deflate_name)
         assert "WSD" == ds.ConversionType
+        assert isinstance(ds.buffer, DicomBytesIO)
+        assert ds.filename == deflate_name
 
     def test_sequence_with_implicit_vr(self):
         """Test that reading a UN sequence with unknown length and implicit VR

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -28,6 +28,7 @@ from pydicom.util.codify import (
     code_dataelem,
     code_dataset,
     main as codify_main,
+    code_file_from_dataset,
 )
 from pydicom.util.dump import (
     print_character,
@@ -94,10 +95,10 @@ class TestCodify:
 
     def test_code_imports(self):
         """Test utils.codify.code_imports"""
-        out = "import pydicom\n"
-        out += "from pydicom.dataset import Dataset, FileMetaDataset\n"
-        out += "from pydicom.sequence import Sequence"
-        assert out == code_imports()
+        out = ["import pydicom"]
+        out.append("from pydicom.dataset import Dataset, FileMetaDataset")
+        out.append("from pydicom.sequence import Sequence")
+        assert "\n".join(out) == code_imports()
 
     def test_code_dataelem_standard(self):
         """Test utils.codify.code_dataelem for standard element"""
@@ -205,10 +206,26 @@ class TestCodify:
     def test_code_file(self, capsys):
         """Test utils.codify.code_file"""
         filename = get_testdata_file("rtplan.dcm")
+        args = [filename]
+        codify_main(100, args)
+        out, err = capsys.readouterr()
+        assert r"rtplan_from_codify.dcm" in out
+
+    def test_code_file_save_as(self, capsys):
+        """Test utils.codify.code_file"""
+        filename = get_testdata_file("rtplan.dcm")
         args = ["--save-as", r"c:\temp\testout.dcm", filename]
         codify_main(100, args)
         out, err = capsys.readouterr()
         assert r"c:\temp\testout.dcm" in out
+
+    def test_code_file_deflated(self, capsys):
+        """Test utils.codify.code_file with a deflated dataset"""
+        filename = get_testdata_file("image_dfl.dcm")
+        args = [filename]
+        codify_main(100, args)
+        out, err = capsys.readouterr()
+        assert r"image_dfl_from_codify.dcm" in out
 
     def test_code_relative_filename(self, capsys):
         """Test utils.codify.code_file with a relative path that doesn't exist"""
@@ -324,26 +341,6 @@ class TestDump:
             "(FFFC,FFFC) Data Set Trailing Padding           OB: Array of "
             "126 elements"
         ) in s
-
-
-class TestFixer:
-    """Test the utils.fixer module"""
-
-    def test_fix_separator_callback(self):
-        """Test utils.fixer.fix_separator_callback"""
-        pass
-
-    def test_fix_separator(self):
-        """Test utils.fixer.fix_separator"""
-        pass
-
-    def test_mismatch_callback(self):
-        """Test utils.fixer.mismatch_callback"""
-        pass
-
-    def test_fix_mismatch(self):
-        """Test utils.fixer.fix_mismatch"""
-        pass
 
 
 class TestHexUtil:


### PR DESCRIPTION
#### Describe the changes
* Adds `FileDataset.buffer` which is the object used for deflated datasets and datasets read from a buffer-like such as `BytesIO`
* `FileDataset.filename` is now only either a filename `str` or `None`
* Adds a `name` setter for `DicomIO`
* Keeps the filename used for deflated datasets read using path or file-like
* `copy.copy()` operation on `FileDataset` will return a shallow copy with the `self.buffer` object shared rather than set to `None` if closed (I believe this is in keeping with the expected behaviour for `copy.copy()`?)
* `copy.deepcopy()` operation on `FileDataset` will return a deep copy and only set `self.buffer` to `None` if unable to perform a deep copy on it.

Closes #1937

I'd be happy to change the attribute name to something other than `buffer`. 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/3edb9434-c53d-42c8-86c1-338b1905c3c9/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
