### PR TITLE
[MRG] CLI tag numbers allowed

### DIFF
--- a/doc/guides/cli/cli_codify.rst
+++ b/doc/guides/cli/cli_codify.rst
@@ -60,12 +60,11 @@ was specified. To see the available command options, use the ``help`` command:
     Read a DICOM file and produce the *pydicom* (Python) code which can create that file
 
     positional arguments:
-    filespec              File specification, in format [pydicom::]filename[::element]. If `pydicom::`
-                            prefix is used, then use the pydicom test file with that name. If `element`
-                            is given, use only that data element within the file. Examples:
-                            path/to/your_file.dcm, your_file.dcm::StudyDate,
-                            pydicom::rtplan.dcm::BeamSequence[0],
-                            yourplan.dcm::BeamSequence[0].BeamNumber
+    filespec           File specification, in format [pydicom::]filename[::element]. If `pydicom::` prefix is present,
+                        then use the pydicom test file with that name. If `element` is given, use only that data element
+                        within the file. Examples: path/to/your_file.dcm, your_file.dcm::StudyDate,
+                        your_file.dcm::(0001,0001), pydicom::rtplan.dcm::BeamSequence[0],
+                        yourplan.dcm::BeamSequence[0].BeamNumber, pydicom::rtplan.dcm::(300A,00B0)[0].(300A,00B6)
     outfile               Filename to write python code to. If not specified, code is written to
                             stdout
 

--- a/doc/guides/cli/cli_intro.rst
+++ b/doc/guides/cli/cli_intro.rst
@@ -69,11 +69,12 @@ by typing ``pydicom help [subcommand]``.  For example:
     Display all or part of a DICOM file
 
     positional arguments:
-    filespec              File specification, in format [pydicom::]filename[::element]. If `pydicom::`
-                            prefix is used, then show the pydicom test file with that name. If `element`
-                            is given, use only that data element within the file. Examples:
-                            path/to/your_file.dcm, your_file.dcm::StudyDate,
-                            pydicom::rtplan.dcm::BeamSequence[0], yourplan.dcm::BeamSequence[0].BeamNumber
+    filespec           File specification, in format [pydicom::]filename[::element]. If `pydicom::` prefix is present,
+                        then use the pydicom test file with that name. If `element` is given, use only that data element
+                        within the file. Examples: path/to/your_file.dcm, your_file.dcm::StudyDate,
+                        your_file.dcm::(0001,0001), pydicom::rtplan.dcm::BeamSequence[0],
+                        yourplan.dcm::BeamSequence[0].BeamNumber, pydicom::rtplan.dcm::(300A,00B0)[0].(300A,00B6)
+
 
     optional arguments:
     -h, --help            show this help message and exit
@@ -91,9 +92,9 @@ The ``pydicom`` command should automatically be available after you
 path or environment variables.
 
 If you are helping develop *pydicom* code, and are using git clones,
-you will have to ``pip install -e .`` or ``python setup.py develop`` from
+you will have to ``pip install -e .`` from
 the `pydicom` repository root. This has to be repeated for any changes to
-`setup.py` (e.g. to add a new subcommand).
+`pyproject.toml` (e.g. to add a new subcommand).
 
 If you are developing subcommands within your own package, you will need to
 reinstall your package similar to the above as you add entry points.

--- a/doc/guides/cli/cli_show.rst
+++ b/doc/guides/cli/cli_show.rst
@@ -102,7 +102,7 @@ You can also use a tag number in format (group,elem) anywhere a DICOM keyword ca
 
 The ``-q`` quiet argument shows a minimal version of some of the information in the
 file, using just the DICOM keyword and value (not showing the tag numbers
-and VR). The example below shows the quiet mode with an image slice::
+and VR). The example below shows the quiet mode with an image slice:
 
 .. code-block:: console
 
@@ -121,7 +121,7 @@ and VR). The example below shows the quiet mode with an image slice::
     Columns: 128
     SliceLocation: -77.2040634155
 
-And the following example shows an RT Plan in quiet mode::
+And the following example shows an RT Plan in quiet mode:
 
 .. code-block:: console
 

--- a/doc/guides/cli/cli_show.rst
+++ b/doc/guides/cli/cli_show.rst
@@ -19,11 +19,11 @@ or ``pydicom show -h``.
     Display all or part of a DICOM file
 
     positional arguments:
