### PR TITLE
[MRG] Make JSON conversion errors more verbose at a lower level

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -65,7 +65,7 @@ Changes
 * An exception will now be raised if an :class:`~numpy.ndarray` is used to set
   *Pixel Data* (:issue:`50`)
 * Logging of errors when converting elements using :meth:`Dataset.to_json_dict()
-  <pydicom.dataset.dataset.to_json_dict>` have been made more verbose and now use
+  <pydicom.dataset.Dataset.to_json_dict>` have been made more verbose and now use
   ``logging.WARNING`` (:issue:`1909`).
 
 

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -64,6 +64,9 @@ Changes
   exception as Pillow cannot decode such data correctly (:issue:`2006`)
 * An exception will now be raised if an :class:`~numpy.ndarray` is used to set
   *Pixel Data* (:issue:`50`)
+* Logging of errors when converting elements using :meth:`Dataset.to_json_dict()
+  <pydicom.dataset.dataset.to_json_dict>` have been made more verbose and now use
+  ``logging.WARNING`` (:issue:`1909`).
 
 
 Removals

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -3145,9 +3145,11 @@ class Dataset:
                         bulk_data_threshold=bulk_data_threshold,
                     )
                 except Exception as exc:
-                    logger.error(f"Error while processing tag {json_key}")
                     if not suppress_invalid_tags:
+                        logger.error(f"Error while processing tag {json_key}")
                         raise exc
+
+                    logger.warning(f"Error while processing tag {json_key}: {exc}")
 
         return json_dataset
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -315,7 +315,7 @@ class TestDataSetToJson:
             assert "00082128" not in ds_json
 
         assert (
-            "Error while processing tag 00082127: Invalid value for VR IS: '5.25'"
+            "Error while processing tag 00082128: Invalid value for VR IS: '5.25'"
         ) in caplog.text
 
 


### PR DESCRIPTION
#### Describe the changes
* Errors during conversion to JSON changed to be more verbose and use `logging.WARNING`

Closes #1909

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/52a7d2ff-c7ca-438f-b37c-20bcd0370ea9/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
