### PR TITLE
Make sure MultiValue is used for values with VM>1

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -22,6 +22,8 @@ Fixes
   *LUT Descriptor* and *Red Palette Color LUT Descriptor* (:issue:`2160`).
 * Fixed :meth:`~pydicom.dataset.Dataset.decompress` and :meth:`~pydicom.dataset.Dataset.compress`
   changing the *SOP Instance UID* when not required (:issue:`2171`).
+* Make sure the value of multi-valued tags is always returned as an instance of
+  :class:`~pydicom.multival.MultiValue`.
 
 Enhancements
 ------------

--- a/src/pydicom/hooks.py
+++ b/src/pydicom/hooks.py
@@ -7,6 +7,7 @@ from pydicom import config
 from pydicom.datadict import dictionary_VR, private_dictionary_VR
 from pydicom.errors import BytesLengthException
 from pydicom.misc import warn_and_log
+from pydicom.multival import MultiValue
 from pydicom.tag import BaseTag, _LUT_DESCRIPTOR_TAGS
 from pydicom.valuerep import VR
 
@@ -264,7 +265,7 @@ def raw_element_value(
 
     if raw.tag in _LUT_DESCRIPTOR_TAGS:
         # We only fix the first value as the third value is 8 or 16
-        if value and isinstance(value, list):
+        if value and isinstance(value, MultiValue):
             try:
                 if value[0] < 0:
                     value[0] += 65536

--- a/src/pydicom/values.py
+++ b/src/pydicom/values.py
@@ -432,7 +432,7 @@ def convert_numbers(
         return value[0]
 
     # convert from tuple to a list so can modify if need to
-    return list(value)
+    return MultiValue(type(value[0]), value)
 
 
 def convert_OBvalue(


### PR DESCRIPTION
- this had been the case before, but had changed for numeric values some time ago

This was not a real bug, just a convenience, if anyone relies on this (I myself had, see [this issue](https://github.com/pydicom/dicom-validator/issues/165)). 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
