### PR TITLE
[MRG] Add argument to raise FileExistsError when writing

### DIFF
--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -35,6 +35,10 @@ Changes
   method will now raise an exception if the user tries to convert between little
   and big endian datasets. If this is something you need, use
   :func:`~pydicom.filewriter.dcmwrite` instead.
+* :meth:`Dataset.save_as()<pydicom.dataset.Dataset.save_as>` and
+  :func:`~pydicom.filewriter.dcmwrite` will now raise a :class:`FileExistsError` by
+  default when trying to write to a file that already exists. This behavior can be
+  overridden by passing ``exist_ok=True`` (:issue:`2104`).
 * `implicit_vr`, `little_endian` and `force_encoding` optional arguments
   added to  :func:`~pydicom.filewriter.dcmwrite`.
 * The priority used to decide which encoding to use with

--- a/doc/release_notes/v3.0.0.rst
+++ b/doc/release_notes/v3.0.0.rst
@@ -35,10 +35,9 @@ Changes
   method will now raise an exception if the user tries to convert between little
   and big endian datasets. If this is something you need, use
   :func:`~pydicom.filewriter.dcmwrite` instead.
-* :meth:`Dataset.save_as()<pydicom.dataset.Dataset.save_as>` and
-  :func:`~pydicom.filewriter.dcmwrite` will now raise a :class:`FileExistsError` by
-  default when trying to write to a file that already exists. This behavior can be
-  overridden by passing ``exist_ok=True`` (:issue:`2104`).
+* Added the `exist_ok` argument to :meth:`Dataset.save_as()<pydicom.dataset.Dataset.save_as>`
+  and :func:`~pydicom.filewriter.dcmwrite` to allow raising a :class:`FileExistsError`
+  if trying to write to a file that already exists (:issue:`2104`).
 * `implicit_vr`, `little_endian` and `force_encoding` optional arguments
   added to  :func:`~pydicom.filewriter.dcmwrite`.
 * The priority used to decide which encoding to use with

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2533,6 +2533,7 @@ class Dataset:
         implicit_vr: bool | None = None,
         little_endian: bool | None = None,
         enforce_file_format: bool = False,
+        exist_ok: bool = False,
         **kwargs: Any,
     ) -> None:
         """Encode the current :class:`Dataset` and write it to `filename`.
@@ -2557,7 +2558,8 @@ class Dataset:
 
         .. versionchanged:: 3.0
 
-            Added `implicit_vr`, `little_endian` and `enforce_file_format`
+            Added `implicit_vr`, `little_endian`, `enforce_file_format` and `exist_ok`
+            keyword arguments
 
         .. deprecated:: 3.0
 
@@ -2599,6 +2601,10 @@ class Dataset:
             - ``Dataset.file_meta``: if the dataset is missing any required
               *File Meta Information Group* elements then they will not be
               added or written
+        exist_ok : bool, optional
+            If ``False`` (default) and `filename` is a :class:`str` or PathLike, then
+            raise a :class:`FileExistsError` if a file already exists with the given
+            filename.
 
         See Also
         --------
@@ -2640,6 +2646,7 @@ class Dataset:
             implicit_vr=implicit_vr,
             little_endian=little_endian,
             enforce_file_format=enforce_file_format,
+            exist_ok=exist_ok,
             **kwargs,
         )
 

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2533,7 +2533,7 @@ class Dataset:
         implicit_vr: bool | None = None,
         little_endian: bool | None = None,
         enforce_file_format: bool = False,
-        exist_ok: bool = False,
+        exist_ok: bool = True,
         **kwargs: Any,
     ) -> None:
         """Encode the current :class:`Dataset` and write it to `filename`.
@@ -2602,9 +2602,9 @@ class Dataset:
               *File Meta Information Group* elements then they will not be
               added or written
         exist_ok : bool, optional
-            If ``False`` (default) and `filename` is a :class:`str` or PathLike, then
-            raise a :class:`FileExistsError` if a file already exists with the given
-            filename.
+            If ``False`` and `filename` is a :class:`str` or PathLike, then raise a
+            :class:`FileExistsError` if a file already exists with the given filename
+            (default ``True``).
 
         See Also
         --------

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -1123,7 +1123,7 @@ def dcmwrite(
     little_endian: bool | None = None,
     enforce_file_format: bool = False,
     force_encoding: bool = False,
-    exist_ok: bool = False,
+    exist_ok: bool = True,
     **kwargs: Any,
 ) -> None:
     """Write `dataset` to `filename`, which can be a path, a file-like or a
@@ -1260,9 +1260,9 @@ def dcmwrite(
         `little_endian`. Cannot be used with `enforce_file_format`. Default
         ``False``.
     exist_ok : bool, optional
-        If ``False`` (default) and `filename` is a :class:`str` or PathLike, then
-        raise a :class:`FileExistsError` if a file already exists with the given
-        filename.
+        If ``False`` and `filename` is a :class:`str` or PathLike, then raise a
+        :class:`FileExistsError` if a file already exists with the given filename
+        (default ``True``).
 
     Raises
     ------

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -1123,6 +1123,7 @@ def dcmwrite(
     little_endian: bool | None = None,
     enforce_file_format: bool = False,
     force_encoding: bool = False,
+    exist_ok: bool = False,
     **kwargs: Any,
 ) -> None:
     """Write `dataset` to `filename`, which can be a path, a file-like or a
