### PR TITLE
Migrate to modern logger interface

### DIFF
--- a/src/pydicom/fileutil.py
+++ b/src/pydicom/fileutil.py
@@ -30,7 +30,7 @@ def absorb_delimiter_item(
     group, elem, length = unpack(struct_format, fp.read(8))
     tag = TupleTag((group, elem))
     if tag != delimiter:
-        logger.warn(
+        logger.warning(
             "Did not find expected delimiter "
             f"'{dictionary_description(delimiter)}', instead found "
             f"{tag} at file position 0x{fp.tell() - 8:X}"


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
