### PR TITLE
[MRG] Fix single bit native decoding for images with non byte-aligned frames

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -9,3 +9,4 @@ Fixes
 * Fixed an invalid VR value in the private data dictionary (:issue:`2132`).
 * Fixed checking for *Bits Stored* when converting *Float Pixel Data* and *Double Float
   Pixel Data* using the :mod:`~pydicom.pixels` backend (:issue:`2135`).
+* Fixed decoding of pixel data for images with *Bits Stored* of 1 when frame boundaries are not aligned with byte boundaries (:issue:`2134`).

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -9,4 +9,4 @@ Fixes
 * Fixed an invalid VR value in the private data dictionary (:issue:`2132`).
 * Fixed checking for *Bits Stored* when converting *Float Pixel Data* and *Double Float
   Pixel Data* using the :mod:`~pydicom.pixels` backend (:issue:`2135`).
-* Fixed decoding of pixel data for images with *Bits Stored* of 1 when frame boundaries are not aligned with byte boundaries (:issue:`2134`).
+* Fixed decoding of pixel data for images with *Bits Allocated* of 1 when frame boundaries are not aligned with byte boundaries (:issue:`2134`).

--- a/src/pydicom/data/hashes.json
+++ b/src/pydicom/data/hashes.json
@@ -76,5 +76,6 @@
   "JLSL_08_07_0_1F.dcm": "308fb028c8fbdd1e9a93e731978ea4da6b15cb55b40451cf6f21e7c9ba35dd8a",
   "JLSL_16_15_1_1F.dcm": "61f38f250a7dc82c44529c0face2eeab3ffd02ca8b9dfc756dd818eb252104b6",
   "parametric_map_float.dcm": "957f34397c26d82f7a90cad7a653ce0f7238f4be6aa9dfa9a33bae5dc2ce7e23",
-  "parametric_map_double_float.dcm": "a41e0b78b05e543a2448e22435858f9ca8d5f94807d7b391b93b4bca80e23a22"
+  "parametric_map_double_float.dcm": "a41e0b78b05e543a2448e22435858f9ca8d5f94807d7b391b93b4bca80e23a22",
+  "liver_nonbyte_aligned.dcm": "530c6af2a2a0caa6033d99ad407fe1f6e3942c64a8fcfc5649d4d06c26473862"
 }

--- a/src/pydicom/data/urls.json
+++ b/src/pydicom/data/urls.json
@@ -21,6 +21,7 @@
     "JPGLosslessP14SV1_1s_1f_8b.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/JPGLosslessP14SV1_1s_1f_8b.dcm",
     "liver.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/liver.dcm",
     "liver_expb.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/liver_expb.dcm",
+    "liver_nonbyte_aligned.dcm": "https://github.com/pydicom/pydicom-data/raw/6cd879296e76a546de6c51438bcb6dfa5d0210c6/data/liver_nonbyte_aligned.dcm",
     "mlut_18.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/mlut_18.dcm",
     "MR-SIEMENS-DICOM-WithOverlays.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/MR-SIEMENS-DICOM-WithOverlays.dcm",
     "MR2_J2KI.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/MR2_J2KI.dcm",

--- a/src/pydicom/data/urls.json
+++ b/src/pydicom/data/urls.json
@@ -21,7 +21,7 @@
     "JPGLosslessP14SV1_1s_1f_8b.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/JPGLosslessP14SV1_1s_1f_8b.dcm",
     "liver.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/liver.dcm",
     "liver_expb.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/liver_expb.dcm",
-    "liver_nonbyte_aligned.dcm": "https://github.com/pydicom/pydicom-data/raw/8da482f208401d63cd63f3f4efc41b6856ef36c7/data/liver_nonbyte_aligned.dcm",
+    "liver_nonbyte_aligned.dcm": "https://github.com/pydicom/pydicom-data/raw/8da482f208401d63cd63f3f4efc41b6856ef36c7/data_store/data/liver_nonbyte_aligned.dcm",
     "mlut_18.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/mlut_18.dcm",
     "MR-SIEMENS-DICOM-WithOverlays.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/MR-SIEMENS-DICOM-WithOverlays.dcm",
     "MR2_J2KI.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/MR2_J2KI.dcm",

--- a/src/pydicom/data/urls.json
+++ b/src/pydicom/data/urls.json
@@ -21,7 +21,7 @@
     "JPGLosslessP14SV1_1s_1f_8b.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/JPGLosslessP14SV1_1s_1f_8b.dcm",
     "liver.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/liver.dcm",
     "liver_expb.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/liver_expb.dcm",
