### PR TITLE
Enhancements for colour space conversions

### DIFF
--- a/.github/workflows/tests_wf.yml
+++ b/.github/workflows/tests_wf.yml
@@ -88,4 +88,4 @@ jobs:
       env:
         codecov_token: ${{ secrets.codecov_token }}
       with:
-        env_vars: inputs.os, inputs.python-version
+        env_vars: inputs.os,inputs.python-version

--- a/.github/workflows/tests_wf.yml
+++ b/.github/workflows/tests_wf.yml
@@ -85,7 +85,6 @@ jobs:
     - name: Send coverage results
       if: success() && inputs.upload-coverage
       uses: codecov/codecov-action@v5
-      env:
-        codecov_token: ${{ secrets.codecov_token }}
       with:
+        token: ${{ secrets.codecov_token }}
         env_vars: inputs.os,inputs.python-version

--- a/doc/guides/decoding/decoder_options.rst
+++ b/doc/guides/decoding/decoder_options.rst
@@ -82,7 +82,7 @@ processing applied after decoding to a NumPy :class:`~numpy.ndarray`:
 
 * `as_rgb`: :class:`bool` - if ``True`` (default) then convert pixel data with a
   :ref:`photometric interpretation<photometric_interpretation>` of ``"YBR_FULL"``,
-   ``"YBR_FULL_422"``,``"YBR_PARTIAL_420"`` or ``"YBR_PARTIAL_422"`` to RGB.
+  ``"YBR_FULL_422"``, ``"YBR_PARTIAL_420"`` or ``"YBR_PARTIAL_422"`` to RGB.
 * `force_rgb`: :class:`bool` - if ``True`` then force a YBR_FULL to RGB color space
   conversion on the array (default ``False``).
 * `force_ybr`: :class:`bool` - if ``True`` then force an RGB to YBR_FULL color space

--- a/doc/guides/decoding/decoder_options.rst
+++ b/doc/guides/decoding/decoder_options.rst
@@ -53,14 +53,15 @@ is a :class:`~pydicom.dataset.Dataset`:
 | `bits_allocated`             |:class:`int`|(0028,0100)| *Bits         | The number of bits used to :ref:`contain each pixel      |
 |                              |            |           | Allocated*    | <bits_allocated>`                                        |
 +------------------------------+------------+-----------+---------------+----------------------------------------------------------+
-| `bits_stored`                |:class:`int`|(0028,0101)|*Bits Stored*  | The number of bits actually :ref:`used by each pixel     |
+| `bits_stored`                |:class:`int`|(0028,0101)|*Bits Stored*  | Required if `pixel_keyword` is ``'PixelData'``, the      |
+|                              |            |           |               | number of bits actually :ref:`used by each pixel         |
 |                              |            |           |               | <bits_stored>`                                           |
 +------------------------------+------------+-----------+---------------+----------------------------------------------------------+
 | `photometric_interpretation` |:class:`str`|(0028,0004)|*Photometric   | The :ref:`color space<photometric_interpretation>`       |
 |                              |            |           |Interpretation*| of the encoded pixel data                                |
 +------------------------------+------------+-----------+---------------+----------------------------------------------------------+
-| `pixel_representation`       |:class:`int`|(0028,0103)|*Pixel         | Required if `pixel_keyword` is ``'PixelData'``, whether  |
-|                              |            |           |Representation*| the pixels are :ref:`signed or unsigned                  |
+| `pixel_representation`       |:class:`int`|(0028,0103)|*Pixel         | Required if `pixel_keyword` is ``'PixelData'``,          |
+|                              |            |           |Representation*| whether the pixels are :ref:`signed or unsigned          |
 |                              |            |           |               | <pixel_representation>`                                  |
 +------------------------------+------------+-----------+---------------+----------------------------------------------------------+
 | `planar_configuration`       |:class:`int`|(0028,0006)|*Planar        | Required if `samples_per_pixel` > 1, the :ref:`pixel     |
@@ -80,11 +81,11 @@ The following options may be used with any transfer syntax for controlling the
 processing applied after decoding to a NumPy :class:`~numpy.ndarray`:
 
 * `as_rgb`: :class:`bool` - if ``True`` (default) then convert pixel data with a
-  YCbCr :ref:`photometric interpretation<photometric_interpretation>`
-  such as ``"YBR_FULL_422"`` to RGB.
-* `force_rgb`: :class:`bool` - if ``True`` then force a YCbCr to RGB color space
+  :ref:`photometric interpretation<photometric_interpretation>` of ``"YBR_FULL"``,
+   ``"YBR_FULL_422"``,``"YBR_PARTIAL_420"`` or ``"YBR_PARTIAL_422"`` to RGB.
+* `force_rgb`: :class:`bool` - if ``True`` then force a YBR_FULL to RGB color space
   conversion on the array (default ``False``).
-* `force_ybr`: :class:`bool` - if ``True`` then force an RGB to YCbCr color space
+* `force_ybr`: :class:`bool` - if ``True`` then force an RGB to YBR_FULL color space
   conversion on the array (default ``False``).
 
 

--- a/doc/guides/encoding/jpeg_2k.rst
+++ b/doc/guides/encoding/jpeg_2k.rst
@@ -73,16 +73,17 @@ pixel data should already be in the corresponding color space:
 
   * For *Photometric Interpretation* ``RGB``, ``YBR_ICT`` or ``YBR_RCT``; nothing
     else is required.
-  * For *Photometric Interpretation* ``YBR_FULL``; data must be :func:`converted into
-    YCbCr color space <pydicom.pixels.processing.convert_color_space>`. However
-    you should keep in mind that the conversion operation is lossy.
+  * For *Photometric Interpretation* ``YBR_FULL`` data must be :func:`converted into
+    YCbCr color space <pydicom.pixels.processing.convert_color_space>`, however
+    the conversion operation is lossy.
 
 * If your uncompressed pixel data is in `YCbCr
   <https://en.wikipedia.org/wiki/YCbCr>`_ color space:
 