-    filespec              File specification, in format [pydicom::]filename[::element]. If `pydicom::`
-                            prefix is present, then use the pydicom test file with that name. If `element`
-                            is given, use only that data element within the file. Examples:
-                            path/to/your_file.dcm, your_file.dcm::StudyDate,
-                            pydicom::rtplan.dcm::BeamSequence[0], yourplan.dcm::BeamSequence[0].BeamNumber
+    filespec           File specification, in format [pydicom::]filename[::element]. If `pydicom::` prefix is present,
+                        then use the pydicom test file with that name. If `element` is given, use only that data element
+                        within the file. Examples: path/to/your_file.dcm, your_file.dcm::StudyDate,
+                        your_file.dcm::(0001,0001), pydicom::rtplan.dcm::BeamSequence[0],
+                        yourplan.dcm::BeamSequence[0].BeamNumber, pydicom::rtplan.dcm::(300A,00B0)[0].(300A,00B6)
 
     optional arguments:
     -h, --help            show this help message and exit
@@ -87,6 +87,16 @@ using the usual pydicom keyword notation:
     (300a, 0086) Beam Meterset                       DS: "116.0036697"
     (300c, 0006) Referenced Beam Number              IS: "1"
     ---------]
+
+You can also use a tag number in format (group,elem) anywhere a DICOM keyword can be used:
+
+    $ pydicom show pydicom::ct_small.dcm::(0043,1013)
+    [107, 21, 4, 2, 20]
+
+    $ pydicom show pydicom::rtplan.dcm::(300A,00B0)[0].(300a,0111)
+    [(300A,0112) Control Point Index                 IS: '0'
+    (300A,0114) Nominal Beam Energy                 DS: '6.00000000000000'
+    ...
 
 The ``-q`` quiet argument shows a minimal version of some of the information in the
 file, using just the DICOM keyword and value (not showing the tag numbers

--- a/doc/guides/cli/cli_show.rst
+++ b/doc/guides/cli/cli_show.rst
@@ -90,6 +90,8 @@ using the usual pydicom keyword notation:
 
 You can also use a tag number in format (group,elem) anywhere a DICOM keyword can be used:
 
+.. code-block:: console
+
     $ pydicom show pydicom::ct_small.dcm::(0043,1013)
     [107, 21, 4, 2, 20]
 
@@ -102,7 +104,9 @@ The ``-q`` quiet argument shows a minimal version of some of the information in 
 file, using just the DICOM keyword and value (not showing the tag numbers
 and VR). The example below shows the quiet mode with an image slice::
 
-    pydicom show -q pydicom::ct_small.dcm
+.. code-block:: console
+
+    $ pydicom show -q pydicom::ct_small.dcm
 
     SOPClassUID: CT Image Storage
     PatientName: CompressedSamples^CT1
@@ -119,7 +123,9 @@ and VR). The example below shows the quiet mode with an image slice::
 
 And the following example shows an RT Plan in quiet mode::
 
-    pydicom show -q pydicom::rtplan.dcm
+.. code-block:: console
+
+    $ pydicom show -q pydicom::rtplan.dcm
 
     SOPClassUID: RT Plan Storage
     PatientName: Last^First^mid^pre

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -39,3 +39,4 @@ Enhancements
     * :attr:`~pydicom.uid.JPEGXLLossless`
     * :attr:`~pydicom.uid.JPEGXLJPEGRecompression`
     * :attr:`~pydicom.uid.JPEGXL`
+* Added ability to specify tag numbers in the CLI commands (allows private tags to be specified)

--- a/src/pydicom/cli/main.py
+++ b/src/pydicom/cli/main.py
@@ -169,8 +169,7 @@ def filespec_parser(filespec: str) -> list[tuple[Dataset, Any]]:
         # Special message if a tag with spaces
         if m := re.search(re_tag_with_spaces, element):
             msg = (
-                f"Tag '{m.group()}' is not valid syntax for a "
-                "tag: no spaces allowed"
+                f"Tag '{m.group()}' is not valid syntax for a " "tag: no spaces allowed"
             )
         else:
             msg = (

--- a/src/pydicom/cli/main.py
+++ b/src/pydicom/cli/main.py
@@ -46,8 +46,10 @@ filespec_help = (
     "Examples: "
     "path/to/your_file.dcm, "
     "your_file.dcm::StudyDate, "
+    "your_file.dcm::(0001,0001), "
     "pydicom::rtplan.dcm::BeamSequence[0], "
-    "yourplan.dcm::BeamSequence[0].BeamNumber"
+    "yourplan.dcm::BeamSequence[0].BeamNumber, "
+    "pydicom::rtplan.dcm::(300A,00B0)[0].(300A,00B6)"
 )
 
 
@@ -104,12 +106,18 @@ def filespec_parser(filespec: str) -> list[tuple[Dataset, Any]]:
         in format:
             [pydicom::]<filename>[::<element>]
         If an element is specified, it must be a path to a data element,
-        sequence item (dataset), or a sequence.
+        sequence item (dataset), or a sequence, specified with
+        DICOM keywords, or DICOM tags in the format (gggg,eeee).
+
         Examples:
             your_file.dcm
             your_file.dcm::StudyDate
+            pydicom::ct_small.dcm::(0019,0010)
             pydicom::rtplan.dcm::BeamSequence[0]
             pydicom::rtplan.dcm::BeamSequence[0].BeamLimitingDeviceSequence
+            pydicom::rtplan.dcm::(300A,00B0)[0]
+            pydicom::rtplan.dcm::(300A,00B0)[0].BeamLimitingDeviceSequence
+            pydicom::rtplan.dcm::(300A,00B0)[0].(300A,00B6)
 
     Returns
     -------

--- a/src/pydicom/data/data_manager.py
+++ b/src/pydicom/data/data_manager.py
@@ -6,8 +6,8 @@ External Data Sources
 ---------------------
 
 *pydicom* can also search third-party data sources for matching data. To do so
-your project should register its entry points in its `setup.py` file. For
-example, a project named "mydata" with the interface class ``MyInterface``
+your project should register its entry points in its `pyproject.toml` or `setup.py` file. For
+example, a project named "mydata" using `setup.py` with the interface class ``MyInterface``
 should register:
 
 .. codeblock: python

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,10 @@ bad_elem_specs = (
     "no_callable()",
     "no_equals = ",
     "BeamSequence[0]extra",  # must match to end of string
+    "(300a,00b0)[0]extra",  # as above
     "BeamSequence[x]",  # index must be an int
+    "(0010,0010b)",  # bad tag format
+    "BeamSequence[0].(10,10)"  # bad tag format not initial
 )
 
 missing_elements = (
@@ -87,6 +90,14 @@ class TestFilespecElementEval:
         elem_val = eval_element(self.plan, elem_str)
         assert 6.0 == elem_val.NominalBeamEnergy
 
+        elem_str = "(300A,00B0)[0].ControlPointSequence[0]"
+        elem_val = eval_element(self.plan, elem_str)
+        assert 6.0 == elem_val.NominalBeamEnergy
+
+        elem_str = "(300a,00b0)[0].(300a,0111)[0]"
+        elem_val = eval_element(self.plan, elem_str)
+        assert 6.0 == elem_val.NominalBeamEnergy
+
         # A nested Sequence itself
         elem_str = "BeamSequence[0].ControlPointSequence"
         elem_val = eval_element(self.plan, elem_str)
@@ -94,6 +105,10 @@ class TestFilespecElementEval:
 
         # A non-nested data element
         elem_str = "PatientID"
+        elem_val = eval_element(self.plan, elem_str)
+        assert "id00001" == elem_val
+
+        elem_str = "(0010,0020)"
         elem_val = eval_element(self.plan, elem_str)
         assert "id00001" == elem_val
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ bad_elem_specs = (
     "(300a,00b0)[0]extra",  # as above
     "BeamSequence[x]",  # index must be an int
     "(0010,0010b)",  # bad tag format
-    "BeamSequence[0].(10,10)"  # bad tag format not initial
+    "BeamSequence[0].(10,10)"  # nested bad tag format
 )
 
 missing_elements = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,8 @@ bad_elem_specs = (
     "(300a,00b0)[0]extra",  # as above
     "BeamSequence[x]",  # index must be an int
     "(0010,0010b)",  # bad tag format
+    "(0010, 0010)",  # space in tag
+    "(0010,  0010)",  # spaces in tag
     "BeamSequence[0].(10,10)",  # nested bad tag format
 )
 
@@ -34,8 +36,11 @@ bad_indexes = (
 class TestFilespec:
     @pytest.mark.parametrize("bad_spec", bad_elem_specs)
     def test_syntax(self, bad_spec):
-        """Invalid syntax for for CLI file:element spec raises error"""
-        with pytest.raises(ArgumentTypeError, match=r".* syntax .*"):
+        """Invalid syntax for CLI file:element spec raises error"""
+        match = r".* syntax .*"
+        if ", " in bad_spec:
+            match += "tag: no spaces allowed"
+        with pytest.raises(ArgumentTypeError, match=match):
             filespec_parser(f"pydicom::rtplan.dcm::{bad_spec}")
 
     @pytest.mark.parametrize("missing_element", missing_elements)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,47 +78,40 @@ class TestFilespecElementEval:
     # Load plan once
     plan, _ = filespec_parser("pydicom::rtplan.dcm")[0]
 
-    def test_correct_values(self):
+    # Test basic correct data elements
+    @pytest.mark.parametrize("elem_str, expected",
+        (
+            ("BeamSequence[0].ControlPointSequence[0].NominalBeamEnergy", 6.0),
+            ("PatientID", "id00001"),
+            ("(0010,0020)", "id00001"),  
+        )                                             
+    )
+    def test_correct_data_elements(self, elem_str, expected):
         """CLI produces correct evaluation of requested element"""
-        # A nested data element
-        elem_str = "BeamSequence[0].ControlPointSequence[0].NominalBeamEnergy"
-        elem_val = eval_element(self.plan, elem_str)
-        assert 6.0 == elem_val
+        assert eval_element(self.plan, elem_str) == expected
 
-        # A nested Sequence item
-        elem_str = "BeamSequence[0].ControlPointSequence[0]"
+    # Test data elements in sequence items
+    @pytest.mark.parametrize(
+        "elem_str, expected",
+        (
+            ("BeamSequence[0].ControlPointSequence[0]", 6.0),
+            ("(300A,00B0)[0].ControlPointSequence[0]", 6.0),
+            ("(300a,00b0)[0].(300a,0111)[0]", 6.0),
+        )
+    )
+    def test_data_elem_from_sequence_item(self, elem_str, expected):
         elem_val = eval_element(self.plan, elem_str)
-        assert 6.0 == elem_val.NominalBeamEnergy
+        assert elem_val.NominalBeamEnergy == expected
 
-        elem_str = "(300A,00B0)[0].ControlPointSequence[0]"
-        elem_val = eval_element(self.plan, elem_str)
-        assert 6.0 == elem_val.NominalBeamEnergy
-
-        elem_str = "(300a,00b0)[0].(300a,0111)[0]"
-        elem_val = eval_element(self.plan, elem_str)
-        assert 6.0 == elem_val.NominalBeamEnergy
-
-        # A nested Sequence itself
-        elem_str = "BeamSequence[0].ControlPointSequence"
-        elem_val = eval_element(self.plan, elem_str)
+    def test_nested_sequence(self):
+        elem_val = eval_element(self.plan, "BeamSequence[0].ControlPointSequence")
         assert 6.0 == elem_val[0].NominalBeamEnergy
-
-        # A non-nested data element
-        elem_str = "PatientID"
-        elem_val = eval_element(self.plan, elem_str)
-        assert "id00001" == elem_val
-
-        elem_str = "(0010,0020)"
-        elem_val = eval_element(self.plan, elem_str)
-        assert "id00001" == elem_val
-
-        # The file_meta or file_meta data element
-        elem_str = "file_meta"
-        elem_val = eval_element(self.plan, elem_str)
+        
+    def test_file_meta_or_meta_element(self):
+        elem_val = eval_element(self.plan, "file_meta")
         assert "RT Plan Storage" == elem_val.MediaStorageSOPClassUID.name
 
-        elem_str = "file_meta.MediaStorageSOPClassUID"
-        elem_val = eval_element(self.plan, elem_str)
+        elem_val = eval_element(self.plan, "file_meta.MediaStorageSOPClassUID")
         assert "RT Plan Storage" == elem_val.name
 
 


### PR DESCRIPTION
Closes issue #2177.

Allow tags in CLI filespec in format (gggg,eeee), wherever a DICOM keyword could be used.

Also cleaned up (parametrized, separated by intent) some of the CLI tests.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [x] Preview link ([CircleCI -> Artifacts -> `doc/_build/html/cli_guide.html`](https://output.circle-artifacts.com/output/job/21f999f6-6f94-4476-b259-0a88e3b9ad2c/artifacts/0/doc/_build/html/guides/cli/cli_guide.html))
- [x] Unit tests passing and overall coverage the same or better
