### PR TITLE
[WIP] Enable single bit compression

### DIFF
--- a/doc/guides/encoding/jpeg_2k.rst
+++ b/doc/guides/encoding/jpeg_2k.rst
@@ -32,7 +32,7 @@ with the *Pixel Data* see the :doc:`glossary of Image Pixel elements<../glossary
 | *Samples   | *Photometric          | *Pixel          | *Planar        | *Bits      | *Bits   |
 | per Pixel* | Interpretation*       | Representation* | Configuration* | Allocated* | Stored* |
 +============+=======================+=================+================+============+=========+
-| 1          | MONOCHROME1           | 0 or 1          | (absent)       | 8, 16, 24, | 1 to 38 |
+| 1          | MONOCHROME1           | 0 or 1          | (absent)       | 1, 8, 16,  | 1 to 38 |
 |            +-----------------------+                 |                | 32 or 40   |         |
 |            | MONOCHROME2           |                 |                |            |         |
 |            +-----------------------+-----------------+----------------+------------+---------+

--- a/doc/guides/encoding/rle_lossless.rst
+++ b/doc/guides/encoding/rle_lossless.rst
@@ -20,7 +20,7 @@ syntax. For an explanation of each parameter and its relationship with the
 | *Samples   | *Photometric    | *Pixel          | *Bits      | *Bits   |
 | per Pixel* | Interpretation* | Representation* | Allocated* | Stored* |
 +============+=================+=================+============+=========+
-| 1          | MONOCHROME1     | 0 or 1          | 8 or 16    | 1 to 16 |
+| 1          | MONOCHROME1     | 0 or 1          | 1, 8 or 16 | 1 to 16 |
 |            +-----------------+                 |            |         |
 |            | MONOCHROME2     |                 |            |         |
 |            +-----------------+-----------------+            |         |

--- a/src/pydicom/pixels/decoders/native.py
+++ b/src/pydicom/pixels/decoders/native.py
@@ -9,6 +9,7 @@ import zlib
 
 from pydicom.misc import warn_and_log
 from pydicom.pixels.decoders.base import DecodeRunner
+from pydicom.pixels.utils import unpack_bits
 from pydicom.uid import RLELossless, DeflatedImageFrameCompression
 
 
@@ -64,10 +65,14 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytearray:
         # Update the runner options to ensure the reshaping is correct
         # Only do this if we successfully decoded the frame
         runner.set_option("planar_configuration", 1)
+    else:
+        frame = _deflated_decode_frame(src)
 
-        return frame
+    # Unpack bit-packed data
+    if runner.bits_allocated == 1:
+        frame = bytearray(unpack_bits(frame))
 
-    return _deflated_decode_frame(src)
+    return frame
 
 
 def _deflated_decode_frame(src: bytes) -> bytearray:
@@ -122,7 +127,7 @@ def _rle_decode_frame(
         green then all blue, with the bytes for each pixel ordered from
         MSB to LSB when reading left to right).
     """
-    if nr_bits % 8:
+    if nr_bits % 8 and nr_bits != 1:
         raise NotImplementedError(
             f"Unable to decode RLE encoded pixel data with {nr_bits} bits allocated"
         )
@@ -132,11 +137,41 @@ def _rle_decode_frame(
     nr_segments = len(offsets)
 
     # Check that the actual number of segments is as expected
-    bytes_per_sample = nr_bits // 8
-    if nr_segments != nr_samples * bytes_per_sample:
+    if nr_bits == 1:
+        if nr_samples != 1:
+            raise ValueError(
+                "Cannot decode RLE pixel data with Bits Allocated = 1 "
+                "and SamplesPerPixel > 1."
+            )
+
+        bytes_per_sample = 1
+        expected_nr_segments = 1
+
+        # Since there can only be one segment, the length of the segment, the
+        # stride and total decoded length are all the same, and equal to the
+        # decoded length n bytes of the bit-packed array
+        decoded_segment_length = (rows * columns - 1) // 8 + 1
+        decoded_total_length = decoded_segment_length
+
+        # `stride` is the total number of bytes of each sample plane
+        stride = decoded_total_length
+    else:
+        bytes_per_sample = nr_bits // 8
+        expected_nr_segments = nr_samples * bytes_per_sample
+
+        # Number of bytes in each decoded segment
+        decoded_segment_length = rows * columns
+
+        # `stride` is the total number of bytes of each sample plane
+        stride = bytes_per_sample * rows * columns
+
+        # total number of bytes in decoded array
+        decoded_total_length = stride * nr_samples
+
+    if nr_segments != expected_nr_segments:
         raise ValueError(
             "The number of RLE segments in the pixel data doesn't match the "
-            f"expected amount ({nr_segments} vs. {nr_samples * bytes_per_sample} "
+            f"expected amount ({nr_segments} vs. {expected_nr_segments} "
             "segments)"
         )
 
@@ -144,7 +179,7 @@ def _rle_decode_frame(
     offsets.append(len(src))
 
     # Preallocate with null bytes
-    decoded = bytearray(rows * columns * nr_samples * bytes_per_sample)
+    decoded = bytearray(decoded_total_length)
 
     # Example:
     # RLE encoded data is ordered like this (for 16-bit, 3 sample):
@@ -173,15 +208,17 @@ def _rle_decode_frame(
 
             # Check that the number of decoded bytes is correct
             actual_length = len(segment)
-            if actual_length < rows * columns:
+            if actual_length < decoded_segment_length:
                 raise ValueError(
                     "The amount of decoded RLE segment data doesn't match the "
-                    f"expected amount ({actual_length} vs. {rows * columns} bytes)"
+                    f"expected amount ({actual_length} vs. {decoded_segment_length} "
+                    "bytes)"
                 )
-            elif actual_length != rows * columns:
+            elif actual_length != decoded_segment_length:
                 warn_and_log(
                     "The decoded RLE segment contains non-conformant padding "
-                    f"- {actual_length} vs. {rows * columns} bytes expected"
+                    f"- {actual_length} vs. {decoded_segment_length} bytes "
+                    "expected"
                 )
 
             if segment_order == ">":
@@ -191,7 +228,7 @@ def _rle_decode_frame(
             #   0, 1, 2, 3, 400, 401, 402, 403, 800, 801, 802, 803
             start = byte_offset + (sample_number * stride)
             decoded[start : start + stride : bytes_per_sample] = segment[
-                : rows * columns
+                :decoded_segment_length
             ]
 
     return decoded

--- a/src/pydicom/pixels/encoders/native.py
+++ b/src/pydicom/pixels/encoders/native.py
@@ -7,6 +7,7 @@ from struct import pack
 import zlib
 
 from pydicom.pixels.encoders.base import EncodeRunner
+from pydicom.pixels.utils import pack_bits
 from pydicom.uid import RLELossless, DeflatedImageFrameCompression
 
 
@@ -29,7 +30,8 @@ def _encode_deflated_frame(src: bytes, runner: EncodeRunner) -> bytes:
     Parameters
     ----------
     src : bytes
-        A single frame of little-endian ordered image data to be encoded.
+        A single frame of little-endian ordered image data to be encoded. For
+        single bit images, the data should not be bit-packed.
     runner : pydicom.pixels.encoders.base.EncodeRunner
         The runner managing the encoding process.
 
@@ -38,6 +40,11 @@ def _encode_deflated_frame(src: bytes, runner: EncodeRunner) -> bytes:
     bytes
         A deflate encoded frame.
     """
+    # In the case of single bit images, the data must first be bit-packed
+    # before being encoded with Deflate
+    if runner.get_option("bits_allocated") == 1:
+        src = pack_bits(src)
+
     # TODO: Python 3.11 switch to using zlib.compress() instead
     enc = zlib.compressobj(wbits=-zlib.MAX_WBITS)
 
@@ -51,6 +58,7 @@ def _encode_rle_frame(src: bytes, runner: EncodeRunner) -> bytes:
     ----------
     src : bytes
         A single frame of little-endian ordered image data to be RLE encoded.
+        For single bit images, the data should not be bit-packed.
     runner : pydicom.pixels.encoders.base.EncodeRunner
         The runner managing the encoding process.
 
@@ -61,6 +69,11 @@ def _encode_rle_frame(src: bytes, runner: EncodeRunner) -> bytes:
     """
     if runner.get_option("byteorder", "<") == ">":
         raise ValueError("Unsupported option \"byteorder = '>'\"")
+
+    # In the case of single bit images, the data must first be bit-packed
+    # before being encoded with Deflate
+    if runner.get_option("bits_allocated") == 1:
+        src = pack_bits(src)
 
     bytes_allocated = math.ceil(runner.bits_allocated / 8)
 

--- a/src/pydicom/pixels/utils.py
+++ b/src/pydicom/pixels/utils.py
@@ -681,6 +681,9 @@ def decompress(
     elem.is_undefined_length = False
     elem.VR = VR.OB if ds.BitsAllocated <= 8 else VR.OW
 
+    if ds.BitsAllocated == 1:
+        elem.value = pack_bits(elem.value)
+
     # Update the transfer syntax
     ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
 
@@ -1283,8 +1286,8 @@ def iter_pixels(
             f.seek(file_offset)
 
 
-def pack_bits(arr: "np.ndarray", pad: bool = True) -> bytes:
-    """Pack a binary :class:`numpy.ndarray` for use with *Pixel Data*.
+def pack_bits(arr: "np.ndarray | bytes | bytearray", pad: bool = True) -> bytes:
+    """Pack a binary :class:`numpy.ndarray` or bytes for use with *Pixel Data*.
 
     Should be used in conjunction with (0028,0100) *Bits Allocated* = 1.
 
@@ -1293,17 +1296,27 @@ def pack_bits(arr: "np.ndarray", pad: bool = True) -> bytes:
         Added the `pad` keyword parameter and changed to allow `arr` to be
         2 or 3D.
 
+    .. versionchanged:: 3.1
+
+        Allow packing of bytes and bytearray objects when numpy is not
+        installed.
+
     Parameters
     ----------
-    arr : numpy.ndarray
-        The :class:`numpy.ndarray` containing 1-bit data as ints. `arr` must
-        only contain integer values of 0 and 1 and must have an 'uint'  or
-        'int' :class:`numpy.dtype`. For the sake of efficiency it's recommended
+    arr : numpy.ndarray | bytes
+        The :class:`numpy.ndarray`, `bytes`, or `bytesarray` containing 1-bit
+        data as ints/bytes. If it is a :class:`numpy.ndarray`, `arr` must only
+        contain integer values of 0 and 1 and must have an 'uint'  or 'int'
+        :class:`numpy.dtype`. If it is a `bytes` or `bytesarray`, each byte
+        represents a pixel and must have a value of either 0 or 1 (i.e.
+        `b'\x00'` or `b'\x01'`). For the sake of efficiency it's recommended
         that the length of `arr` be a multiple of 8 (i.e. that any empty
-        bit-padding to round out the byte has already been added). The input
-        `arr` should either be shaped as (rows, columns) or (frames, rows,
-        columns) or the equivalent 1D array used to ensure that the packed
-        data is in the correct order.
+        bit-padding to round out the byte has already been added). For arrays,
+        the input `arr` should either be shaped as (rows, columns) or (frames,
+        rows, columns) or the equivalent 1D array used to ensure that the
+        packed data is in the correct order. For `bytes` or `bytesarray`,
+        pixels should be ordered in the same order as a 1D array, i.e. column
+        index changes most frequently, then row index, then frame index.
     pad : bool, optional
         If ``True`` (default) then add a null byte to the end of the packed
         data to ensure even length, otherwise no padding will be added.
@@ -1324,6 +1337,38 @@ def pack_bits(arr: "np.ndarray", pad: bool = True) -> bytes:
     :dcm:`Section 8.1.1<part05/chapter_8.html#sect_8.1.1>` and
     :dcm:`Annex D<part05/chapter_D.html>`
     """
+    if isinstance(arr, bytes | bytearray):
+        if len(arr) == 0:
+            return b""
+
+        if HAVE_NP:
+            # Form an array because the numpy implementation is more efficient
+            arr = np.frombuffer(arr, dtype=np.uint8)
+        else:
+            # Fallback for when numpy is not installed (slower)
+            out_array = bytearray()
+            for offset in range(0, len(arr), 8):
+                packed_int = 0
+                for i in range(8):
+                    byte_index = offset + i
+                    if byte_index >= len(arr):
+                        break
+                    b = arr[byte_index]
+                    if b not in (0, 1):
+                        raise ValueError(
+                            "Only binary arrays (containing ones or zeroes) "
+                            "can be packed."
+                        )
+                    if b == 1:
+                        packed_int |= 1 << i
+
+                out_array.append(packed_int)
+
+            if pad and len(out_array) % 2 == 1:
+                out_array.append(0)
+
+            return bytes(out_array)
+
     if arr.shape == (0,):
         return b""
 

--- a/tests/pixels/test_encoder_pydicom.py
+++ b/tests/pixels/test_encoder_pydicom.py
@@ -525,7 +525,9 @@ class TestEncodeDeflatedFrame:
         runner = EncodeRunner(DeflatedImageFrameCompression)
         runner.set_options(**kwargs)
 
-        encoded = _encode_deflated_frame(ds.PixelData, runner)
+        # Unpack pixel data before passing to encode function
+        unpacked_pixel_data = unpack_bits(ds.PixelData, as_array=False)
+        encoded = _encode_deflated_frame(unpacked_pixel_data, runner)
         decoded = _deflated_decode_frame(encoded)
         # Bit-packed data
         arr = unpack_bits(decoded)


### PR DESCRIPTION

I would like to add support for encoded/decoding of single bit images (those with Bits Allocated = 1) to pydicom. This PR is a working prototype and I'm looking for feedback before finalising (@scaramallion @mrbean-bremen @darcymason ).

### Motivation/Background

Single bit images are commonly encountered as segmentations (with segmentation type BINARY). One of the most common complaints with segmentations is that the file sizes can quickly become unwieldy. Largely this has been because support for compression historically has been bad so segmentations are stored with native transfer syntaxes even though they are typically very compressible. However with changes to the standard over the last few years, this problem has gradually been resolving. There are now 4 transfer syntaxes in the standard that support compression of single bit images:

- The new [DeflatedImageFrameCompression](https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_8.2.16.html), which I notice just got added to pydicom (thank you!) and prompted me to work on this
- [RLELossless](https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_8.2.2.html)
- [JPEG2000Lossless and JPEG2000](https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_8.2.4.html) (personally I don't think you should lossily compress a segmentation, but I suppose the option should be there)

However, as things stand, pydicom will not correctly compress or decompress single bit images with these transfer syntaxes. It is not allowed for the latter three, and for the unreleased DeflatedImageFrameCompression implementation it is allowed but fails with a very cryptic error message. I have never actually encountered compressed single bit files "in the wild" (i.e. that weren't created by me), which is why this has probably never come up as an issue. But through our work on the [Imaging Data Commons](https://datacommons.cancer.gov/repository/imaging-data-commons) and the [highdicom](https://github.com/ImagingDataCommons/highdicom) library, we are hoping to change this and broaden support and adoption for compressed segmentations. If we merge this PR, Pydicom might be the first tool in any language to be able to read and write compressed single bit files. I mention this mostly because it means testing will be challenging given the lack of existing files.

Of note, the change proposal for DeflatedImageFrameCompression specifically mentioned compression of segmentations as motivation for its addition the standard  because deflate is particularly effective at compressing most segmentations (that change propsoal grew out of work we have been doing at the Imaging Data Commons).

### Summary of Changes

- Change encoding profiles to allow BitsAllocated = 1 for these four transfer syntaxes
- Tweaks to the native encoder and decoder to support single bit images for DeflatedImageFrameCompression
- A generalisation of the native RLE decoder and encoder to work with single bit images
- Changes to encoder and decoder base to make all this work
- Generalise the `pack_bits` function to additionally accept bytes/bytearrays, and to fall-back to a non-numpy implementation if numpy is not present.


### Design Considerations/Point of Discussions

The trickiest aspect of all this is that single bit images are bit-packed when stored natively, giving 8 pixels to one byte. What's worse, this bit packing may cause pixels from different frames to be packed into different bytes (specifically this happens when the number of pixels in a frame is not a multiple of 8), which can lead to situations in which it becomes necessary to unpack the full array and then re-pack each frame before compressing the individual frames. Furthermore, `RLELossless` and `DeflatedImageFrameCompression` are byte-level compression methods that expect the input bytes to be packed before compressing them and give packed bits when decompressing, whereas `JPEG2000` and `JPEG2000Lossless` are image encoders that expect unpacked pixels to compress and return unpacked pixels upon decompression.

As a result, there are some difficult decisions about whether arrays/buffers should be packed (8 pixels/byte) or unpacked (1 pixel/byte) when passing across the various function calls in the compression/decompression stack. If the user passes an array for compression, they would probably want/expect this to be unpacked, since no-one works with packed arrays in numpy. However, if the source pixels are coming from an existing dataset (e.g. in a call to `compress` with no `arr` supplied), the source pixels will be bit packed and this may or may not require unpacking and repacking before compression, depending on the situation.

I considered allowing either packed or unpacked arrays/buffers to be passed around, with either an explicit argument differentating the two, or inferring it automatically by comparing the length of the array to the row and columns. I think that could be workable, but ultimately settled on a simpler approach of always passing around unpacked pixels, which is the simplest approach that can work in any situation. As a result, the encoder functions expect unpacked data and the `EncoderRunner._get_frame_buffer` method first unpacks the buffer in the case of single bit images. While this simplifies things, there are situations where this leads to unnecessary unpacking then repacking of the data (i.e. when using RLE or Deflate compression with frames that are a mlutiple of 8 pixels) during compression and decompression. I don't think my approach should preclude future optimizations that do allow passing around bit-packed buffers in order to to avoid this issue. This is the main issue that I am seeking feedback on.

Because of this design, the RLE and deflate encoders are responsible for packing bits in the single bit case before running the relevant algorithm. Since the current implementation of `pack_bits` requires its input as a `np.ndarray`, this would introduce a numpy dependency for this encoders just to handle the single bit case, which seems undesirable (and is not backwards compatible). As a result, I generalised the `pack_bits` function to allow it to work on input `bytes` or `bytearray` object, and without numpy if it is not installed. My crude non-numpy implementation is significantly less efficient but it does work, and it will always fall back to the more efficient numpy one if it can. I would be glad to hear if anyone has a smarter way of doing this without numpy, or if you prefer we rethink the whole design somehow such that the encoder plugins themselves are not responsible for packing.

### Current Status

This is a working implementation at an appropriate point for discussion and feedback. Remaining to-dos are:
- Tests
- Adding test files? (difficult because these would probably have to be created with pydicom itself)
- Documentation (I changed some docstrings but need to be more thorough)
- I still need to check whether these changes lead to unexpected behaviour with other plugins (e.g. pylibjpeg's implementation of RLELossless)

Please let me know if you have any concerns with this approach before I finalise it, particularly with regards to the discussion points above. Thanks in advance

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
