### PR TITLE
[MRG] Fix being unable to pickle datasets with LUT Descriptor

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -13,6 +13,8 @@ Fixes
   are not aligned with byte boundaries (:issue:`2134`).
 * Fixed a number of issues with decoding pixel data on big endian systems such as s390x
   (:issue:`2147`).
+* Fixed being unable to pickle datasets containing LUT descriptor elements such as
+  *LUT Descriptor* and *Red Palette Color LUT Descriptor* (:issue:`2160`).
 
 Enhancements
 ------------

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -101,6 +101,11 @@ def empty_value_for_VR(
     return None
 
 
+def _pass_through(val: Any) -> Any:
+    """Pass through function to skip DataElement value validation."""
+    return val
+
+
 class DataElement:
     """Contain and manipulate a DICOM Element.
 
@@ -597,15 +602,11 @@ class DataElement:
         # e.g. LUT Descriptor is 'US or SS' and VM 3, but the first and
         #   third values are always US (the third should be <= 16, so SS is OK)
         if self.tag in _LUT_DESCRIPTOR_TAGS and val:
-
-            def _skip_conversion(val: Any) -> Any:
-                return val
-
             validate_value(VR_.US, val[0], self.validation_mode)
             for value in val[1:]:
                 validate_value(self.VR, value, self.validation_mode)
 
-            return MultiValue(_skip_conversion, val)
+            return MultiValue(_pass_through, val)
 
         return MultiValue(self._convert, val)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1756,6 +1756,15 @@ class TestDataset:
         ds.file_meta.TransferSyntaxUID = JPEGBaseline8Bit
         assert ds.is_decompressed is False
 
+    def test_pickle_lut(self):
+        """Reversion test for #2160"""
+        ds = Dataset()
+        ds["LUTDescriptor"] = DataElement(0x00283002, "US", [1, 2])
+        s = pickle.dumps({"ds": ds})
+        ds1 = pickle.loads(s)["ds"]
+        assert ds == ds1
+        assert ds1.LUTDescriptor == [1, 2]
+
 
 class TestDatasetSaveAs:
     def test_no_transfer_syntax(self):


### PR DESCRIPTION
#### Describe the changes
Fixes being unable to pickle datasets with LUT Descriptor elements, closes #2160 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/e596fd2f-676c-407c-91b5-9886f513611e/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
