### PR TITLE
[MRG] Fixes for pixel data handling using pyjpegls and pylibjpeg on big endian systems

### DIFF
--- a/src/pydicom/pixels/decoders/pillow.py
+++ b/src/pydicom/pixels/decoders/pillow.py
@@ -27,10 +27,10 @@ except ImportError:
 
 
 DECODER_DEPENDENCIES = {
-    uid.JPEGBaseline8Bit: ("pillow>=10.0",),
-    uid.JPEGExtended12Bit: ("pillow>=10.0",),
-    uid.JPEG2000Lossless: ("numpy", "pillow>=10.0"),
-    uid.JPEG2000: ("numpy", "pillow>=10.0"),
+    uid.JPEGBaseline8Bit: ("pillow>=10.3",),
+    uid.JPEGExtended12Bit: ("pillow>=10.3",),
+    uid.JPEG2000Lossless: ("numpy", "pillow>=10.3"),
+    uid.JPEG2000: ("numpy", "pillow>=10.3"),
 }
 
 _LIBJPEG_SYNTAXES = [uid.JPEGBaseline8Bit, uid.JPEGExtended12Bit]
@@ -41,7 +41,7 @@ def is_available(uid: str) -> bool:
     """Return ``True`` if a pixel data decoder for `uid` is available for use,
     ``False`` otherwise.
     """
-    if not _passes_version_check("PIL", (10, 0)):
+    if not _passes_version_check("PIL", (10, 3)):
         return False
 
     if uid in _LIBJPEG_SYNTAXES:

--- a/src/pydicom/pixels/decoders/pyjpegls.py
+++ b/src/pydicom/pixels/decoders/pyjpegls.py
@@ -18,14 +18,14 @@ except ImportError:
 
 
 DECODER_DEPENDENCIES = {
-    uid.JPEGLSLossless: ("numpy", "pyjpegls>=1.2"),
-    uid.JPEGLSNearLossless: ("numpy", "pyjpegls>=1.2"),
+    uid.JPEGLSLossless: ("numpy", "pyjpegls>=1.5"),
+    uid.JPEGLSNearLossless: ("numpy", "pyjpegls>=1.5"),
 }
 
 
 def is_available(uid: str) -> bool:
     """Return ``True`` if the decoder has its dependencies met, ``False`` otherwise"""
-    return _passes_version_check("jpeg_ls", (1, 2))
+    return _passes_version_check("jpeg_ls", (1, 5))
 
 
 def _decode_frame(src: bytes, runner: DecodeRunner) -> bytearray:

--- a/src/pydicom/pixels/decoders/pylibjpeg.py
+++ b/src/pydicom/pixels/decoders/pylibjpeg.py
@@ -24,17 +24,17 @@ except ImportError:
 
 
 DECODER_DEPENDENCIES = {
-    uid.JPEGBaseline8Bit: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.1"),
-    uid.JPEGExtended12Bit: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.1"),
-    uid.JPEGLossless: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.1"),
-    uid.JPEGLosslessSV1: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.1"),
-    uid.JPEGLSLossless: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.1"),
-    uid.JPEGLSNearLossless: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.1"),
-    uid.JPEG2000Lossless: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.0"),
-    uid.JPEG2000: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.0"),
-    uid.HTJ2KLossless: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.0"),
-    uid.HTJ2KLosslessRPCL: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.0"),
-    uid.HTJ2K: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.0"),
+    uid.JPEGBaseline8Bit: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.3"),
+    uid.JPEGExtended12Bit: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.3"),
+    uid.JPEGLossless: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.3"),
+    uid.JPEGLosslessSV1: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.3"),
+    uid.JPEGLSLossless: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.3"),
+    uid.JPEGLSNearLossless: ("pylibjpeg>=2.0", "pylibjpeg-libjpeg>=2.3"),
+    uid.JPEG2000Lossless: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.4"),
+    uid.JPEG2000: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.4"),
+    uid.HTJ2KLossless: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.4"),
+    uid.HTJ2KLosslessRPCL: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.4"),
+    uid.HTJ2K: ("pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.4"),
     uid.RLELossless: ("pylibjpeg>=2.0", "pylibjpeg-rle>=2.0"),
 }
 