-    "liver_nonbyte_aligned.dcm": "https://github.com/pydicom/pydicom-data/raw/6cd879296e76a546de6c51438bcb6dfa5d0210c6/data/liver_nonbyte_aligned.dcm",
+    "liver_nonbyte_aligned.dcm": "https://github.com/pydicom/pydicom-data/raw/8da482f208401d63cd63f3f4efc41b6856ef36c7/data/liver_nonbyte_aligned.dcm",
     "mlut_18.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/mlut_18.dcm",
     "MR-SIEMENS-DICOM-WithOverlays.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/MR-SIEMENS-DICOM-WithOverlays.dcm",
     "MR2_J2KI.dcm": "https://github.com/pydicom/pydicom-data/raw/39a2eb31815eec435dc26c322c27aec5cfcbddb6/data/MR2_J2KI.dcm",

--- a/src/pydicom/pixels/common.py
+++ b/src/pydicom/pixels/common.py
@@ -379,7 +379,7 @@ class RunnerBase:
             "bytes", a float will be returned for images with BitsAllocated of
             1 whose frames do not consist of a whole number of bytes.
         """
-        length = self.rows * self.columns * self.samples_per_pixel
+        length: int | float = self.rows * self.columns * self.samples_per_pixel
 
         if unit == "pixels":
             return length

--- a/src/pydicom/pixels/common.py
+++ b/src/pydicom/pixels/common.py
@@ -372,10 +372,12 @@ class RunnerBase:
 
         Returns
         -------
-        int
-            The expected length of a single frame of pixel data in either
-            whole bytes or pixels, excluding the NULL trailing padding byte
-            for odd length data.
+        int | float
+            The expected length of a single frame of pixel data in either whole
+            bytes or pixels, excluding the NULL trailing padding byte for odd
+            length data. For "pixels", an integer will always be returned. For
+            "bytes", a float will be returned for images with BitsAllocated of
+            1 whose frames do not consist of a whole number of bytes.
         """
         length = self.rows * self.columns * self.samples_per_pixel
 

--- a/src/pydicom/pixels/common.py
+++ b/src/pydicom/pixels/common.py
@@ -357,7 +357,7 @@ class RunnerBase:
         """
         return self._opts.get("extended_offsets", None)
 
-    def frame_length(self, unit: str = "bytes") -> int:
+    def frame_length(self, unit: str = "bytes") -> int | float:
         """Return the expected length (in number of bytes or pixels) of each
         frame of pixel data.
 
@@ -384,10 +384,18 @@ class RunnerBase:
 
         # Correct for the number of bytes per pixel
         if self.bits_allocated == 1:
-            # Determine the nearest whole number of bytes needed to contain
-            #   1-bit pixel data. e.g. 10 x 10 1-bit pixels is 100 bits, which
-            #   are packed into 12.5 -> 13 bytes
-            length = length // 8 + (length % 8 > 0)
+            if self.transfer_syntax.is_encapsulated:
+                # Determine the nearest whole number of bytes needed to contain
+                # 1-bit pixel data. e.g. 10 x 10 1-bit pixels is 100 bits,
+                # which are packed into 12.5 -> 13 bytes
+                length = length // 8 + (length % 8 > 0)
+            else:
+                # For native, "bit-packed" pixel data, frames are not padded so
+                # this may not be a whole number of bytes e.g. 10x10 = 100
+                # pixels images are packed into 12.5 bytes
+                length = length / 8
+                if length.is_integer():
+                    length = int(length)
         else:
             length *= self.bits_allocated // 8
 

--- a/src/pydicom/pixels/encoders/base.py
+++ b/src/pydicom/pixels/encoders/base.py
@@ -175,12 +175,12 @@ class EncodeRunner(RunnerBase):
         #    8 < precision <= 16: a 16-bit container (short)
         #   16 < precision <= 32: a 32-bit container (int/long)
         #   32 < precision <= 64: a 64-bit container (long long)
-        bytes_per_frame = self.frame_length(unit="bytes")
+        bytes_per_frame = cast(int, self.frame_length(unit="bytes"))
         start = 0 if index is None else index * bytes_per_frame
         src = cast(bytes, self.src[start : start + bytes_per_frame])
 
         # Resize the data to fit the appropriate container
