### PR TITLE
[MRG] Catch missed test warnings, clean up validation warnings with DSdecimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,3 @@ We are all volunteers working on *pydicom* in our free time. As our
 resources are limited, we very much value your contributions, be it bug fixes, new
 core features, or documentation improvements. For more information, please
 read our [contribution guide](https://github.com/pydicom/pydicom/blob/main/CONTRIBUTING.md).
-
-If you have examples or extensions of *pydicom* that don't belong with the
-core software, but that you deem useful to others, you can add them to our
-contribution repository:
-[contrib-pydicom](https://www.github.com/pydicom/contrib-pydicom).

--- a/src/pydicom/valuerep.py
+++ b/src/pydicom/valuerep.py
@@ -1108,7 +1108,7 @@ class DSfloat(float):
         return repr(self)[1:-1]
 
     def __repr__(self) -> str:
-        if self.auto_format and hasattr(self, "original_string"):
+        if hasattr(self, "original_string"):
             return f"'{self.original_string}'"
 
         return f"'{super().__repr__()}'"
@@ -1219,7 +1219,7 @@ class DSdecimal(Decimal):
                 if validation_mode == config.RAISE:
                     raise OverflowError(msg)
                 warn_and_log(msg)
-            if not is_valid_ds(repr(self).strip("'")):
+            elif not is_valid_ds(repr(self).strip("'")):
                 # This will catch nan and inf
                 msg = f'Value "{self}" is not valid for elements with a VR of DS'
                 if validation_mode == config.RAISE:
@@ -1247,8 +1247,9 @@ class DSdecimal(Decimal):
         return super().__str__()
 
     def __repr__(self) -> str:
-        if self.auto_format and hasattr(self, "original_string"):
+        if hasattr(self, "original_string"):
             return f"'{self.original_string}'"
+
         return f"'{self}'"
 
 

--- a/tests/pixels/test_processing.py
+++ b/tests/pixels/test_processing.py
@@ -1819,9 +1819,9 @@ class TestApplyPresentationLUT:
         # 4096 entries, 8-bit output, LUTData as 16-bit bytes
         seq[0].LUTDescriptor = [4096, 0, 16]
         seq[0]["LUTData"].VR = "OW"
-        seq[0].LUTData = [int(round(x * (2**16 - 1) / 4095, 0)) for x in range(0, 4096)]
+        data = [int(round(x * (2**16 - 1) / 4095, 0)) for x in range(0, 4096)]
         seq[0].LUTData = b"".join(
-            x.to_bytes(length=2, byteorder="little") for x in seq[0].LUTData
+            x.to_bytes(length=2, byteorder="little") for x in data
         )
         out = apply_presentation_lut(arr, ds)
         results = [

--- a/tests/test_charset.py
+++ b/tests/test_charset.py
@@ -205,14 +205,14 @@ class TestCharset:
 
     def test_convert_encodings_warnings(self):
         """Test warning if stand-alone encodings are used as code extension"""
-        with pytest.warns(
-            UserWarning,
-            match="Value 'GBK' cannot be used as code extension, ignoring it",
-        ):
-            encodings = pydicom.charset.convert_encodings(
-                ["ISO_IR 126", "GBK", "ISO 2022 IR 144", "ISO_IR 192"]
-            )
-            assert ["iso_ir_126", "iso_ir_144"] == encodings
+        msg_iso = "Value 'ISO_IR 192' cannot be used as code extension, ignoring it"
+        msg_gbk = "Value 'GBK' cannot be used as code extension, ignoring it"
+        with pytest.warns(UserWarning, match=msg_iso):
+            with pytest.warns(UserWarning, match=msg_gbk):
+                encodings = pydicom.charset.convert_encodings(
+                    ["ISO_IR 126", "GBK", "ISO 2022 IR 144", "ISO_IR 192"]
+                )
+                assert ["iso_ir_126", "iso_ir_144"] == encodings
 
     def test_convert_python_encodings(self):
         """Test that unknown encodings are returned unchanged by

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -3252,7 +3252,6 @@ class TestWritingBufferedPixelData:
         ds.BitsAllocated = bits_allocated
 
         with TemporaryFile("+wb") as buffer, TemporaryFile("+wb") as fp:
-            # 100 megabytes
             buffer.write(b"\x00" * FILE_SIZE)
             buffer.seek(0)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -119,7 +119,7 @@ class TestCodify:
     def test_code_dataelem_exclude_size(self):
         """Test utils.codify.code_dataelem exclude_size param"""
         input_elem = [
-            DataElement(0x00100010, "OB", "CITIZEN"),
+            DataElement(0x00100010, "OB", b"CITIZEN"),
             DataElement(0x0008010C, "UI", "1.1"),
             DataElement(0x00200011, "IS", 3),
         ]


### PR DESCRIPTION
#### Describe the changes
* Catches missed logged warnings in the tests
* Update README to remove contrib-pydicom mention
* Cleaner validation warning for DSdecimal (either too long warning, or invalid warning, not both)
* Use `original_string` value with DSdecimal if auto_format is False... it was flagging DSdecimal("1.2345") as invalid.
* Refactored the buffer test since it's taking a weirdly long time in the workflow.

The validation warnings with IS/DS are a bit messy. I think either the validation should be done externally by the validation checks in `valuerep`, or internally by the class `__init__`. Currently it's both, so you can get two warnings about the same invalid value.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