-  * For *Photometric Interpretation* ``RGB``, ``YBR_ICT`` or ``YBR_RCT``; the
-    pixel data must first be converted into RGB color space, however the
-    conversion operation is lossy.
+  * For *Photometric Interpretation* ``RGB``, ``YBR_ICT`` or ``YBR_RCT``the pixel data
+    must first be :func:`converted into RGB color space
+    <pydicom.pixels.processing.convert_color_space>`, however the conversion
+    operation is lossy.
   * For *Photometric Interpretation* ``YBR_FULL`` nothing else is required.
 
 If your uncompressed pixel data is in RGB color space then setting the
@@ -95,7 +96,7 @@ for a given image quality. If you don't wish to use MCT then keep the
 Bits Stored
 ...........
 The maximum supported *Bits Stored* value for encoding is ``24``, however the
-results for lossy compression are quite poor for more than 20-bits or so.
+results for lossy compression are quite poor for more than ~20 bits.
 
 
 Examples

--- a/doc/guides/encoding/jpeg_2k.rst
+++ b/doc/guides/encoding/jpeg_2k.rst
@@ -80,7 +80,7 @@ pixel data should already be in the corresponding color space:
 * If your uncompressed pixel data is in `YCbCr
   <https://en.wikipedia.org/wiki/YCbCr>`_ color space:
 
-  * For *Photometric Interpretation* ``RGB``, ``YBR_ICT`` or ``YBR_RCT``the pixel data
+  * For *Photometric Interpretation* ``RGB``, ``YBR_ICT`` or ``YBR_RCT`` the pixel data
     must first be :func:`converted into RGB color space
     <pydicom.pixels.processing.convert_color_space>`, however the conversion
     operation is lossy.

--- a/doc/guides/encoding/jpeg_2k.rst
+++ b/doc/guides/encoding/jpeg_2k.rst
@@ -73,8 +73,9 @@ pixel data should already be in the corresponding color space:
 
   * For *Photometric Interpretation* ``RGB``, ``YBR_ICT`` or ``YBR_RCT``; nothing
     else is required.
-  * For *Photometric Interpretation* ``YBR_FULL`` the pixel data must first be
-    converted into RGB color space, however the conversion operation is lossy.
+  * For *Photometric Interpretation* ``YBR_FULL``; data must be :func:`converted into
+    YCbCr color space <pydicom.pixels.processing.convert_color_space>`. However
+    you should keep in mind that the conversion operation is lossy.
 
 * If your uncompressed pixel data is in `YCbCr
   <https://en.wikipedia.org/wiki/YCbCr>`_ color space:
@@ -93,7 +94,8 @@ for a given image quality. If you don't wish to use MCT then keep the
 
 Bits Stored
 ...........
-The maximum supported *Bits Stored* value for encoding is ``24``.
+The maximum supported *Bits Stored* value for encoding is ``24``, however the
+results for lossy compression are quite poor for more than 20-bits or so.
 
 
 Examples

