### PR TITLE
Don't try to download on importing examples

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -24,6 +24,8 @@ Fixes
   changing the *SOP Instance UID* when not required (:issue:`2171`).
 * Make sure the value of multi-valued tags is always returned as an instance of
   :class:`~pydicom.multival.MultiValue`.
+* Make sure that no download of examples is attempted on importing examples if the example
+  data is not found locally (:issue:`2223`).
 
 Enhancements
 ------------

--- a/src/pydicom/examples/__init__.py
+++ b/src/pydicom/examples/__init__.py
@@ -10,19 +10,19 @@ from pydicom.filereader import dcmread
 # All datasets included here must be available in the package itself
 #   NOT via the pydicom-data download method
 _DATASETS: dict[str, str] = {
-    "ct": cast(str, get_testdata_file("CT_small.dcm")),
-    "dicomdir": cast(str, get_testdata_file("DICOMDIR")),
-    "jpeg2k": cast(str, get_testdata_file("examples_jpeg2k.dcm")),
-    "mr": cast(str, get_testdata_file("MR_small.dcm")),
-    "no_meta": cast(str, get_testdata_file("no_meta.dcm")),
-    "overlay": cast(str, get_testdata_file("examples_overlay.dcm")),
-    "palette_color": cast(str, get_testdata_file("examples_palette.dcm")),
-    "rgb_color": cast(str, get_testdata_file("examples_rgb_color.dcm")),
-    "rt_dose": cast(str, get_testdata_file("rtdose.dcm")),
-    "rt_plan": cast(str, get_testdata_file("rtplan.dcm")),
-    "rt_ss": cast(str, get_testdata_file("rtstruct.dcm")),
-    "waveform": cast(str, get_testdata_file("waveform_ecg.dcm")),
-    "ybr_color": cast(str, get_testdata_file("examples_ybr_color.dcm")),
+    "ct": cast(str, get_testdata_file("CT_small.dcm", download=False)),
+    "dicomdir": cast(str, get_testdata_file("DICOMDIR", download=False)),
+    "jpeg2k": cast(str, get_testdata_file("examples_jpeg2k.dcm", download=False)),
+    "mr": cast(str, get_testdata_file("MR_small.dcm", download=False)),
+    "no_meta": cast(str, get_testdata_file("no_meta.dcm", download=False)),
+    "overlay": cast(str, get_testdata_file("examples_overlay.dcm", download=False)),
+    "palette_color": cast(str, get_testdata_file("examples_palette.dcm", download=False)),
+    "rgb_color": cast(str, get_testdata_file("examples_rgb_color.dcm", download=False)),
+    "rt_dose": cast(str, get_testdata_file("rtdose.dcm", download=False)),
+    "rt_plan": cast(str, get_testdata_file("rtplan.dcm", download=False)),
+    "rt_ss": cast(str, get_testdata_file("rtstruct.dcm", download=False)),
+    "waveform": cast(str, get_testdata_file("waveform_ecg.dcm", download=False)),
+    "ybr_color": cast(str, get_testdata_file("examples_ybr_color.dcm", download=False)),
 }
 
 

--- a/src/pydicom/examples/__init__.py
+++ b/src/pydicom/examples/__init__.py
@@ -16,7 +16,9 @@ _DATASETS: dict[str, str] = {
     "mr": cast(str, get_testdata_file("MR_small.dcm", download=False)),
     "no_meta": cast(str, get_testdata_file("no_meta.dcm", download=False)),
     "overlay": cast(str, get_testdata_file("examples_overlay.dcm", download=False)),
-    "palette_color": cast(str, get_testdata_file("examples_palette.dcm", download=False)),
+    "palette_color": cast(
+        str, get_testdata_file("examples_palette.dcm", download=False)
+    ),
     "rgb_color": cast(str, get_testdata_file("examples_rgb_color.dcm", download=False)),
     "rt_dose": cast(str, get_testdata_file("rtdose.dcm", download=False)),
     "rt_plan": cast(str, get_testdata_file("rtplan.dcm", download=False)),


### PR DESCRIPTION
- if the example data are not found locally for some reason, they should not be looked up externally
- fixes #2223

Instead of changing the default for `dowload`, this just avoids the download in the import if the example data is not available for some reason (they are not available remotely anyway). This does not change the behavior in any other way.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working - could not think of a simple test here
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
