### PR TITLE
Add exception handling to Dataset context manager exit

### DIFF
--- a/src/pydicom/config.py
+++ b/src/pydicom/config.py
@@ -133,7 +133,7 @@ def DS_numpy(use_numpy: bool = True) -> None:
     use_numpy : bool, optional
         ``True`` (default) to read multi-value **DS** elements
         as :class:`~numpy.ndarray`, ``False`` to read multi-valued **DS**
-        data elements as type :class:`~python.mulitval.MultiValue`
+        data elements as type :class:`~pydicom.multival.MultiValue`
 
         Note: once a value has been accessed, changing this setting will
         no longer change its type

--- a/src/pydicom/dataset.py
+++ b/src/pydicom/dataset.py
@@ -19,6 +19,7 @@ import io
 import json
 import os
 import os.path
+from pathlib import Path
 import re
 from bisect import bisect_left
 from collections.abc import (
@@ -31,8 +32,10 @@ from collections.abc import (
 )
 from contextlib import nullcontext
 from importlib.util import find_spec as have_package
-from itertools import takewhile
-from types import TracebackType
+from itertools import chain, takewhile
+import sys
+import traceback
+from types import SimpleNamespace, TracebackType
 from typing import (
     TypeAlias,
     Any,
@@ -440,6 +443,35 @@ class Dataset:  # noqa: PLW1641
         exc_tb: TracebackType | None,
     ) -> bool | None:
         """Method invoked on exit from a with statement."""
+        new_elem = False
+        if exc_val is not None:
+            # Find first data element or Sequence up the trace
+            tb = exc_val.__traceback__
+            all_frames = list(traceback.walk_tb(tb))
+            note = ""
+            for frame, lineno in reversed(all_frames):
+                filename = Path(frame.f_code.co_filename).name
+                if filename in ("dataelem.py", "sequence.py"): 
+                    elem = frame.f_locals.get("self")
+                    if elem and (path := path_to(elem, self)):
+                        note = "Error occurred at " + path
+                        break
+                    else:
+                        new_elem = filename == "dataelem.py"
+                elif filename == "dataset.py":
+                    elem = frame.f_locals.get("self")
+                    if elem is self:
+                        break
+                    path = path_to(elem, self)
+                    if path:
+                        if new_elem:
+                            note = "New data element at "
+                        note += path
+                        break
+            if note:
+                if sys.version_info >= (3, 11):
+                    exc_val.add_note(note)
+
         # Returning anything other than True will re-raise any exceptions
         return None
 
@@ -1085,7 +1117,7 @@ class Dataset:  # noqa: PLW1641
                 self[tag] = correct_ambiguous_vr_element(self[tag], self, elem[6])
 
         return cast(DataElement, self._dict.get(tag))
-
+    
     def private_block(
         self, group: int, private_creator: str, create: bool = False
     ) -> PrivateBlock:
@@ -3673,3 +3705,64 @@ _RE_CAMEL_CASE = re.compile(
     "(?P<start>(^[A-Za-z])((?=.+?[A-Z])[A-Za-z0-9]+)|(^[A-Z])([A-Za-z0-9]+))"
     "(?P<last>[A-Za-z0-9][^_]$)"  # Last character is alphanumeric
 )
+
+
+def path_to(target, node) -> str | None:
+    """Return a pseudo-code path to a particular DataElement, Sequence, or value
+    
+    This is used by Dataset's context manager to report the specific data element
+    where an error occurred.
+
+    Params
+    ------
+    target: Any
+        Usually a DataElement, Sequence, or Sequence item.  Can be a value, 
+        in which case the path to the first DataElement found (depth first search)
+        with that value is returned.
+    node: Any
+        The object currently being searched (function is called recursively).  
+        First call to the function will typically be a Dataset
+
+    Returns
+    -------
+    str | None:  
+        The path to the target object from the node.  
+        During recursion, returns none if a leaf node reached without finding target.
+    
+    Examples
+    --------
+    >> path_to(data_element)
+    'FileDataset(filename='rtplan.dcm').BeamSequence[0].BeamName'
+    
+    """
+    ns = SimpleNamespace(target=target)  # make dotted lookup to avoid name binding
+    match node:
+        case elem if node is target:  # done if match on identity
+            return f""
+        
+        case Dataset():
+            if hasattr(node, "file_meta"):
+                items = chain(node.items(), node.file_meta.items()) 
+            else:
+                items = node.items()
+            for tag, dataelem in items:
+                if (path := path_to(target, dataelem)) is not None:
+                    tag_str = keyword_for_tag(tag)
+                    prefix = f"FileDataset(filename='{node.filename}')" if hasattr(node, "filename") else ""
+                    if tag.group == 2:
+                        prefix += ".file_meta"
+                    if tag_str:
+                        return f"{prefix}.{tag_str}" + path
+                    else:
+                        return f"{prefix}[{tag}]" + path
+            # XX could also go down node.file_meta here, if it exists       
+                
+        case DataElement(VR="SQ"):
+            for i, subnode in enumerate(node.value):
+                if (path := path_to(target, subnode)) is not None:
+                    return f"[{i}]" + path
+        
+        case DataElement(value=ns.target): # Done if match a data element value
+            return ""  # f" (value = {target})"
+
+    return None


### PR DESCRIPTION

#### Describe the changes
Related to issue #2168.  Adds a 'path' to the object where an error occurred, if using Dataset in a context manager `with` statement.

This is a first-pass rough proof of principle.
* requires some introspection of stack frames to try to determine the source, with some faith in finding which object the error point was operating on (here just use `self` from local vars).
* first commit just trapping for an error when setting an existing or new data element
* would need to work out different types of errors and how to determine which object information is useful to present
* first commit needs Python >= 3.11 to use `add_notes` for exceptions.  For Py 3.10, maybe do something like `tag_in_exception` does to add the message.
* credit:  `path_to` patterned closely to a json example from a Raymond Hettinger talk.  Uses `match`/`case` which is available Python 3.10+
* I've added this to Dataset, but could make a stand-alone context manager.  `Dataset` is nice because if `FileDataset`, the filename is reported.

Also
* happened to see and fix a DS_numpy docstring


Looking for feedback before pursuing further.  Of course, so far this only helps a user locate where it happened (super-charged version of `tag_in_exception`).  Still need to address more meaningful info about conversion errors, etc.


#### Tasks
- [x] (some) Unit tests added that reproduce the issue or prove feature is working
- [x] (in progress) Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
