### PR TITLE
Add a suggested keyword when using unknown camel case dataset attribute

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -53,3 +53,4 @@ Enhancements
 * Added support for ``YBR_PARTIAL_420`` and ``YBR_PARTIAL_422`` to
   :func:`~pydicom.pixels.convert_color_space` (:issue:`2210`)
 * Added support for compressing and decompressing *Deflated Image Frame Compression* (:issue:`2213`)
+* Suggest an element keyword when an unknown camel case dataset attribute is used.

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -64,7 +64,7 @@ from pydicom.datadict import (
 from pydicom.dataelem import DataElement, convert_raw_data_element, RawDataElement
 from pydicom.filebase import ReadableBuffer, WriteableBuffer
 from pydicom.fileutil import path_from_pathlike, PathType
-from pydicom.misc import warn_and_log
+from pydicom.misc import warn_and_log, find_keyword_candidates
 from pydicom.pixels import compress, convert_color_space, decompress, pixel_array
 from pydicom.pixels.utils import (
     reshape_pixel_array,
@@ -2731,9 +2731,12 @@ class Dataset:
             # Warn if `name` is camel case but not a keyword
             if _RE_CAMEL_CASE.match(name):
                 msg = (
-                    f"Camel case attribute '{name}' used which is not in the "
-                    "element keyword data dictionary"
+                    f"Camel case attribute '{name}' used which is not a known public "
+                    "element keyword"
                 )
+                if candidates := find_keyword_candidates(name):
+                    msg += f", did you mean '{candidates[0]}'?"
+
                 if config.INVALID_KEYWORD_BEHAVIOR == "WARN":
                     warn_and_log(msg)
                 elif config.INVALID_KEYWORD_BEHAVIOR == "RAISE":

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -186,8 +186,8 @@ class TestDataset:
         """Dataset: can set class instance property (non-dicom)."""
         ds = Dataset()
         msg = (
-            r"Camel case attribute 'SomeVariableName' used which is not in "
-            r"the element keyword data dictionary"
+            r"Camel case attribute 'SomeVariableName' used which is not a "
+            r"known public element keyword"
         )
         with pytest.warns(UserWarning, match=msg):
             ds.SomeVariableName = 42
@@ -477,8 +477,8 @@ class TestDataset:
         ds.PatientName = "name"
         ds.PatientID = "id"
         msg = (
-            r"Camel case attribute 'NonDicomVariable' used which is not in "
-            r"the element keyword data dictionary"
+            r"Camel case attribute 'NonDicomVariable' used which is not a "
+            r"known public element keyword"
         )
         with pytest.warns(UserWarning, match=msg):
             ds.NonDicomVariable = "junk"
@@ -498,8 +498,8 @@ class TestDataset:
         ds.PatientName = "name"
         ds.PatientID = "id"
         msg = (
-            r"Camel case attribute 'NonDicomVariable' used which is not in "
-            r"the element keyword data dictionary"
+            r"Camel case attribute 'NonDicomVariable' used which is not a "
+            r"known public element keyword"
         )
         with pytest.warns(UserWarning, match=msg):
             ds.NonDicomVariable = "junk"
@@ -658,8 +658,8 @@ class TestDataset:
         # Non-element class members are ignored in equality testing
         d = Dataset()
         msg = (
-            r"Camel case attribute 'SOPEustaceUID' used which is not in "
-            r"the element keyword data dictionary"
+            r"Camel case attribute 'SOPEustaceUID' used which is not a "
+            r"known public element keyword"
         )
         with pytest.warns(UserWarning, match=msg):
             d.SOPEustaceUID = "1.2.3.4"
@@ -2773,12 +2773,12 @@ CAMEL_CASE = (
         "PatientName",
     ],
     [  # Should warn
-        "bitsStored",
-        "BitSStored",
-        "TwelveLeadECG",
-        "SOPInstanceUId",
-        "PatientsName",
-        "Rowds",
+        ("bitsStored", "BitsStored"),
+        ("BitSStored", "BitsStored"),
+        ("TwelveLeadECG", ""),
+        ("SOPInstanceUId", "SOPInstanceUID"),
+        ("PatientsName", "PatientName"),
+        ("Rowds", "Rows"),
     ],
 )
 
@@ -2831,11 +2831,14 @@ def test_setattr_warns(setattr_warn):
                 val = getattr(ds, s, None)
                 setattr(ds, s, val)
 
-    for s in CAMEL_CASE[1]:
+    for s, kw in CAMEL_CASE[1]:
         msg = (
-            r"Camel case attribute '" + s + r"' used which is not in the "
-            r"element keyword data dictionary"
+            r"Camel case attribute '" + s + r"' used which is not a known public "
+            r"element keyword"
         )
+        if kw:
+            msg += f", did you mean '{kw}'"
+
         with pytest.warns(UserWarning, match=msg):
             val = getattr(ds, s, None)
             setattr(ds, s, None)
@@ -2862,11 +2865,14 @@ def test_setattr_raises(setattr_raise):
                 val = getattr(ds, s, None)
                 setattr(ds, s, val)
 
-    for s in CAMEL_CASE[1]:
+    for s, kw in CAMEL_CASE[1]:
         msg = (
-            r"Camel case attribute '" + s + r"' used which is not in the "
-            r"element keyword data dictionary"
+            r"Camel case attribute '" + s + r"' used which is not a known public "
+            r"element keyword"
         )
+        if kw:
+            msg += f", did you mean '{kw}'"
+
         with pytest.raises(ValueError, match=msg):
             val = getattr(ds, s, None)
             setattr(ds, s, None)
@@ -2894,7 +2900,7 @@ def test_setattr_ignore(setattr_ignore):
                 setattr(ds, s, val)
 
     ds = Dataset()
-    for s in CAMEL_CASE[1]:
+    for s, kw in CAMEL_CASE[1]:
         with assert_no_warning():
             getattr(ds, s, None)
             setattr(ds, s, None)

--- a/tests/test_gdcm_pixel_data.py
+++ b/tests/test_gdcm_pixel_data.py
@@ -647,7 +647,6 @@ class TestSupportFunctions:
         assert data_element.GetByteValue() is None
 
     def test_create_image_from_3d_dataset(self, dataset_3d):
-        data_element = gdcm_handler.create_data_element(dataset_3d)
         image = gdcm_handler.create_image(dataset_3d)
         assert 3 == image.GetNumberOfDimensions()
         assert [

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -7,7 +7,7 @@ import os
 import pytest
 
 from pydicom.data import get_testdata_file
-from pydicom.misc import is_dicom, size_in_bytes, warn_and_log
+from pydicom.misc import is_dicom, size_in_bytes, warn_and_log, find_keyword_candidates
 
 
 test_file = get_testdata_file("CT_small.dcm")
@@ -66,3 +66,23 @@ class TestMisc:
                 warn_and_log("Foo!")
 
             assert "Foo" in caplog.text
+
+    def test_find_keyword_candidates(self):
+        """Test find_keyword_candidates()"""
+        results = find_keyword_candidates(
+            "Patientnae", allowed_edits=2, max_candidates=None
+        )
+        assert results == ["PatientAge", "PatientName"]
+
+        results = find_keyword_candidates(
+            "SelectorULValue", allowed_edits=1, max_candidates=None
+        )
+        assert len(results) == 11
+        results = find_keyword_candidates(
+            "SelectorULValue", allowed_edits=2, max_candidates=None
+        )
+        assert len(results) == 33
+        results = find_keyword_candidates(
+            "SelectorULValue", allowed_edits=2, max_candidates=2
+        )
+        assert len(results) == 2


### PR DESCRIPTION
#### Describe the changes
Add a suggested element keyword when an unknown keyword is used with `Dataset`. I've kept the number of edits allowed to 1 as our default is only to warn and 2 edits is noticeably slower.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
