### PR TITLE
[MRG] Python 3.13, 3.14a added to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -14,8 +14,8 @@ jobs:
         # Macos unlikely to fail if ubuntu okay so also cover in merge
         os: [windows]
         python-version: ["3.12", "3.13"]
-        test-extras: [false]
         test-numpy: [true]
+        test-extras: [false]
         upload-coverage: [false]
         include:
           - os: ubuntu

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -15,14 +15,17 @@ jobs:
         os: [windows]
         python-version: ["3.12", "3.13"]
         test-extras: [false]
+        test-numpy: [true]
         upload-coverage: [false]
         include:
           - os: ubuntu
             python-version: "3.11"
+            test-numpy: true
             test-extras: true
             upload-coverage: true
           - os: macos
             python-version: "3.10"
+            test-numpy: true
             test-extras: true
             upload-coverage: false
           # Pre-release Python
@@ -38,6 +41,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version:  ${{ matrix.python-version }}
+      test-numpy: ${{ matrix.test-numpy }}
       test-extras: ${{ matrix.test-extras }}
       upload-coverage: ${{ matrix.upload-coverage }}
 

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -13,7 +13,7 @@ jobs:
         # PyPy only has one line in pydicom (as of 2003-07) so cover in merge only
         # Macos unlikely to fail if ubuntu okay so also cover in merge
         os: [windows]
-        python-version: ["3.10"]  # , "3.12" soon
+        python-version: ["3.12", "3.13"]
         test-extras: [false]
         upload-coverage: [false]
         include:
@@ -25,6 +25,13 @@ jobs:
             python-version: "3.10"
             test-extras: true
             upload-coverage: false
+          # Pre-release Python
+          - os: ubuntu
+            python-version: "3.14"  
+            test-numpy: false
+            test-extras: false
+            upload-coverage: false
+
     uses: ./.github/workflows/tests_wf.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
@@ -43,10 +50,10 @@ jobs:
           python-version: ['3.10']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -12,20 +12,24 @@ jobs:
       matrix:
         # Do the ones not covered in PR workflow
         os: [ubuntu, macos]
-        python-version: ["3.10"]  # , "3.12" except PyPy
+        python-version: ["3.10", "3.11"]
+        test-numpy: [true]
         test-extras: [false]
         upload-coverage: [false]
         include:
           - os: windows
-            python-version: "3.11"
+            python-version: "3.13"
+            test-numpy: true
             test-extras: true
             upload-coverage: true
           - os: macos
-            python-version: "3.10"
+            python-version: "3.12"
+            test-numpy: true
             test-extras: true
             upload-coverage: false
           - os: ubuntu
             python-version: "pypy3.10"
+            test-numpy: true
             test-extras: false
             upload-coverage: false
         exclude:
@@ -39,5 +43,6 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version:  ${{ matrix.python-version }}
+      test-numpy: ${{ matrix.test-numpy }}
       test-extras: ${{ matrix.test-extras }}
       upload-coverage: ${{ matrix.upload-coverage }}

--- a/.github/workflows/publish-pypi-deploy.yml
+++ b/.github/workflows/publish-pypi-deploy.yml
@@ -19,10 +19,10 @@ jobs:
       id-token: write
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests_wf.yml
+++ b/.github/workflows/tests_wf.yml
@@ -9,6 +9,10 @@ on:
       python-version:
         required: true
         type: string
+      test-numpy:
+        required: false
+        type: boolean
+        default: true
       test-extras:
         required: false
         type: boolean
@@ -37,11 +41,11 @@ jobs:
     - name: Set env variables
       run: echo "PYTEST_ARGS=--cov-append --cov=pydicom" >> "$GITHUB_ENV"
     - name: Check-out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip
@@ -56,6 +60,7 @@ jobs:
         python -m pytest --cov-reset ${{ env.PYTEST_ARGS }}
 
     - name: Test with Numpy
+      if: inputs.test-numpy
       run: |
         python -m pip install .[basic]
         python -m pytest ${{ env.PYTEST_ARGS }}

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -23,7 +23,7 @@ Fixes
 
 Enhancements
 ------------
