### PR TITLE
Add support for registering public transfer syntaxes

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -59,3 +59,4 @@ Enhancements
   :func:`~pydicom.pixels.convert_color_space` (:issue:`2210`)
 * Added support for compressing and decompressing *Deflated Image Frame Compression* (:issue:`2213`)
 * Suggest an element keyword when an unknown camel case dataset attribute is used.
+* Added support for adding unknown public transfer syntaxes to :func:`~pydicom.uid.register_transfer_syntax`


### PR DESCRIPTION
#### Describe the changes
* Add support for registering unknown public transfer syntaxes via `register_transfer_syntax()`.
* Disallow registering the same UID twice

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] [Documentation updated](https://output.circle-artifacts.com/output/job/e901b9ef-16db-4ce8-995b-35eabeddb424/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