--- a/doc/guides/encoding/jpeg_ls.rst
+++ b/doc/guides/encoding/jpeg_ls.rst
@@ -96,17 +96,9 @@ pixel data should already be in the corresponding color space:
 * If your uncompressed pixel data is in RGB color space:
 
   * For *Photometric Interpretation* ``RGB`` nothing else is required.
-  * For *Photometric Interpretation* ``YBR_FULL``
-
-    * For *Bits Allocated* and *Bits Stored* less than or equal to 8: pixel
-      data must be :func:`converted into YCbCr color space
-      <pydicom.pixels.processing.convert_color_space>`. However
-      you should keep in mind that the conversion operation is lossy.
-    * For *Bits Allocated* and *Bits Stored* between 9 and 16 (inclusive):
-      pixel data should be downscaled to 8-bit (with *Bits Stored*, *Bits
-      Allocated* and *High Bit* updated accordingly) and converted to `YCbCr
-      <https://en.wikipedia.org/wiki/YCbCr>`_ color space. Both of these
-      operations are lossy.
+  * For *Photometric Interpretation* ``YBR_FULL``; data must be :func:`converted into
+    YCbCr color space <pydicom.pixels.processing.convert_color_space>`. However
+    you should keep in mind that the conversion operation is lossy.
 
 * If your uncompressed pixel data is in `YCbCr
   <https://en.wikipedia.org/wiki/YCbCr>`_ color space:

--- a/doc/guides/encoding/jpeg_ls.rst
+++ b/doc/guides/encoding/jpeg_ls.rst
@@ -96,16 +96,16 @@ pixel data should already be in the corresponding color space:
 * If your uncompressed pixel data is in RGB color space:
 
   * For *Photometric Interpretation* ``RGB`` nothing else is required.
-  * For *Photometric Interpretation* ``YBR_FULL``; data must be :func:`converted into
-    YCbCr color space <pydicom.pixels.processing.convert_color_space>`. However
-    you should keep in mind that the conversion operation is lossy.
+  * For *Photometric Interpretation* ``YBR_FULL`` data must be :func:`converted into
+    YCbCr color space <pydicom.pixels.processing.convert_color_space>`, however
+    the conversion operation is lossy.
 
 * If your uncompressed pixel data is in `YCbCr
   <https://en.wikipedia.org/wiki/YCbCr>`_ color space:
 
   * For *Photometric Interpretation* ``RGB`` the pixel data must first be
     :func:`converted into RGB color space
-    <pydicom.pixels.processing.convert_color_space>`. However the conversion
+    <pydicom.pixels.processing.convert_color_space>`, however the conversion
     operation is lossy.
   * For *Photometric Interpretation* ``YBR_FULL`` nothing else is required.
 

--- a/doc/guides/encoding/rle_lossless.rst
+++ b/doc/guides/encoding/rle_lossless.rst
@@ -51,16 +51,16 @@ corresponding color space:
 * If your uncompressed pixel data is in RGB color space:
 
   * For *Photometric Interpretation* ``RGB`` nothing else is required.
-  * For *Photometric Interpretation* ``YBR_FULL``; data must be :func:`converted into
-    YCbCr color space <pydicom.pixels.processing.convert_color_space>`. However
-    you should keep in mind that the conversion operation is lossy.
+  * For *Photometric Interpretation* ``YBR_FULL`` data must be :func:`converted into
+    YCbCr color space <pydicom.pixels.processing.convert_color_space>`, however
+    the conversion operation is lossy.
 
 * If your uncompressed pixel data is in `YCbCr
   <https://en.wikipedia.org/wiki/YCbCr>`_ color space:
 
   * For *Photometric Interpretation* ``RGB`` the pixel data must first be
     :func:`converted into RGB color space
-    <pydicom.pixels.processing.convert_color_space>`. However the conversion
+    <pydicom.pixels.processing.convert_color_space>`, however the conversion
     operation is lossy.
   * For *Photometric Interpretation* ``YBR_FULL`` nothing else is required.
 

--- a/doc/guides/encoding/rle_lossless.rst
+++ b/doc/guides/encoding/rle_lossless.rst
@@ -51,17 +51,9 @@ corresponding color space:
 * If your uncompressed pixel data is in RGB color space:
 
   * For *Photometric Interpretation* ``RGB`` nothing else is required.
-  * For *Photometric Interpretation* ``YBR_FULL``
-
-    * For *Bits Allocated* and *Bits Stored* less than or equal to 8: pixel
-      data must be :func:`converted into YCbCr color space
-      <pydicom.pixels.processing.convert_color_space>`. However
-      you should keep in mind that the conversion operation is lossy.
-    * For *Bits Allocated* and *Bits Stored* between 9 and 16 (inclusive):
-      pixel data should be downscaled to 8-bit (with *Bits Stored*, *Bits
-      Allocated* and *High Bit* updated accordingly) and converted to `YCbCr
-      <https://en.wikipedia.org/wiki/YCbCr>`_ color space. Both of these
-      operations are lossy.
+  * For *Photometric Interpretation* ``YBR_FULL``; data must be :func:`converted into
+    YCbCr color space <pydicom.pixels.processing.convert_color_space>`. However
+    you should keep in mind that the conversion operation is lossy.
 
 * If your uncompressed pixel data is in `YCbCr
   <https://en.wikipedia.org/wiki/YCbCr>`_ color space:

