### PR TITLE
[MRG] `set_pixel_data` with boolean array for bit-packing

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+pydicom

--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,0 @@
-pydicom

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -10,4 +10,7 @@ Fixes
 * Fixed checking for *Bits Stored* when converting *Float Pixel Data* and *Double Float
   Pixel Data* using the :mod:`~pydicom.pixels` backend (:issue:`2135`).
 * Fixed decoding of pixel data for images with *Bits Allocated* of 1 when frame boundaries are not aligned with byte boundaries (:issue:`2134`).
-* Add option to pass array of dtype `bool` to `set_pixel_data` to store with *BitsAllocated* of (using bit-packing) (:issue:`2141`).
+
+Enhancements
+------------
+* Added the option to pass a ``bool`` ndarray to :func:`~pydicom.pixels.set_pixel_data` to store with *Bits Allocated* of ``1`` using bit-packing (:issue:`2141`).

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -10,3 +10,4 @@ Fixes
 * Fixed checking for *Bits Stored* when converting *Float Pixel Data* and *Double Float
   Pixel Data* using the :mod:`~pydicom.pixels` backend (:issue:`2135`).
 * Fixed decoding of pixel data for images with *Bits Allocated* of 1 when frame boundaries are not aligned with byte boundaries (:issue:`2134`).
+* Add option to pass array of dtype `bool` to `set_pixel_data` to store with *BitsAllocated* of (using bit-packing) (:issue:`2141`).

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2843,6 +2843,11 @@ class Dataset:
         * If a ``bool`` array is used then the pixel data will be bit-packed using
           :func:`~pydicom.pixels.pack_bits`.
 
+        .. versionchanged:: 3.1
+
+            Added the ability to use a ``bool`` ndarray for *Bits Allocated* ``1`` with
+            bit-packing.
+
         Parameters
         ----------
         arr : numpy.ndarray

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2840,6 +2840,8 @@ class Dataset:
           it doesn't already exist or uses a compressed (encapsulated) transfer syntax.
         * If `generate_instance_uid` is ``True`` (default) then the *SOP Instance UID*
           will be added or updated.
+        * If a ``bool`` array is used then the pixel data will be bit-packed using
+          :func:`~pydicom.pixels.pack_bits`.
 
         Parameters
         ----------

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -2844,8 +2844,8 @@ class Dataset:
         Parameters
         ----------
         arr : numpy.ndarray
-            An array with :class:`~numpy.dtype` uint8, uint16, int8 or int16. The
-            array must be shaped as one of the following:
+            An array with :class:`~numpy.dtype` bool, uint8, uint16, int8, or
+            int16. The array must be shaped as one of the following:
 
             * (rows, columns) for a single frame of grayscale data.
             * (frames, rows, columns) for multi-frame grayscale data.
@@ -2857,8 +2857,9 @@ class Dataset:
             values are ``"MONOCHROME1"``, ``"MONOCHROME2"``, ``"PALETTE COLOR"``,
             ``"RGB"``, ``"YBR_FULL"``, ``"YBR_FULL_422"``.
         bits_stored : int
-            The value to use for (0028,0101) *Bits Stored*. Must be no greater than
-            the number of bits used by the :attr:`~numpy.dtype.itemsize` of `arr`.
+            The value to use for (0028,0101) *Bits Stored*. Must be no greater
+            than the number of bits used by the :attr:`~numpy.dtype.itemsize`
+            of `arr`, or 1 in the case of an array of dtype bool.
         generate_instance_uid : bool, optional
             If ``True`` (default) then add or update the (0008,0018) *SOP Instance
             UID* element with a value generated using :func:`~pydicom.uid.generate_uid`.

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -1795,7 +1795,7 @@ def set_pixel_data(
     bits_stored : int
         The value to use for (0028,0101) *Bits Stored*. Must be no greater than
         the number of bits used by the :attr:`~numpy.dtype.itemsize` of `arr`,
-        or 1 in the case of an array of type bool.
+        or 1 in the case of an array of dtype bool.
     generate_instance_uid : bool, optional
         If ``True`` (default) then add or update the (0008,0018) *SOP Instance
         UID* element with a value generated using :func:`~pydicom.uid.generate_uid`.

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -1774,6 +1774,8 @@ def set_pixel_data(
       transfer syntax.
     * If `generate_instance_uid` is ``True`` (default) then the *SOP Instance UID*
       will be added or updated.
+    * If a ``bool`` array is used then the pixel data will be bit-packed using
+      :func:`~pydicom.pixels.pack_bits`.
 
     Parameters
     ----------
@@ -1928,10 +1930,7 @@ def set_pixel_data(
         arr = out
 
     # Update the Pixel Data
-    if bits_allocated == 1:
-        data = pack_bits(arr)
-    else:
-        data = arr.tobytes()
+    data = pack_bits(arr) if bits_allocated == 1 else arr.tobytes()
     ds.PixelData = data if len(data) % 2 == 0 else b"".join((data, b"\x00"))
     elem = ds["PixelData"]
     elem.VR = VR.OB if ds.BitsAllocated <= 8 else VR.OW

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -1777,6 +1777,11 @@ def set_pixel_data(
     * If a ``bool`` array is used then the pixel data will be bit-packed using
       :func:`~pydicom.pixels.pack_bits`.
 
+    .. versionchanged:: 3.1
+
+        Added the ability to use a ``bool`` ndarray for *Bits Allocated* ``1`` with
+        bit-packing.
+
     Parameters
     ----------
     ds : pydicom.dataset.Dataset


### PR DESCRIPTION
#### Describe the changes

Extends the `set_pixel_data` function (and hence also the corresponding method of the `Dataset` class) to accept numpy arrays with dtype of `bool`, and in this case uses bit-packing to set the array with *BitsAllocated* of 1. Implements as discussed in #2141.

I also added a tentative line to the release notes, however it seems the versioning there is out of sync with actual github/PyPI releases (features in 3.0.1 release are described in the document for upcoming 3.1.0 release).


#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
