### PR TITLE
[MRG] Let pre-commit specify and run its dev tools

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -44,25 +44,3 @@ jobs:
       test-numpy: ${{ matrix.test-numpy }}
       test-extras: ${{ matrix.test-extras }}
       upload-coverage: ${{ matrix.upload-coverage }}
-
-  typing:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-        fail-fast: false
-        matrix:
-          python-version: ['3.10']
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install typing dependencies
-      run: |
-        python -m pip install .[dev]
-    - name: Run typing check with mypy
-      run: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,12 +48,9 @@ docs = [
 ]
 
 dev = [
-    "black==24.10.0",
-    "mypy==1.14.1",
     "pydicom-data",
     "pytest",
     "pytest-cov",
-    "ruff==0.9.1",
     "types-requests",
     "pre-commit",
 ]


### PR DESCRIPTION
#### Describe the changes

Avoid specifying dev tools twice. When using pre-commit, specify dev tools in the pre-commit config file.

Accordingly, no need to run mypy twice, both in pre-commit and in a GitHub job. Let pre-commit handle that.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