@@ -62,10 +62,10 @@ def is_available(uid: str) -> bool:
         return False
 
     if uid in _LIBJPEG_SYNTAXES:
-        return _passes_version_check("libjpeg", (2, 0, 2))
+        return _passes_version_check("libjpeg", (2, 3))
 
     if uid in _OPENJPEG_SYNTAXES:
-        return _passes_version_check("openjpeg", (2, 0))
+        return _passes_version_check("openjpeg", (2, 4))
 
     if uid in _RLE_SYNTAXES:
         return _passes_version_check("rle", (2, 0))

--- a/src/pydicom/pixels/encoders/pyjpegls.py
+++ b/src/pydicom/pixels/encoders/pyjpegls.py
@@ -18,14 +18,14 @@ except ImportError:
 
 
 ENCODER_DEPENDENCIES = {
-    uid.JPEGLSLossless: ("numpy", "pyjpegls>=1.3"),
-    uid.JPEGLSNearLossless: ("numpy", "pyjpegls>=1.3"),
+    uid.JPEGLSLossless: ("numpy", "pyjpegls>=1.5"),
+    uid.JPEGLSNearLossless: ("numpy", "pyjpegls>=1.5"),
 }
 
 
 def is_available(uid: str) -> bool:
     """Return ``True`` if the decoder has its dependencies met, ``False`` otherwise"""
-    return _passes_version_check("jpeg_ls", (1, 3))
+    return _passes_version_check("jpeg_ls", (1, 5))
 
 
 def _encode_frame(src: bytes, runner: EncodeRunner) -> bytearray:

--- a/src/pydicom/pixels/encoders/pylibjpeg.py
+++ b/src/pydicom/pixels/encoders/pylibjpeg.py
@@ -17,8 +17,8 @@ except ImportError:
 
 
 ENCODER_DEPENDENCIES = {
-    uid.JPEG2000Lossless: ("numpy", "pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.2"),
-    uid.JPEG2000: ("numpy", "pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.2"),
+    uid.JPEG2000Lossless: ("numpy", "pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.4"),
+    uid.JPEG2000: ("numpy", "pylibjpeg>=2.0", "pylibjpeg-openjpeg>=2.4"),
     uid.RLELossless: ("numpy", "pylibjpeg>=2.0", "pylibjpeg-rle>=2.0"),
 }
 _OPENJPEG_SYNTAXES = [uid.JPEG2000Lossless, uid.JPEG2000]
@@ -33,7 +33,7 @@ def is_available(uid: str) -> bool:
         return False
 
     if uid in _OPENJPEG_SYNTAXES:
-        return _passes_version_check("openjpeg", (2, 2))
+        return _passes_version_check("openjpeg", (2, 4))
 
     if uid in _RLE_SYNTAXES:
         return _passes_version_check("rle", (2, 0))

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -1336,8 +1336,8 @@ def _passes_version_check(package_name: str, minimum_version: tuple[int, ...]) -
 
     try:
         module = importlib.import_module(package_name, "__version__")
-        version = module.__version__.split(".")[:len(minimum_version)]
-        return tuple(int(x) for x in version) >= minimum_version
+        available_version = module.__version__.split(".")[: len(minimum_version)]
+        return tuple(int(x) for x in available_version) >= minimum_version
     except Exception as exc:
         LOGGER.debug(exc)
 

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -1333,9 +1333,11 @@ def _passes_version_check(package_name: str, minimum_version: tuple[int, ...]) -
     """Return True if `package_name` is available and its version is greater or
     equal to `minimum_version`
     """
+
     try:
         module = importlib.import_module(package_name, "__version__")
-        return tuple(int(x) for x in module.__version__.split(".")) >= minimum_version
+        version = module.__version__.split(".")[:len(minimum_version)]
+        return tuple(int(x) for x in version) >= minimum_version
     except Exception as exc:
         LOGGER.debug(exc)
 

