### PR TITLE
[MRG] Remove hardcoded number of test files

### DIFF
--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -327,7 +327,7 @@ def test_fetch_data_files_download_failure(download_failure):
     """Test fetch_data_files() with download failures."""
     msg = (
         r"The following exception\(s\) occurred trying to download the data files\n"
-        r"  'RuntimeError: No network!' for 693_J2KR.dcm, 693_UNCI.dcm and 77 others"
+        r"  'RuntimeError: No network!' for 693_J2KR.dcm, 693_UNCI.dcm and [0-9]+ others"
     )
     with pytest.raises(RuntimeError, match=msg):
         fetch_data_files()


### PR DESCRIPTION
#### Describe the changes

Recent changes in https://github.com/pydicom/pydicom/pull/2240 added a hard-coded number of test files to a test of the data manager. This means that any pull request that introduces new test files fails. I assume this was not deliberate, as it doesn't seem to be useful to check the exact number of files. For example merge tests on #2216 are currently failing because of this. See [here](https://github.com/pydicom/pydicom/actions/runs/16543684622/job/46788400137?pr=2216):

```
FAILED tests/test_data_manager.py::test_fetch_data_files_download_failure - AssertionError: Regex pattern did not match.
 Regex: "The following exception\\(s\\) occurred trying to download the data files\\n  'RuntimeError: No network!' for 693_J2KR.dcm, 693_UNCI.dcm and 77 others"
 Input: "The following exception(s) occurred trying to download the data files\n  'RuntimeError: No network!' for 693_J2KR.dcm, 693_UNCI.dcm and 83 others"
```

In this PR I switch the hard-coded number (`77`) for a regex (`[0-9]+`)

#### Tasks
- [N/A] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [N/A] Code typed and mypy shows no errors
- [ N/A] Documentation updated (if relevant)
  - [x] No warnings during build
  - [N/A] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