--- a/doc/guides/glossary.rst
+++ b/doc/guides/glossary.rst
@@ -98,7 +98,7 @@ Glossary
 
     Allowed values: ``'MONOCHROME1'``, ``'MONOCHROME2'``, ``'PALETTE COLOR'``,
     ``'RGB'``, ``'YBR_FULL'``, ``'YBR_FULL_422'``, ``'YBR_PARTIAL_420'``,
-    ``'YBR_ICT'``, ``'YBR_RCT'``, however restrictions apply based on
+    ``'YBR_ICT'``, ``'YBR_RCT'``, ``'XYB'``, however restrictions apply based on
     the *Transfer Syntax UID*, and further constraints may be required by the
     :dcm:`IOD<part03/ps3.3.html>`.
 

--- a/doc/guides/user/working_with_pixel_data.rst
+++ b/doc/guides/user/working_with_pixel_data.rst
@@ -118,17 +118,13 @@ data to graphics libraries for viewing. See :doc:`viewing_images` for details.
 Color space
 -----------
 
-When using :attr:`~pydicom.dataset.Dataset.pixel_array`
-with *Pixel Data* that has an (0028,0002) *Samples per Pixel* value
-of ``3`` then the returned pixel data will be in the color space as given by
-(0028,0004) *Photometric Interpretation* (e.g. ``RGB``, ``YBR_FULL``,
-``YBR_FULL_422``, etc).
+When using :attr:`~pydicom.dataset.Dataset.pixel_array` with *Pixel Data* that has an
+(0028,0002) *Samples per Pixel* value of ``3`` then the returned pixel data will be in
+RGB color space by default.
 
-*pydicom* offers a limited ability to convert between 8-bits/channel YBR and
-RGB color spaces through the
-:func:`~pydicom.pixels.processing.convert_color_space`
-function. When changing the color space you should also change the value
-of *Photometric Interpretation* to match.
+*pydicom* offers the ability to convert between YCbCr and RGB color spaces through the
+:func:`~pydicom.pixels.processing.convert_color_space` function. When changing the
+color space you should also change the value of *Photometric Interpretation* to match.
 
 
 .. note:: See the DICOM Standard, Part 3,

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -42,5 +42,5 @@ Enhancements
 * Added ability to specify tag numbers in the CLI commands (allows private tags to be specified)
 * Removed `exec` and `eval` from tests, CLI, and scripts for improved security (:issue:`2193`)
 * Added support for up to 16-bit input images to :func:`~pydicom.pixels.convert_color_space`
-* Added support for ``YBR_PARTIAL_410`` and ``YBR_PARTIAL_422`` to
+* Added support for ``YBR_PARTIAL_420`` and ``YBR_PARTIAL_422`` to
   :func:`~pydicom.pixels.convert_color_space` (:issue:`2210`)

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -41,3 +41,6 @@ Enhancements
     * :attr:`~pydicom.uid.JPEGXL`
 * Added ability to specify tag numbers in the CLI commands (allows private tags to be specified)
 * Removed `exec` and `eval` from tests, CLI, and scripts for improved security (:issue:`2193`)
+* Added support for up to 16-bit input images to :func:`~pydicom.pixels.convert_color_space`
+* Added support for ``YBR_PARTIAL_410`` and ``YBR_PARTIAL_422`` to
+  :func:`~pydicom.pixels.convert_color_space` (:issue:`2210`)