-        expected_length = self.frame_length(unit="pixels")
+        expected_length = cast(int, self.frame_length(unit="pixels"))
         bytes_per_pixel = len(src) // expected_length
 
         # 1 byte/px actual

--- a/tests/pixels/pixels_reference.py
+++ b/tests/pixels/pixels_reference.py
@@ -201,7 +201,7 @@ def test(ref, arr, **kwargs):
 EXPL_1_1_3F = PixelReference("liver.dcm", "u1", test)
 
 
-# Same image cropped from 512 x 512 to 510 x 510 such that frame boundaries are
+# Same image cropped from 512 x 512 to 510 x 511 such that frame boundaries are
 # no longer aligned with byte boundaries
 EXPL_1_1_3F_NONALIGNED = PixelReference("liver_seg_nonbyte_aligned.dcm", "u1", test)
 

--- a/tests/pixels/pixels_reference.py
+++ b/tests/pixels/pixels_reference.py
@@ -203,7 +203,7 @@ EXPL_1_1_3F = PixelReference("liver.dcm", "u1", test)
 
 # Same image cropped from 512 x 512 to 510 x 511 such that frame boundaries are
 # no longer aligned with byte boundaries
-EXPL_1_1_3F_NONALIGNED = PixelReference("liver_seg_nonbyte_aligned.dcm", "u1", test)
+EXPL_1_1_3F_NONALIGNED = PixelReference("liver_nonbyte_aligned.dcm", "u1", test)
 
 
 # DEFL, (8, 8), (1, 512, 512, 1), OB, MONOCHROME2, 0

--- a/tests/pixels/pixels_reference.py
+++ b/tests/pixels/pixels_reference.py
@@ -187,7 +187,7 @@ def test(ref, arr, **kwargs):
     # Frame 3
     if index in (None, 2):
         frame = arr if index == 2 else arr[2]
-        assert 0 == frame[511][511]
+        assert 0 == frame[-1][-1]
         assert 0 == frame[147, :249].max()
         assert (0, 1, 0, 1, 1, 1) == tuple(frame[147, 248:254])
         assert (1, 0, 1, 0, 1, 1) == tuple(frame[147, 260:266])
@@ -199,6 +199,11 @@ def test(ref, arr, **kwargs):
 
 
 EXPL_1_1_3F = PixelReference("liver.dcm", "u1", test)
+
+
+# Same image cropped from 512 x 512 to 510 x 510 such that frame boundaries are
+# no longer aligned with byte boundaries
+EXPL_1_1_3F_NONALIGNED = PixelReference("liver_seg_nonbyte_aligned.dcm", "u1", test)
 
 
 # DEFL, (8, 8), (1, 512, 512, 1), OB, MONOCHROME2, 0
