### PR TITLE
[MRG] Reduce logging for missing imports

### DIFF
--- a/doc/release_notes/v3.0.1.rst
+++ b/doc/release_notes/v3.0.1.rst
@@ -1,0 +1,7 @@
+Version 3.0.1
+=============
+
+Fixes
+-----
+* Changed logging of missing plugin imports to use :attr:`logging.WARNING` and made it
+  controllable via :func:`config.debug()<pydicom.config.debug>` (:issue:`2128`).

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -1,4 +1,4 @@
-Version 3.0.1
+Version 3.1.0
 =============
 
 Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ license = {text = "MIT"}
 name = "pydicom"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "3.0.1.dev0"
+version = "3.1.0.dev0"
 
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ license = {text = "MIT"}
 name = "pydicom"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "3.0.0"
+version = "3.0.1.dev0"
 
 
 [project.optional-dependencies]

--- a/src/pydicom/config.py
+++ b/src/pydicom/config.py
@@ -30,6 +30,50 @@ if TYPE_CHECKING:  # pragma: no cover
 _use_future = False
 _use_future_env = os.getenv("PYDICOM_FUTURE")
 
+
+# Logging system and debug function to change logging level
+logger = logging.getLogger("pydicom")
+logger.addHandler(logging.NullHandler())
+
+debugging: bool
+
+
+def debug(debug_on: bool = True, default_handler: bool = True) -> None:
+    """Turn on/off debugging of DICOM file reading and writing.
+
+    When debugging is on, file location and details about the elements read at
+    that location are logged to the 'pydicom' logger using Python's
+    :mod:`logging`
+    module.
+
+    Parameters
+    ----------
+    debug_on : bool, optional
+        If ``True`` (default) then turn on debugging, ``False`` to turn off.
+    default_handler : bool, optional
+        If ``True`` (default) then use :class:`logging.StreamHandler` as the
+        handler for log messages.
+    """
+    global logger, debugging
+
+    if default_handler:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter("%(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    if debug_on:
+        logger.setLevel(logging.DEBUG)
+        debugging = True
+    else:
+        logger.setLevel(logging.WARNING)
+        debugging = False
+
+
+# force level=WARNING, in case logging default is set differently (issue 103)
+debug(False, False)
+
+
 # Set the type used to hold DS values
 #    default False; was decimal-based in pydicom 0.9.7
 use_DS_decimal: bool = False
@@ -360,10 +404,6 @@ displaying the file meta information data elements
 .. versionadded:: 2.0
 """
 
-# Logging system and debug function to change logging level
-logger = logging.getLogger("pydicom")
-logger.addHandler(logging.NullHandler())
-
 import pydicom.pixel_data_handlers.numpy_handler as np_handler  # noqa
 import pydicom.pixel_data_handlers.rle_handler as rle_handler  # noqa
 import pydicom.pixel_data_handlers.pillow_handler as pillow_handler  # noqa
@@ -496,43 +536,6 @@ ValueError: Invalid value used with the 'in' operator: must be an
 element tag as a 2-tuple or int, or an element keyword
 """
 
-debugging: bool
-
-
-def debug(debug_on: bool = True, default_handler: bool = True) -> None:
-    """Turn on/off debugging of DICOM file reading and writing.
-
-    When debugging is on, file location and details about the elements read at
-    that location are logged to the 'pydicom' logger using Python's
-    :mod:`logging`
-    module.
-
-    Parameters
-    ----------
-    debug_on : bool, optional
-        If ``True`` (default) then turn on debugging, ``False`` to turn off.
-    default_handler : bool, optional
-        If ``True`` (default) then use :class:`logging.StreamHandler` as the
-        handler for log messages.
-    """
-    global logger, debugging
-
-    if default_handler:
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter("%(message)s")
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-
-    if debug_on:
-        logger.setLevel(logging.DEBUG)
-        debugging = True
-    else:
-        logger.setLevel(logging.WARNING)
-        debugging = False
-
-
-# force level=WARNING, in case logging default is set differently (issue 103)
-debug(False, False)
 
 if _use_future_env:
     if _use_future_env.lower() in ["true", "yes", "on", "1"]:

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -1276,7 +1276,7 @@ def _passes_version_check(package_name: str, minimum_version: tuple[int, ...]) -
         return tuple(int(x) for x in module.__version__.split(".")) >= minimum_version
     except Exception as exc:
         if config.debugging:
-            LOGGER.warning(exc)
+            LOGGER.debug(exc)
 
     return False
 

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     HAVE_NP = False
 
+from pydicom import config
 from pydicom.charset import default_encoding
 from pydicom._dicom_dict import DicomDictionary
 from pydicom.encaps import encapsulate, encapsulate_extended
@@ -1274,7 +1275,8 @@ def _passes_version_check(package_name: str, minimum_version: tuple[int, ...]) -
         module = importlib.import_module(package_name, "__version__")
         return tuple(int(x) for x in module.__version__.split(".")) >= minimum_version
     except Exception as exc:
-        LOGGER.exception(exc)
+        if config.debugging:
+            LOGGER.warning(exc)
 
     return False
 

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -16,7 +16,6 @@ try:
 except ImportError:
     HAVE_NP = False
 
-from pydicom import config
 from pydicom.charset import default_encoding
 from pydicom._dicom_dict import DicomDictionary
 from pydicom.encaps import encapsulate, encapsulate_extended
@@ -1271,6 +1270,8 @@ def _passes_version_check(package_name: str, minimum_version: tuple[int, ...]) -
     """Return True if `package_name` is available and its version is greater or
     equal to `minimum_version`
     """
+    from pydicom import config
+
     try:
         module = importlib.import_module(package_name, "__version__")
         return tuple(int(x) for x in module.__version__.split(".")) >= minimum_version

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -16,7 +16,6 @@ try:
 except ImportError:
     HAVE_NP = False
 
-from pydicom import config
 from pydicom.charset import default_encoding
 from pydicom._dicom_dict import DicomDictionary
 from pydicom.encaps import encapsulate, encapsulate_extended
@@ -1275,8 +1274,7 @@ def _passes_version_check(package_name: str, minimum_version: tuple[int, ...]) -
         module = importlib.import_module(package_name, "__version__")
         return tuple(int(x) for x in module.__version__.split(".")) >= minimum_version
     except Exception as exc:
-        if config.debugging:
-            LOGGER.debug(exc)
+        LOGGER.debug(exc)
 
     return False
 

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     HAVE_NP = False
 
+from pydicom import config
 from pydicom.charset import default_encoding
 from pydicom._dicom_dict import DicomDictionary
 from pydicom.encaps import encapsulate, encapsulate_extended
@@ -1270,8 +1271,6 @@ def _passes_version_check(package_name: str, minimum_version: tuple[int, ...]) -
     """Return True if `package_name` is available and its version is greater or
     equal to `minimum_version`
     """
-    from pydicom import config
-
     try:
         module = importlib.import_module(package_name, "__version__")
         return tuple(int(x) for x in module.__version__.split(".")) >= minimum_version

--- a/tests/pixels/test_decoder_gdcm.py
+++ b/tests/pixels/test_decoder_gdcm.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     HAVE_NP = False
 
-from pydicom import dcmread
+from pydicom import dcmread, config
 from pydicom.pixels import get_decoder
 from pydicom.pixels.utils import _passes_version_check
 from pydicom.uid import (
@@ -239,10 +239,18 @@ class TestDecoding:
         assert meta["photometric_interpretation"] == "YBR_FULL_422"
 
 
+@pytest.fixture()
+def enable_debugging():
+    original = config.debugging
+    config.debugging = True
+    yield
+    config.debugging = original
+
+
 @pytest.mark.skipif(SKIP_TEST, reason="Test is missing dependencies")
-def test_version_check(caplog):
+def test_version_check(enable_debugging, caplog):
     """Test _passes_version_check() when the package has no __version__"""
     # GDCM doesn't have a __version__ attribute
-    with caplog.at_level(logging.ERROR, logger="pydicom"):
+    with caplog.at_level(logging.WARNING, logger="pydicom"):
         assert _passes_version_check("gdcm", (3, 0)) is False
         assert "module 'gdcm' has no attribute '__version__'" in caplog.text

--- a/tests/pixels/test_decoder_gdcm.py
+++ b/tests/pixels/test_decoder_gdcm.py
@@ -251,6 +251,6 @@ def enable_debugging():
 def test_version_check(enable_debugging, caplog):
     """Test _passes_version_check() when the package has no __version__"""
     # GDCM doesn't have a __version__ attribute
-    with caplog.at_level(logging.WARNING, logger="pydicom"):
+    with caplog.at_level(logging.DEBUG, logger="pydicom"):
         assert _passes_version_check("gdcm", (3, 0)) is False
         assert "module 'gdcm' has no attribute '__version__'" in caplog.text

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -479,11 +479,26 @@ class TestIterPixels:
             next(iter_pixels(b))
 
 
-def test_version_check(caplog):
-    """Test _passes_version_check() when the package is absent"""
-    with caplog.at_level(logging.ERROR, logger="pydicom"):
+@pytest.fixture()
+def enable_debugging():
+    original = config.debugging
+    config.debugging = True
+    yield
+    config.debugging = original
+
+
+def test_version_check_debugging(enable_debugging, caplog):
+    """Test _passes_version_check() when the package is absent and debugging on"""
+    with caplog.at_level(logging.WARNING, logger="pydicom"):
         assert _passes_version_check("foo", (3, 0)) is False
         assert "No module named 'foo'" in caplog.text
+
+
+def test_version_check_no_debugging(caplog):
+    """Test _passes_version_check() when the package is absent and debugging off"""
+    with caplog.at_level(logging.WARNING, logger="pydicom"):
+        assert _passes_version_check("foo", (3, 0)) is False
+        assert not caplog.text
 
 
 class TestGetJpgParameters:

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -489,14 +489,14 @@ def enable_debugging():
 
 def test_version_check_debugging(enable_debugging, caplog):
     """Test _passes_version_check() when the package is absent and debugging on"""
-    with caplog.at_level(logging.WARNING, logger="pydicom"):
+    with caplog.at_level(logging.DEBUG, logger="pydicom"):
         assert _passes_version_check("foo", (3, 0)) is False
         assert "No module named 'foo'" in caplog.text
 
 
 def test_version_check_no_debugging(caplog):
     """Test _passes_version_check() when the package is absent and debugging off"""
-    with caplog.at_level(logging.WARNING, logger="pydicom"):
+    with caplog.at_level(logging.DEBUG, logger="pydicom"):
         assert _passes_version_check("foo", (3, 0)) is False
         assert not caplog.text
 

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -479,26 +479,11 @@ class TestIterPixels:
             next(iter_pixels(b))
 
 
-@pytest.fixture()
-def enable_debugging():
-    original = config.debugging
-    config.debugging = True
-    yield
-    config.debugging = original
-
-
-def test_version_check_debugging(enable_debugging, caplog):
+def test_version_check_debugging(caplog):
     """Test _passes_version_check() when the package is absent and debugging on"""
     with caplog.at_level(logging.DEBUG, logger="pydicom"):
         assert _passes_version_check("foo", (3, 0)) is False
         assert "No module named 'foo'" in caplog.text
-
-
-def test_version_check_no_debugging(caplog):
-    """Test _passes_version_check() when the package is absent and debugging off"""
-    with caplog.at_level(logging.DEBUG, logger="pydicom"):
-        assert _passes_version_check("foo", (3, 0)) is False
-        assert not caplog.text
 
 
 class TestGetJpgParameters:


### PR DESCRIPTION
#### Describe the changes
* Setup debugging/logging earlier to avoid having it undefined during import process
* Reduces the amount of logging when `pixels` plugin imports are missing.
* Closes #2128

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
- [x] Unit tests passing and overall coverage the same or better