--- a/doc/tutorials/pixel_data/compressing.rst
+++ b/doc/tutorials/pixel_data/compressing.rst
@@ -382,7 +382,7 @@ you can pass its name via the `decoding_plugin` argument::
     >>> ds.decompress(decoding_plugin="pylibjpeg")
 
 If the dataset's *Pixel Data* is in the YCbCr color space it will also be converted
-to RGB by default. This can be disabled by passing ``as_rgb=False``::
+to RGB by default. This can be disabled by passing ``as_rgb=False`` or ``raw=True``::
 
     import numpy as np
 

--- a/src/pydicom/pixels/common.py
+++ b/src/pydicom/pixels/common.py
@@ -283,7 +283,8 @@ class PhotometricInterpretation(str, Enum):
     ARGB = "ARGB"  # Retired
     CMYK = "CMYK"  # Retired
     YBR_PARTIAL_422 = "YBR_PARTIAL_422"  # Retired
-    YBR_PARTIAL_420 = "YBR_PARTIAL_420"  # Retired
+    YBR_PARTIAL_420 = "YBR_PARTIAL_420"
+    XYB = "XYB"
 
     # TODO: no longer needed if StrEnum
     def __str__(self) -> str:

--- a/src/pydicom/pixels/processing.py
+++ b/src/pydicom/pixels/processing.py
@@ -849,7 +849,8 @@ def convert_color_space(
         The image(s) as :class:`numpy.ndarray` with :attr:`~numpy.ndarray.shape`
         (frames, rows, columns, 3) or (rows, columns, 3) and a 'uint8'
         or 'uint16' :class:`~numpy.dtype`. uint16 is only supported when converting to
-        or from ``YBR_FULL`` or ``YBR_FULL_422``.
+        or from ``YBR_FULL`` or ``YBR_FULL_422``. For subsampled YCbCr data, such as
+        ``YBR_FULL_422``, the subsampling must be removed prior to conversion.
     current : str
         The current color space, should be a valid value for (0028,0004)
         *Photometric Interpretation*. One of ``'RGB'``, ``'YBR_FULL'``,
@@ -882,11 +883,9 @@ def convert_color_space(
     * ISO/IEC 10918-5:2012 (`ITU T.871
       <https://www.ijg.org/files/T-REC-T.871-201105-I!!PDF-E.pdf>`_),
       Section 7
-    * `ITU BT 601-2 (1990)<https://www.itu.int/rec/R-REC-BT.601/>`_
+    * `ITU BT 601-2 (1990) <https://www.itu.int/rec/R-REC-BT.601/>`_
+    * `YCbCr on Wikipedia <https://en.wikipedia.org/wiki/YCbCr>`_
     """
-    if not HAVE_NP:
-        raise RuntimeError("NumPy is required for 'convert_color_space()'")
-
     if current == desired:
         return arr
 
@@ -931,7 +930,6 @@ def convert_color_space(
         )
 
     bit_depth = bit_depth if bit_depth is not None else arr.dtype.itemsize * 8
-
     ybr = current if "YBR" in current else desired
     if "PARTIAL" in ybr and bit_depth != 8:
         raise ValueError(f"Invalid bit-depth '{bit_depth}' for {ybr}, must be 8")
@@ -995,7 +993,7 @@ def _convert_RGB_to_YBR_FULL(arr: "np.ndarray", bit_depth: int) -> "np.ndarray":
     ----------
     arr : numpy.ndarray
         An ndarray of a 1 to 16-bits per channel image in RGB color space.
-    bit_depth : int, optional
+    bit_depth : int
         The bit-depth of the input array.
 
     Returns
@@ -1032,7 +1030,7 @@ def _convert_RGB_to_YBR_PARTIAL(arr: "np.ndarray", bit_depth: int) -> "np.ndarra
     ----------
     arr : numpy.ndarray
         An ndarray of an  8-bit per channel image in RGB color space.
-    bit_depth : int, optional
+    bit_depth : int
         The bit-depth of the input array.
 
     Returns
@@ -1066,7 +1064,7 @@ def _convert_YBR_FULL_to_RGB(arr: "np.ndarray", bit_depth: int) -> "np.ndarray":
     ----------
     arr : numpy.ndarray
         An ndarray of a 1 to 16-bits per channel image in YBR_FULL color space.
-    bit_depth : int, optional
+    bit_depth : int
         The bit-depth of the input array.
 
     Returns
@@ -1105,7 +1103,7 @@ def _convert_YBR_PARTIAL_to_RGB(arr: "np.ndarray", bit_depth: int) -> "np.ndarra
     arr : numpy.ndarray
         An ndarray of an 8-bit per channel image in YBR_PARTIAL_422 or
         YBR_PARTIAL_420 color space.
-    bit_depth : int, optional
+    bit_depth : int
         The bit-depth of the input array.
 
     Returns

--- a/tests/pixels/test_processing.py
+++ b/tests/pixels/test_processing.py
@@ -216,6 +216,34 @@ class TestConvertColorSpace:
         assert (63, 128, 128) == tuple(ybr[1, 85, 50, :])
         assert (0, 128, 128) == tuple(ybr[1, 95, 50, :])
 
+    def test_multiframe_partial(self):
+        """Test processing all frames with YBR_PARTIAL."""
+        ds = dcmread(RGB_8_3_2F)
+
+        arr = ds.pixel_array
+        ybr = convert_color_space(arr, "RGB", "YBR_PARTIAL_420", per_frame=False)
+        assert (81, 90, 240) == tuple(ybr[0, 5, 50, :])
+        assert (159, 109, 184) == tuple(ybr[0, 15, 50, :])
+        assert (145, 54, 34) == tuple(ybr[0, 25, 50, :])
+        assert (190, 91, 81) == tuple(ybr[0, 35, 50, :])
+        assert (41, 240, 110) == tuple(ybr[0, 45, 50, :])
+        assert (138, 184, 119) == tuple(ybr[0, 55, 50, :])
+        assert (16, 128, 128) == tuple(ybr[0, 65, 50, :])
+        assert (71, 128, 128) == tuple(ybr[0, 75, 50, :])
+        assert (181, 128, 128) == tuple(ybr[0, 85, 50, :])
+        assert (235, 128, 128) == tuple(ybr[0, 95, 50, :])
+        # Frame 2
+        assert (170, 166, 16) == tuple(ybr[1, 5, 50, :])
+        assert (92, 147, 72) == tuple(ybr[1, 15, 50, :])
+        assert (106, 202, 222) == tuple(ybr[1, 25, 50, :])
+        assert (61, 165, 175) == tuple(ybr[1, 35, 50, :])
+        assert (210, 16, 146) == tuple(ybr[1, 45, 50, :])
+        assert (113, 72, 137) == tuple(ybr[1, 55, 50, :])
+        assert (235, 128, 128) == tuple(ybr[1, 65, 50, :])
+        assert (180, 128, 128) == tuple(ybr[1, 75, 50, :])
+        assert (70, 128, 128) == tuple(ybr[1, 85, 50, :])
+        assert (16, 128, 128) == tuple(ybr[1, 95, 50, :])
+
     def test_unsuitable_dtype_raises(self):
         """Test that non u1/u2 dtypes raise an exception."""
         msg = (

--- a/tests/test_gdcm_pixel_data.py
+++ b/tests/test_gdcm_pixel_data.py
@@ -501,7 +501,7 @@ class TestsWithGDCM:
 
         assert a.flags.writeable
         assert (120, 480, 640, 3) == a.shape
-        a = _convert_YBR_FULL_to_RGB(a)
+        a = _convert_YBR_FULL_to_RGB(a, bit_depth=8)
         # this test points were manually identified in Osirix viewer
         assert (41, 41, 41) == tuple(a[3, 159, 290, :])
         assert (57, 57, 57) == tuple(a[3, 169, 290, :])
@@ -520,7 +520,7 @@ class TestsWithGDCM:
 
         assert (100, 100, 3) == a.shape
         if convert_yuv_to_rgb:
-            a = _convert_YBR_FULL_to_RGB(a)
+            a = _convert_YBR_FULL_to_RGB(a, bit_depth=8)
         # this test points are from the ImageComments tag
         assert results[0] == tuple(a[5, 50, :])
         assert results[1] == tuple(a[15, 50, :])


### PR DESCRIPTION
#### Describe the changes
* Add support for up to 16-bit input arrays for converting to/from YBR_FULL*
* Add support for converting to/from 8-bit YBR_PARTIAL*
* Closes #2210 
* Fixes codecov upload failures

YBR_PARTIAL only supports 8-bit because it's a specialised form of YCbCr with a reduced value range that doesn't make sense to extend to higher (or lower) bit-depths.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] [Documentation updated](https://output.circle-artifacts.com/output/job/2ca3068c-a5aa-4e5c-b3e8-282e33866b67/artifacts/0/doc/_build/html/index.html) (if relevant)
- [x] Unit tests passing and overall coverage the same or better
