### PR TITLE
[MRG] Stop data manager test from altering the data cache

### DIFF
--- a/src/pydicom/data/download.py
+++ b/src/pydicom/data/download.py
@@ -42,6 +42,7 @@ from pydicom.misc import warn_and_log
 
 HERE = pathlib.Path(__file__).resolve().parent
 _SIMULATE_NETWORK_OUTAGE = False  # For testing network outages
+_CONFIG_DIRECTORY = None  # For setting an alternative config directory
 
 
 def calculate_file_hash(fpath: pathlib.Path) -> str:
@@ -74,6 +75,12 @@ def get_config_dir() -> pathlib.Path:
     The config directory will be named ``.pydicom`` and will be created in the
     local user's home directory.
     """
+    if _CONFIG_DIRECTORY is not None:
+        p = pathlib.Path(_CONFIG_DIRECTORY)
+        p.mkdir(exist_ok=True)
+
+        return p
+
     config_dir = pathlib.Path.home() / ".pydicom"
     config_dir.mkdir(exist_ok=True)
 

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -45,6 +45,20 @@ def download_failure():
     download._SIMULATE_NETWORK_OUTAGE = False
 
 
+@pytest.fixture()
+def data_directory(tmp_path_factory):
+    src = get_data_dir()
+    original = download._CONFIG_DIRECTORY
+    path = tmp_path_factory.mktemp("data")
+
+    # Copy contents of the cache to the new temporary directory
+    shutil.copytree(src, path / "data")
+
+    download._CONFIG_DIRECTORY = path
+    yield
+    download._CONFIG_DIRECTORY = original
+
+
 class TestGetData:
     def test_get_dataset(self):
         """Test the different functions to get lists of data files."""
@@ -310,9 +324,9 @@ class TestDownload:
             assert [] == get_testdata_files("693_UN*")
 
 
-def test_fetch_data_files():
+def test_fetch_data_files(data_directory):
     """Test fetch_data_files()."""
-    # Remove a single file from the cache
+    # Remove a single file from the temporary cache
     cache = get_data_dir()
     path = cache / "693_J2KR.dcm"
     if path.exists():


### PR DESCRIPTION
#### Describe the changes
Changes a data manager test to delete the data file from a temporary copy of the `.pydicom/data` cache rather than the real thing so the original doesn't have to keep downloading the deleted file. If for whatever reason you can't download the file then your other tests that depend on that file then fail.

#### Tasks
- [x] Fix or feature added
- [x] Unit tests passing and overall coverage the same or better
