### PR TITLE
Fix broken source links in the documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -318,7 +318,7 @@ def setup(app):
 # The following is used by sphinx.ext.linkcode to provide links to github
 linkcode_resolve = make_linkcode_resolve(
     "pydicom",
-    "https://github.com/pydicom/pydicom/blob/{revision}/{package}/{path}#L{lineno}",
+    "https://github.com/pydicom/pydicom/blob/{revision}/src/{package}/{path}#L{lineno}",
 )
 
 doctest_global_setup = """


### PR DESCRIPTION
#### Describe the changes
Fixes source code links in the API not pointing to the correct URLs since the change to `src/pydicom`

Also, I really like the [pydata sphinx theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/) (as used by matplotlib and pandas), does anyone else want to switch?

#### Tasks
- [x] Documentation updated (if relevant)
  - [x] [Preview link](https://output.circle-artifacts.com/output/job/c9ad42b5-0d2a-4f7a-a76f-395b2a4b2b24/artifacts/0/doc/_build/html/reference/generated/pydicom.pixels.set_pixel_data.html#pydicom.pixels.set_pixel_data)