-* Python 3.12 and 3.13 now supported
+* Python 3.12 and 3.13 now supported; limited support for pre-release Python 3.14
 * Added the option to pass a ``bool`` ndarray to :func:`~pydicom.pixels.set_pixel_data`
   to store with *Bits Allocated* of ``1`` using bit-packing (:issue:`2141`).
 * Added the :attr:`Dataset.is_decompressed<pydicom.dataset.Dataset.is_decompressed>`

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -23,6 +23,7 @@ Fixes
 
 Enhancements
 ------------
+* Python 3.12 and 3.13 now supported
 * Added the option to pass a ``bool`` ndarray to :func:`~pydicom.pixels.set_pixel_data`
   to store with *Bits Allocated* of ``1`` using bit-packing (:issue:`2141`).
 * Added the :attr:`Dataset.is_decompressed<pydicom.dataset.Dataset.is_decompressed>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers=[
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Scientific/Engineering :: Physics",
@@ -65,6 +66,7 @@ pixeldata = [
     "pyjpegls",
     "pylibjpeg[openjpeg]",
     "pylibjpeg[rle]",
+    "pylibjpeg-libjpeg",
     "python-gdcm"
 ]
 

--- a/src/pydicom/data/data_manager.py
+++ b/src/pydicom/data/data_manager.py
@@ -328,13 +328,9 @@ def get_testdata_file(
     ValueError
         If `name` is an absolute path.
     """
-    if os.path.isabs(name):
-        raise ValueError(
-            f"'get_testdata_file' does not support absolute paths, as it only works"
-            f" with internal pydicom test data - did you mean 'dcmread(\"{name}\")'?"
-        )
 
     path = _get_testdata_file(name=name, download=download)
+        
     if read and path is not None:
         from pydicom.filereader import dcmread
 
@@ -345,6 +341,12 @@ def get_testdata_file(
 def _get_testdata_file(name: str, download: bool = True) -> str | None:
     # Check pydicom local
     data_path = Path(DATA_ROOT) / "test_files"
+
+    if Path(name).anchor:
+        raise ValueError(
+                f"'get_testdata_file' does not support absolute paths, as it only works"
+                f" with internal pydicom test data - did you mean 'dcmread(\"{name}\")'?"
+            )
     matches = [m for m in data_path.rglob(name)]
     if matches:
         return os.fspath(matches[0])
@@ -400,7 +402,7 @@ def get_testdata_files(pattern: str = "**/*") -> list[str]:
     ValueError
         If `pattern` matches an absolute path.
     """
-    if os.path.isabs(pattern):
+    if Path(pattern).anchor:
         raise ValueError(
             "'get_testdata_files' does not support absolute paths, as it only works"
             " with internal pydicom test data."

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -3,7 +3,7 @@
 
 from collections.abc import Iterable, Iterator
 try:
-    from collections.abc import Buffer
+    from collections.abc import Buffer  # type: ignore[attr-defined]
 except ImportError:
     from collections.abc import ByteString as Buffer  # Python 3.10, 3.11
 import importlib

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -1,7 +1,11 @@
 # Copyright 2008-2024 pydicom authors. See LICENSE file for details.
 """Utilities for pixel data handling."""
 
-from collections.abc import Iterable, Iterator, ByteString
+from collections.abc import Iterable, Iterator
+try:
+    from collections.abc import Buffer
+except ImportError:
+    from collections.abc import ByteString as Buffer  # Python 3.10, 3.11
 import importlib
 import logging
 from pathlib import Path
@@ -683,7 +687,7 @@ def decompress(
     return ds
 
 
-def expand_ybr422(src: ByteString, bits_allocated: int) -> bytes:
+def expand_ybr422(src: Buffer, bits_allocated: int) -> bytes:
     """Return ``YBR_FULL_422`` data expanded to ``YBR_FULL``.
 
     Uncompressed datasets with a (0028,0004) *Photometric Interpretation* of

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -3012,7 +3012,7 @@ class TestDatasetWithBufferedData:
 
         msg = (
             r"Error deepcopying the buffered element \(7FE0,0010\) 'Pixel Data': "
-            r"cannot (.*) '_io.BufferedReader' object"
+            r"cannot (.*)BufferedReader'"
         )
         with pytest.raises(TypeError, match=msg):
             copy.deepcopy(ds)


### PR DESCRIPTION
#### Describe the changes
Closes #2172.
Update PR workflows to add Python 3.13 and Python 3.14 (pre-release).
It appears numpy is not available for Python 3.14 pre-release, so added workflow flag for whether numpy tests are executed (default true).



#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
- [x] Modify merge workflows