@@ -1130,7 +1131,7 @@ def dcmwrite(
 
     .. versionchanged:: 3.0
 
-        Added the `enforce_file_format` keyword argument.
+        Added the `enforce_file_format` and `exist_ok` keyword arguments.
 
     .. deprecated:: 3.0
 
@@ -1258,6 +1259,10 @@ def dcmwrite(
         If ``True`` then force the encoding to follow `implicit_vr` and
         `little_endian`. Cannot be used with `enforce_file_format`. Default
         ``False``.
+    exist_ok : bool, optional
+        If ``False`` (default) and `filename` is a :class:`str` or PathLike, then
+        raise a :class:`FileExistsError` if a file already exists with the given
+        filename.
 
     Raises
     ------
@@ -1402,7 +1407,8 @@ def dcmwrite(
     filename = path_from_pathlike(filename)
     if isinstance(filename, str):
         # A path-like to be written to
-        fp: DicomIO = DicomFile(filename, "wb")
+        file_mode = "xb" if not exist_ok else "wb"
+        fp: DicomIO = DicomFile(filename, file_mode)
         # caller provided a file name; we own the file handle
         caller_owns_file = False
     elif isinstance(filename, DicomIO):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2898,7 +2898,7 @@ class TestDatasetWithBufferedData:
                 ds = Dataset()
                 ds.PixelData = f
 
-            with pytest.raises(TypeError, match="cannot pickle"):
+            with pytest.raises(TypeError, match="cannot"):
                 pickle.dumps({"ds": ds})
 
     def test_copy_bytesio(self):
@@ -2978,7 +2978,6 @@ class TestDatasetWithBufferedData:
 
     def test_deepcopy_bufferedreader_raises(self):
         with tempfile.TemporaryDirectory() as tdir:
-            print(tdir)
             with open(f"{tdir}/foo.bin", "wb") as f:
                 f.write(b"\x00\x01\x02\x03\x04")
 
@@ -2988,7 +2987,7 @@ class TestDatasetWithBufferedData:
 
         msg = (
             r"Error deepcopying the buffered element \(7FE0,0010\) 'Pixel Data': "
-            "cannot pickle '_io.BufferedReader' object"
+            r"cannot (.*) '_io.BufferedReader' object"
         )
         with pytest.raises(TypeError, match=msg):
             copy.deepcopy(ds)

--- a/tests/test_fileset.py
+++ b/tests/test_fileset.py
@@ -743,7 +743,7 @@ class TestRecordNode:
         item = ds.DirectoryRecordSequence[-1]
         assert "IMAGE" == item.DirectoryRecordType
         item.ReferencedFileID = "01"
-        ds.save_as(p / "DICOMDIR")
+        ds.save_as(p / "DICOMDIR", exist_ok=True)
         fs = FileSet(ds)
         assert fs._instances[0].node._file_id == Path("01")
 

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -1829,6 +1829,24 @@ class TestDCMWrite:
         for elem_orig, elem_conv in zip(ds_orig, ds_expl):
             assert elem_orig.value == elem_conv.value
 
+    def test_exist_ok(self):
+        """Test the exist_ok argument"""
+        ds = dcmread(ct_name)
+        patient_name = ds.PatientName
+
+        with tempfile.TemporaryDirectory() as tdir:
+            p = Path(tdir) / "foo.dcm"
+            p.touch()
+
+            assert p.exists()
+
+            msg = r"File exists: '(.*)foo.dcm'"
+            with pytest.raises(FileExistsError, match=msg):
+                dcmwrite(p, ds, exist_ok=False)
+
+            dcmwrite(p, ds, exist_ok=True)
+            assert dcmread(p).PatientName == patient_name
+
 
 class TestDCMWrite_EnforceFileFormat:
     """Tests for dcmwrite(enforce_file_format=True)"""


### PR DESCRIPTION
#### Describe the changes
* Raise `FileExistsError` by default with `Dataset.save_as()` and `dcmwrite()` when given the path to a filename
* Closes #2104 
* Update exception messages matches in tests to account for PyPy

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/3a96d0bd-8b68-4c37-9245-c20865d1fdea/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