--- a/tests/pixels/test_decoder_pyjpegls.py
+++ b/tests/pixels/test_decoder_pyjpegls.py
@@ -61,7 +61,7 @@ class TestPyJpegLSDecoder:
         JLSN_08_01_1_0_1F.test(arr)
         assert arr.shape == JLSN_08_01_1_0_1F.shape
         assert arr.dtype != JLSN_08_01_1_0_1F.dtype
-        assert arr.dtype == np.uint16
+        assert arr.dtype == "<u2"
         assert arr.flags.writeable
         assert meta["bits_allocated"] == 16
         assert meta["bits_stored"] == 8

--- a/tests/pixels/test_decoder_pylibjpeg.py
+++ b/tests/pixels/test_decoder_pylibjpeg.py
@@ -155,7 +155,7 @@ class TestLibJpegDecoder:
         JLSN_08_01_1_0_1F.test(arr)
         assert arr.shape == JLSN_08_01_1_0_1F.shape
         assert arr.dtype != JLSN_08_01_1_0_1F.dtype
-        assert arr.dtype == np.uint16
+        assert arr.dtype == "<u2"
         assert arr.flags.writeable
         assert meta["bits_allocated"] == 16
         assert meta["bits_stored"] == 8
@@ -235,11 +235,11 @@ class TestLibJpegDecoder:
         decoder = get_decoder(JPEGLSLossless)
         buffer, meta = decoder.as_buffer(ds, decoding_plugin="pylibjpeg")
         assert meta["bits_allocated"] == 16
-        arr = np.frombuffer(buffer, dtype="u2")
+        arr = np.frombuffer(buffer, dtype="<u2")
         arr = arr.reshape(2, ds.Rows, ds.Columns)
         JLSL_08_07_1_0_1F.test(arr[0], plugin="pylibjpeg")
 
-        arr = arr.astype("i2")
+        arr = arr.astype("<i2")
         # Needs bit-shifting to convert values to signed
         np.left_shift(arr, 1, out=arr)
         np.right_shift(arr, 1, out=arr)

--- a/tests/pixels/test_encoder_pyjpegls.py
+++ b/tests/pixels/test_encoder_pyjpegls.py
@@ -43,7 +43,7 @@ class TestJpegLSLossless:
         arr = ds.pixel_array
 
         # Rescale to (0, 1)
-        arr = arr.astype("float32")
+        arr = arr.astype("<f4")
         arr -= arr.min()
         arr /= arr.max()
         self.ref = arr
@@ -51,7 +51,7 @@ class TestJpegLSLossless:
         ds = examples.rgb_color
         arr = ds.pixel_array
 
-        arr = arr.astype("float32")
+        arr = arr.astype("<f4")
         arr -= arr.min()
         arr /= arr.max()
         self.ref3 = arr
@@ -176,7 +176,7 @@ class TestJpegLSLossless:
         for bits_stored in range(2, 17):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEGLSLosslessEncoder.encode(ref, encoding_plugin="pyjpegls", **opts)
@@ -216,7 +216,7 @@ class TestJpegLSLossless:
         for bits_stored in range(2, 9):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEGLSLosslessEncoder.encode(ref, encoding_plugin="pyjpegls", **opts)
@@ -236,7 +236,7 @@ class TestJpegLSLossless:
         for bits_stored in range(2, 9):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEGLSLosslessEncoder.encode(ref, encoding_plugin="pyjpegls", **opts)
@@ -313,7 +313,7 @@ class TestJpegLSLossless:
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
             ref = ref.clip(-(2**15), 2**15 - 1)