@@ -629,6 +634,7 @@ EXPL_64_1F_DOUBLE_FLOAT = PixelReference("parametric_map_double_float.dcm", "<f8
 PIXEL_REFERENCE[ExplicitVRLittleEndian] = [
     EXPL_1_1_1F,
     EXPL_1_1_3F,
+    EXPL_1_1_3F_NONALIGNED,
     EXPL_8_1_1F,
     EXPL_8_1_2F,
     EXPL_8_3_1F,

--- a/tests/pixels/test_common.py
+++ b/tests/pixels/test_common.py
@@ -22,33 +22,33 @@ from .pixels_reference import RLE_16_1_10F, EXPL_8_3_1F_YBR
 
 
 REFERENCE_FRAME_LENGTHS = [
-    # (rows, cols, samples), bit depth, result in (bytes, pixels, ybr_bytes)
+    # (rows, cols, samples), bit depth, result in (bytes (native), bytes(encapsulated), pixels, ybr_bytes)
     # YBR can only be 3 samples/px and > 1 bit depth
-    ((0, 0, 0), 1, (0, 0, None)),
-    ((1, 1, 1), 1, (1, 1, None)),  # 1 bit -> 1 byte
-    ((1, 1, 3), 1, (1, 3, None)),  # 3 bits -> 1 byte
-    ((1, 3, 3), 1, (2, 9, None)),  # 9 bits -> 2 bytes
-    ((2, 2, 1), 1, (1, 4, None)),  # 4 bits -> 1 byte
-    ((2, 4, 1), 1, (1, 8, None)),  # 8 bits -> 1 byte
-    ((3, 3, 1), 1, (2, 9, None)),  # 9 bits -> 2 bytes
-    ((512, 512, 1), 1, (32768, 262144, None)),  # Typical length
-    ((512, 512, 3), 1, (98304, 786432, None)),
-    ((0, 0, 0), 8, (0, 0, None)),
-    ((1, 1, 1), 8, (1, 1, None)),  # Odd length
-    ((9, 1, 1), 8, (9, 9, None)),  # Odd length
-    ((1, 2, 1), 8, (2, 2, None)),  # Even length
-    ((512, 512, 1), 8, (262144, 262144, None)),
-    ((512, 512, 3), 8, (786432, 786432, 524288)),
-    ((0, 0, 0), 16, (0, 0, None)),
-    ((1, 1, 1), 16, (2, 1, None)),  # 16 bit data can't be odd length
-    ((1, 2, 1), 16, (4, 2, None)),
-    ((512, 512, 1), 16, (524288, 262144, None)),
-    ((512, 512, 3), 16, (1572864, 786432, 1048576)),
-    ((0, 0, 0), 32, (0, 0, None)),
-    ((1, 1, 1), 32, (4, 1, None)),  # 32 bit data can't be odd length
-    ((1, 2, 1), 32, (8, 2, None)),
-    ((512, 512, 1), 32, (1048576, 262144, None)),
-    ((512, 512, 3), 32, (3145728, 786432, 2097152)),
+    ((0, 0, 0), 1, (0, 0, 0, None)),
+    ((1, 1, 1), 1, (0.125, 1, 1, None)),  # 1 bit -> 1/8 byte
+    ((1, 1, 3), 1, (0.375, 1, 3, None)),  # 3 bits -> 3/8 byte
+    ((1, 3, 3), 1, (1.125, 2, 9, None)),  # 9 bits -> 1 1/8 bytes
+    ((2, 2, 1), 1, (0.5, 1, 4, None)),  # 4 bits -> 1/2 byte
+    ((2, 4, 1), 1, (1, 1, 8, None)),  # 8 bits -> 1 byte
+    ((3, 3, 1), 1, (1.125, 2, 9, None)),  # 9 bits -> 1 1/8 bytes
+    ((512, 512, 1), 1, (32768, 32768, 262144, None)),  # Typical length
+    ((512, 512, 3), 1, (98304, 98304, 786432, None)),
+    ((0, 0, 0), 8, (0, 0, 0, None)),
+    ((1, 1, 1), 8, (1, 1, 1, None)),  # Odd length
+    ((9, 1, 1), 8, (9, 9, 9, None)),  # Odd length
+    ((1, 2, 1), 8, (2, 2, 2, None)),  # Even length
+    ((512, 512, 1), 8, (262144, 262144, 262144, None)),
+    ((512, 512, 3), 8, (786432, 786432, 786432, 524288)),
+    ((0, 0, 0), 16, (0, 0, 0, None)),
+    ((1, 1, 1), 16, (2, 2, 1, None)),  # 16 bit data can't be odd length
+    ((1, 2, 1), 16, (4, 4, 2, None)),
+    ((512, 512, 1), 16, (524288, 524288, 262144, None)),
+    ((512, 512, 3), 16, (1572864, 1572864, 786432, 1048576)),
+    ((0, 0, 0), 32, (0, 0, 0, None)),
+    ((1, 1, 1), 32, (4, 4, 1, None)),  # 32 bit data can't be odd length
+    ((1, 2, 1), 32, (8, 8, 2, None)),
+    ((512, 512, 1), 32, (1048576, 1048576, 262144, None)),
+    ((512, 512, 3), 32, (3145728, 3145728, 786432, 2097152)),
 ]
 
 
@@ -443,15 +443,15 @@ class TestRunnerBase:
         encaps_runner.set_options(**opts)
 
         assert length[0] == native_runner.frame_length(unit="bytes")
-        assert length[1] == native_runner.frame_length(unit="pixels")
-        assert length[0] == encaps_runner.frame_length(unit="bytes")
-        assert length[1] == encaps_runner.frame_length(unit="pixels")
+        assert length[2] == native_runner.frame_length(unit="pixels")
+        assert length[1] == encaps_runner.frame_length(unit="bytes")
+        assert length[2] == encaps_runner.frame_length(unit="pixels")
 
         if shape[2] == 3 and bits != 1:
             native_runner.set_option("photometric_interpretation", PI.YBR_FULL_422)
             encaps_runner.set_option("photometric_interpretation", PI.YBR_FULL_422)
-            assert length[2] == native_runner.frame_length(unit="bytes")
-            assert length[0] == encaps_runner.frame_length(unit="bytes")
+            assert length[3] == native_runner.frame_length(unit="bytes")
+            assert length[1] == encaps_runner.frame_length(unit="bytes")
 
 
 class TestCoderBase:

--- a/tests/pixels/test_decoder_base.py
+++ b/tests/pixels/test_decoder_base.py
@@ -1639,9 +1639,9 @@ class TestDecoder_Buffer:
         assert decoder.is_available
 
         reference = EXPL_1_1_3F_NONALIGNED
-        buffer, _ = decoder.as_buffer(reference.ds)
+        full_buffer, _ = decoder.as_buffer(reference.ds)
 
-        expected_len = ceil(
+        full_len = ceil(
             (
                 reference.ds.Rows
                 * reference.ds.Columns
@@ -1650,14 +1650,17 @@ class TestDecoder_Buffer:
             )
             / 8
         )
-        assert len(buffer) == expected_len
+        assert len(full_buffer) == full_len
 
-        msg = (
-            "Cannot return a buffer for individual frames since frame "
-            "boundaries do not align with byte boundaries."
+        # When requesting a single frame, the returned buffer will contain some
+        # pixels from neighnoring frames
+        frame_1_buffer, _ = decoder.as_buffer(reference.ds, index=1)
+
+        frame_length_pixels = reference.ds.Rows * reference.ds.Columns
+        assert (
+            frame_1_buffer
+            == full_buffer[frame_length_pixels // 8 : ceil(2 * frame_length_pixels / 8)]
         )
-        with pytest.raises(RuntimeError, match=msg):
-            decoder.as_buffer(reference.ds, index=1)
 
     def test_encapsulated_index(self):
         """Test `index` with an encapsulated pixel data."""

--- a/tests/pixels/test_decoder_base.py
+++ b/tests/pixels/test_decoder_base.py
@@ -1643,11 +1643,12 @@ class TestDecoder_Buffer:
 
         expected_len = ceil(
             (
-                reference.ds.Rows *
-                reference.ds.Columns *
-                reference.ds.SamplesPerPixel *
-                reference.ds.NumberOfFrames
-            ) / 8
+                reference.ds.Rows
+                * reference.ds.Columns
+                * reference.ds.SamplesPerPixel
+                * reference.ds.NumberOfFrames
+            )
+            / 8
         )
         assert len(buffer) == expected_len
 

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -77,6 +77,7 @@ from .pixels_reference import (
     JLSN_08_01_1_0_1F,
     J2KR_08_08_3_0_1F_YBR_RCT,
     EXPL_1_1_3F,
+    EXPL_1_1_3F_NONALIGNED,
 )
 from ..test_helpers import assert_no_warning
 
@@ -1381,6 +1382,13 @@ class TestPackBits:
     def test_functional(self):
         """Test against a real dataset."""
         ds = EXPL_1_1_3F.ds
+        arr = ds.pixel_array
+        arr = arr.ravel()
+        assert ds.PixelData == pack_bits(arr)
+
+    def test_functional_nonaligned(self):
+        """Test against a real dataset."""
+        ds = EXPL_1_1_3F_NONALIGNED.ds
         arr = ds.pixel_array
         arr = arr.ravel()
         assert ds.PixelData == pack_bits(arr)


### PR DESCRIPTION
#### Describe the changes

Address #2134 by:
- Changing the `RunnerBase.frame_length()` method to return a float for the `"bytes"` option in the situation that a frame has a length that is not a multiple of 8.
- Change `DecoderBase._validate_buffer()` method to calculate the expected length accounting for non byte-aligned frames, thus allowing correct decoding of these images.
- Change the `Decoder._as_array_native()` method to account for non byte-aligned frames. Also give `Decoder._as_buffer_native()` the same treatment, however in this case it is not clear what the correct behaviour should be if the caller requests a single frame index for an image with non-byte aligned frames, since any returned `bytes` could include pixels from neighbouring frames. Therefore I just throw a `RuntimeError` in this situation. If the number of pixels is a multiple of 8, or the caller requests the entire image (not just a single frame) everything behaves as expected.
- Add various tests for the above, mostly using a new test image that is included in [this](https://github.com/pydicom/pydicom-data/pull/15) pull request for pydicom-data. I think that will need to be merged before tests pass on this PR.
- Update the `urls.json` with the aforementioned test image.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