-            ref = ref.astype("int16")
+            ref = ref.astype("<i2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEGLSLosslessEncoder.encode(ref, encoding_plugin="pyjpegls", **opts)
@@ -459,7 +459,7 @@ class TestJpegLSLossless:
         for bits_stored in range(2, 17):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 2
@@ -503,7 +503,7 @@ class TestJpegLSLossless:
         for bits_stored in range(2, 9):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 6
@@ -528,7 +528,7 @@ class TestJpegLSLossless:
         for bits_stored in range(2, 9):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEGLSLosslessEncoder.encode(ref, encoding_plugin="pyjpegls", **opts)
@@ -610,7 +610,7 @@ class TestJpegLSLossless:
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
             ref = ref.clip(-(2**15), 2**15 - 1)
-            ref = ref.astype("int16")
+            ref = ref.astype("<i2")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 2
@@ -669,7 +669,7 @@ class TestJpegLSNearLossless:
         arr = ds.pixel_array
 
         # Rescale to (0, 1)
-        arr = arr.astype("float32")
+        arr = arr.astype("<f4")
         arr -= arr.min()
         arr /= arr.max()
         self.ref = arr
@@ -677,7 +677,7 @@ class TestJpegLSNearLossless:
         ds = examples.rgb_color
         arr = ds.pixel_array
 
-        arr = arr.astype("float32")
+        arr = arr.astype("<f4")
         arr -= arr.min()
         arr /= arr.max()
         self.ref3 = arr
@@ -813,7 +813,7 @@ class TestJpegLSNearLossless:
         for bits_stored in range(2, 17):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEGLSNearLosslessEncoder.encode(
@@ -857,7 +857,7 @@ class TestJpegLSNearLossless:
         for bits_stored in range(2, 17):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEGLSNearLosslessEncoder.encode(
@@ -880,7 +880,7 @@ class TestJpegLSNearLossless:
         for bits_stored in range(2, 17):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEGLSNearLosslessEncoder.encode(
@@ -972,7 +972,7 @@ class TestJpegLSNearLossless:
             ref -= 2 ** (bits_stored - 1)
             # Clip within the min/max values for the given bits_stored
             ref = ref.clip(-(2 ** (bits_stored - 1)) + 1, 2 ** (bits_stored - 1) - 2)
-            ref = ref.astype("int16")
+            ref = ref.astype("<i2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEGLSNearLosslessEncoder.encode(
@@ -1132,7 +1132,7 @@ class TestJpegLSNearLossless:
         for bits_stored in range(2, 17):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 2
@@ -1179,7 +1179,7 @@ class TestJpegLSNearLossless:
         for bits_stored in range(2, 17):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 6
@@ -1205,7 +1205,7 @@ class TestJpegLSNearLossless:
         for bits_stored in range(2, 17):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEGLSNearLosslessEncoder.encode(
@@ -1300,7 +1300,7 @@ class TestJpegLSNearLossless:
             ref -= 2 ** (bits_stored - 1)
             # Clip within the min/max values for the given bits_stored
             ref = ref.clip(-(2 ** (bits_stored - 1)) + 1, 2 ** (bits_stored - 1) - 2)
-            ref = ref.astype("int16")
+            ref = ref.astype("<i2")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 2

--- a/tests/pixels/test_encoder_pylibjpeg.py
+++ b/tests/pixels/test_encoder_pylibjpeg.py
@@ -117,7 +117,7 @@ class TestJ2KLosslessEncoding:
         arr = ds.pixel_array
 
         # Rescale to (0, 1)
-        arr = arr.astype("float32")
+        arr = arr.astype("<f4")
         arr -= arr.min()
         arr /= arr.max()
         self.ref = arr
@@ -125,7 +125,7 @@ class TestJ2KLosslessEncoding:
         ds = dcmread(RGB)
         arr = ds.pixel_array
 
-        arr = arr.astype("float32")
+        arr = arr.astype("<f4")
         arr -= arr.min()
         arr /= arr.max()
         self.ref3 = arr
@@ -188,7 +188,7 @@ class TestJ2KLosslessEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000LosslessEncoder.encode(
@@ -223,21 +223,25 @@ class TestJ2KLosslessEncoding:
         if HAVE_GDCM:
             plugins.append("gdcm")
 
-        for bits_stored in range(1, 25):
+        for bits_stored in range(16, 25):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**24 - 1)
-            ref = ref.astype("uint32")
+            ref = ref.astype("<u4")
+            print(bits_stored, ref, ref.dtype, ref.min(), ref.max())
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000LosslessEncoder.encode(
                 ref, encoding_plugin="pylibjpeg", **opts
             )
+            with open(f"{bits_stored}.j2k", "wb") as f:
+                f.write(cs)
             for plugin in plugins:
                 out, _ = JPEG2000LosslessDecoder.as_array(
                     encapsulate([cs]),
                     decoding_plugin=plugin,
                     **opts,
                 )
+                print(out, out.dtype, out.min(), out.max())
                 assert np.array_equal(out, ref)
 
     def test_arr_u1_spp3(self):
@@ -298,7 +302,7 @@ class TestJ2KLosslessEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000LosslessEncoder.encode(
@@ -329,7 +333,7 @@ class TestJ2KLosslessEncoding:
         for bits_stored in range(1, 25):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**24 - 1)
-            ref = ref.astype("uint32")
+            ref = ref.astype("<u4")
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000LosslessEncoder.encode(
@@ -403,7 +407,7 @@ class TestJ2KLosslessEncoding:
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
             ref = ref.clip(-32768, 32767)
-            ref = ref.astype("int16")
+            ref = ref.astype("<i2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000LosslessEncoder.encode(
@@ -443,7 +447,7 @@ class TestJ2KLosslessEncoding:
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
             ref = ref.clip(-8388608, 8388607)
-            ref = ref.astype("int32")
+            ref = ref.astype("<i4")
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000LosslessEncoder.encode(
@@ -518,7 +522,7 @@ class TestJ2KLosslessEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 65535)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 2
@@ -554,7 +558,7 @@ class TestJ2KLosslessEncoding:
         for bits_stored in range(1, 25):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**24 - 1)
-            ref = ref.astype("uint32")
+            ref = ref.astype("<u4")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 4
@@ -631,7 +635,7 @@ class TestJ2KLosslessEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**16 - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 3 * 2
@@ -665,7 +669,7 @@ class TestJ2KLosslessEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**24 - 1)
-            ref = ref.astype("uint32")
+            ref = ref.astype("<u4")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 3 * 4
@@ -745,7 +749,7 @@ class TestJ2KLosslessEncoding:
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
             ref = ref.clip(-(2**15), 2**15 - 1)
-            ref = ref.astype("int16")
+            ref = ref.astype("<i2")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 2
@@ -783,7 +787,7 @@ class TestJ2KLosslessEncoding:
             ref = self.ref * (2**bits_stored - 1)
             ref -= 2 ** (bits_stored - 1)
             ref = ref.clip(-(2**23), 2**23 - 1)
-            ref = ref.astype("int32")
+            ref = ref.astype("<i4")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 4
@@ -889,7 +893,7 @@ class TestJ2KEncoding:
         arr = ds.pixel_array
 
         # Rescale to (0, 1)
-        arr = arr.astype("float32")
+        arr = arr.astype("<f4")
         arr -= arr.min()
         arr /= arr.max()
         self.ref = arr
@@ -897,7 +901,7 @@ class TestJ2KEncoding:
         ds = dcmread(RGB)
         arr = ds.pixel_array
 
-        arr = arr.astype("float32")
+        arr = arr.astype("<f4")
         arr -= arr.min()
         arr /= arr.max()
         self.ref3 = arr
@@ -961,7 +965,7 @@ class TestJ2KEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**bits_stored - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000Encoder.encode(ref, encoding_plugin="pylibjpeg", **opts)
@@ -998,7 +1002,7 @@ class TestJ2KEncoding:
         for bits_stored, atol in zip(range(1, 20), atols):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**bits_stored - 1)
-            ref = ref.astype("uint32")
+            ref = ref.astype("<u4")
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000Encoder.encode(ref, encoding_plugin="pylibjpeg", **opts)
@@ -1069,7 +1073,7 @@ class TestJ2KEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**bits_stored - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000Encoder.encode(ref, encoding_plugin="pylibjpeg", **opts)
@@ -1103,7 +1107,7 @@ class TestJ2KEncoding:
         for bits_stored, atol in zip(range(1, 20), atols):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**bits_stored - 1)
-            ref = ref.astype("uint32")
+            ref = ref.astype("<u4")
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000Encoder.encode(ref, encoding_plugin="pylibjpeg", **opts)
@@ -1181,7 +1185,7 @@ class TestJ2KEncoding:
             minimum = -(2 ** (bits_stored - 1))
             maximum = 2 ** (bits_stored - 1) - 1
             ref = ref.clip(minimum, maximum)
-            ref = ref.astype("int16")
+            ref = ref.astype("<i2")
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000Encoder.encode(ref, encoding_plugin="pylibjpeg", **opts)
@@ -1222,7 +1226,7 @@ class TestJ2KEncoding:
             minimum = -(2 ** (bits_stored - 1))
             maximum = 2 ** (bits_stored - 1) - 1
             ref = ref.clip(minimum, maximum)
-            ref = ref.astype("int32")
+            ref = ref.astype("<i4")
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000Encoder.encode(ref, encoding_plugin="pylibjpeg", **opts)
@@ -1296,7 +1300,7 @@ class TestJ2KEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**bits_stored - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 2
@@ -1335,7 +1339,7 @@ class TestJ2KEncoding:
         for bits_stored, atol in zip(range(1, 21), atols):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**bits_stored - 1)
-            ref = ref.astype("uint32")
+            ref = ref.astype("<u4")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 4
@@ -1412,7 +1416,7 @@ class TestJ2KEncoding:
         for bits_stored in range(1, 17):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**bits_stored - 1)
-            ref = ref.astype("uint16")
+            ref = ref.astype("<u2")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 3 * 2
@@ -1449,7 +1453,7 @@ class TestJ2KEncoding:
         for bits_stored, atol in zip(range(1, 20), atols):
             ref = self.ref3 * (2**bits_stored - 1)
             ref = ref.clip(0, 2**bits_stored - 1)
-            ref = ref.astype("uint32")
+            ref = ref.astype("<u4")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 3 * 4
@@ -1534,7 +1538,7 @@ class TestJ2KEncoding:
             minimum = -(2 ** (bits_stored - 1))
             maximum = 2 ** (bits_stored - 1) - 1
             ref = ref.clip(minimum, maximum)
-            ref = ref.astype("int16")
+            ref = ref.astype("<i2")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 2
@@ -1577,7 +1581,7 @@ class TestJ2KEncoding:
             minimum = -(2 ** (bits_stored - 1))
             maximum = 2 ** (bits_stored - 1) - 1
             ref = ref.clip(minimum, maximum)
-            ref = ref.astype("int32")
+            ref = ref.astype("<i4")
 
             buffer = ref.tobytes()
             assert len(buffer) == ds.Rows * ds.Columns * 4

--- a/tests/pixels/test_encoder_pylibjpeg.py
+++ b/tests/pixels/test_encoder_pylibjpeg.py
@@ -219,7 +219,7 @@ class TestJ2KLosslessEncoding:
         if HAVE_GDCM:
             plugins.append("gdcm")
 
-        for bits_stored in range(16, 25):
+        for bits_stored in range(1, 25):
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**24 - 1)
             ref = ref.astype("<u4")

--- a/tests/pixels/test_encoder_pylibjpeg.py
+++ b/tests/pixels/test_encoder_pylibjpeg.py
@@ -196,10 +196,6 @@ class TestJ2KLosslessEncoding:
             )
 
             for plugin in plugins:
-                # Pillow doesn't decode 9-bit J2K correctly
-                if plugin == "pillow" and bits_stored == 9:
-                    continue
-
                 out, _ = JPEG2000LosslessDecoder.as_array(
                     encapsulate([cs]),
                     decoding_plugin=plugin,
@@ -227,21 +223,17 @@ class TestJ2KLosslessEncoding:
             ref = self.ref * (2**bits_stored - 1)
             ref = ref.clip(0, 2**24 - 1)
             ref = ref.astype("<u4")
-            print(bits_stored, ref, ref.dtype, ref.min(), ref.max())
 
             opts["bits_stored"] = bits_stored
             cs = JPEG2000LosslessEncoder.encode(
                 ref, encoding_plugin="pylibjpeg", **opts
             )
-            with open(f"{bits_stored}.j2k", "wb") as f:
-                f.write(cs)
             for plugin in plugins:
                 out, _ = JPEG2000LosslessDecoder.as_array(
                     encapsulate([cs]),
                     decoding_plugin=plugin,
                     **opts,
                 )
-                print(out, out.dtype, out.min(), out.max())
                 assert np.array_equal(out, ref)
 
     def test_arr_u1_spp3(self):
@@ -415,10 +407,6 @@ class TestJ2KLosslessEncoding:
             )
 
             for plugin in plugins:
-                # Pillow doesn't decode 9-bit J2K correctly
-                if plugin == "pillow" and bits_stored == 9:
-                    continue
-
                 out, _ = JPEG2000LosslessDecoder.as_array(
                     encapsulate([cs]),
                     decoding_plugin=plugin,
@@ -532,9 +520,6 @@ class TestJ2KLosslessEncoding:
                 buffer, encoding_plugin="pylibjpeg", **opts
             )
             for plugin in plugins:
-                if plugin == "pillow" and bits_stored == 9:
-                    continue
-
                 out, _ = JPEG2000LosslessDecoder.as_array(
                     encapsulate([cs]),
                     decoding_plugin=plugin,
@@ -760,9 +745,6 @@ class TestJ2KLosslessEncoding:
             )
 
             for plugin in plugins:
-                if plugin == "pillow" and bits_stored == 9:
-                    continue
-
                 out, _ = JPEG2000LosslessDecoder.as_array(
                     encapsulate([cs]),
                     decoding_plugin=plugin,
@@ -971,10 +953,6 @@ class TestJ2KEncoding:
             cs = JPEG2000Encoder.encode(ref, encoding_plugin="pylibjpeg", **opts)
 
             for plugin in plugins:
-                # Pillow doesn't decode 9-bit J2K correctly
-                if plugin == "pillow" and bits_stored == 9:
-                    continue
-
                 out, _ = JPEG2000Decoder.as_array(
                     encapsulate([cs]),
                     decoding_plugin=plugin,
@@ -1191,10 +1169,6 @@ class TestJ2KEncoding:
             cs = JPEG2000Encoder.encode(ref, encoding_plugin="pylibjpeg", **opts)
 
             for plugin in plugins:
-                # Pillow doesn't decode 9-bit J2K correctly
-                if plugin == "pillow" and bits_stored == 9:
-                    continue
-
                 out, _ = JPEG2000Decoder.as_array(
                     encapsulate([cs]),
                     decoding_plugin=plugin,
@@ -1308,9 +1282,6 @@ class TestJ2KEncoding:
             opts["bits_stored"] = bits_stored
             cs = JPEG2000Encoder.encode(buffer, encoding_plugin="pylibjpeg", **opts)
             for plugin in plugins:
-                if plugin == "pillow" and bits_stored == 9:
-                    continue
-
                 out, _ = JPEG2000Decoder.as_array(
                     encapsulate([cs]),
                     decoding_plugin=plugin,
@@ -1547,9 +1518,6 @@ class TestJ2KEncoding:
             cs = JPEG2000Encoder.encode(buffer, encoding_plugin="pylibjpeg", **opts)
 
             for plugin in plugins:
-                if plugin == "pillow" and bits_stored == 9:
-                    continue
-
                 out, _ = JPEG2000Decoder.as_array(
                     encapsulate([cs]),
                     decoding_plugin=plugin,


### PR DESCRIPTION
#### Describe the changes
* Bump required versions for `pyjpegls`, `pylibjpeg-libjpeg`, `pylibjpeg-openjpeg` and `pillow`
* Update tests for big endian mostly to make the dtype endianness explicit
* Remove test exceptions for decoding 9-bit J2K with Pillow (fixed in v10.3)
* Make `_passes_version_check()` a bit more forgiving so it allows things like "2.4.0.dev0" when compared to (2, 4)

Closes #2147

#### Tasks
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
