### PR TITLE
Add per-frame options and improved colour conversion with Pillow

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -97,7 +97,7 @@ extlinks = {
     "gh": ("https://github.com/pydicom/%s", None),
     "issue": ("https://github.com/pydicom/pydicom/issues/%s", "#%s"),
     "pr": ("https://github.com/pydicom/pydicom/pull/%s", "#%s"),
-    "wiki": ("https://en.wikipedia.org/wiki/%s", "#%s"),
+    "wiki": ("https://en.wikipedia.org/wiki/%s", None),
 }
 
 # intersphinx configuration

--- a/doc/guides/decoding/decoder_plugins.rst
+++ b/doc/guides/decoding/decoder_plugins.rst
@@ -76,11 +76,12 @@ A decoding plugin must implement three objects within the same module:
   * ``number_of_frames``: :class:`int` - the number of image frames
     contained in `src`
   * ``bits_allocated``: :class:`int` - the number of bits used to contain
-    each pixel in `src`, should be a multiple of 8.
+    each pixel in `src`, should be 1 or a multiple of 8.
   * ``photometric_interpretation``: :class:`str` - the color space
     of the encoded data, such as ``'YBR_FULL'``
   * ``pixel_keyword``: :class:`str` - one of ``"PixelData"``, ``"FloatPixelData"``,
     ``"DoubleFloatPixelData"``.
+  * ``as_rgb``: :class:`bool` - whether or not YCbCr data should be converted to RGB.
 
   And conditionally:
 
@@ -93,14 +94,31 @@ A decoding plugin must implement three objects within the same module:
   * ``planar_configuration``: :class:`int` - required when ``samples_per_pixel``
     > 1, ``0`` for color-by-pixel, ``1`` for color-by-plane.
 
-  If your decoder needs to signal that one of the decoding option values needs
-  to be modified then this can be done with the
-  :meth:`~pydicom.pixels.decoders.base.DecodeRunner.set_option` method. This
-  should only be done after successfully decoding the frame, as if the
-  decoding fails changing the option value may cause issues with
-  other decoding plugins that may also attempt to decode the same frame. It's also
-  important to be aware that any changes you make will also affect following frames
-  (if any).
+  In addition, the following options for individual frames can be set or retrieved
+  by the plugin using the :meth:`~pydicom.pixels.decoders.base.DecodeRunner.get_frame_option`
+  and :meth:`~pydicom.pixels.decoders.base.DecodeRunner.set_frame_option` methods:
+
+  * ``bits_allocated``: :class:`int` - the number of bits used to contain
+    each pixel in the decoded frame, should be 1 or a multiple of 8.
+  * ``photometric_interpretation``: :class:`str` - the color space of the decoded
+    frame, such as ``'YBR_FULL'``.
+  * ``planar_configuration``: :class:`int` - the order of the pixels in the decoded
+    frame, available when ``samples_per_pixel`` > 1, ``0`` for color-by-pixel, ``1``
+    for color-by-plane.
+  * ``jls_precision`` :class:`int` - the precision used in the JPEG-LS codestream for
+    the frame being decoded (JPEG-LS transfer syntaxes only).
+  * ``j2k_precision``: :class:`int` - the precision used in the JPEG 2000 codestream
+    for the frame being decoded (JPEG 2000 transfer syntaxes only).
+  * ``j2k_is_signed``: :class:`bool` - whether the JPEG 2000 codestream for the frame
+    frame being decoded uses signed integers or not (JPEG 2000 transfer syntaxes only).
+  * ``is_bitpacked``: :class:`bool` - whether or not the frame's data has been
+    bit-packed.
+
+  The values for these frame options should be set appropriately to match the decoded
+  pixel data returned by the plugin. For example, if a frame's original
+  ``photometric_interpretation`` is ``YBR_FULL`` and the plugin converts it to ``RGB``
+  then you should use :meth:`~pydicom.pixels.decoders.base.DecodeRunner.set_frame_option`
+  to reflect the change in color space.
 
   When possible it's recommended that the decoding function return the decoded
   pixel data as a :class:`bytearray` to minimize later memory usage.

--- a/doc/guides/encoding/encoder_plugins.rst
+++ b/doc/guides/encoding/encoder_plugins.rst
@@ -63,7 +63,7 @@ An encoding plugin must implement three objects within the same module:
     * ``'number_of_frames'``: :class:`int` - the number of image frames
       contained in `src`
     * ``'bits_allocated'``: :class:`int` - the number of bits used to contain
-      each pixel in `src`, should be a multiple of 8.
+      each pixel in `src`, should be 1 or a multiple of 8.
     * ``'bits_stored'``: :class:`int` - the number of bits actually used by
       each pixel in `src`, e.g. 12-bit pixel data (range 0 to 4095) will be
       contained by 16-bits (range 0 to 65535).
@@ -72,6 +72,14 @@ An encoding plugin must implement three objects within the same module:
       integers.
     * ``'photometric_interpretation'``: :class:`str` - the intended color space
       of the encoded data, such as ``'YBR_FULL'``
+
+    In addition, the following option for individual frames can be set or retrieved
+    by the plugin using the
+    :meth:`~pydicom.pixels.encoders.base.EncodeRunner.get_frame_option` and
+    and :meth:`~pydicom.pixels.encoders.base.EncodeRunner.set_frame_option` methods:
+
+    * ``bits_allocated``: :class:`int` - the number of bits used to contain each pixel
+      in the frame, should be 1 (for bit-packed data) or a multiple of 8.
 
     If your encoder needs to signal that one of the encoding option values needs
     to be modified then this can be done with the

--- a/doc/guides/plugin_table.rst
+++ b/doc/guides/plugin_table.rst
@@ -92,8 +92,8 @@ Plugin requirements and limitations
 | Plugin        | Requires                                  | Known limitations                                                   |
 +===============+===========================================+===============================+=====================================+
 | ``pylibjpeg`` | `pylibjpeg <pylj_>`_ and at least one of  | * Maximum supported *Bits Stored* for JPEG 2000 and HTJ2K is 24     |
-|               | `pylibjpeg-libjpeg <pylj-lj_>`_,          |                                                                     |
-|               | `pylibjpeg-openjpeg <pylj-oj_>`_ and      |                                                                     |
+|               | `pylibjpeg-libjpeg <pylj-lj_>`_,          | * Slower than ``pillow`` to decode *JPEG Baseline* and *JPEG        |
+|               | `pylibjpeg-openjpeg <pylj-oj_>`_ and      |   Extended 12-bit*, especially if needing to convert to RGB         |
 |               | `pylibjpeg-rle <pylj-rle_>`_              |                                                                     |
 +---------------+-------------------------------------------+---------------------------------------------------------------------+
 | ``gdcm``      | `python-gdcm <py-gdcm_>`_                 | * *JPEG Extended 12-bit* is only available if *Bits Allocated* is 8 |
@@ -102,6 +102,8 @@ Plugin requirements and limitations
 |               |                                           | * *JPEG-LS Lossless* and *JPEG-LS Near Lossless* only if            |
 |               |                                           |   *Bits Stored* is not 6 or 7                                       |
 |               |                                           | * Maximum supported *Bits Stored* is 16                             |
+|               |                                           | * Slower than ``pillow`` to decode *JPEG Baseline* and *JPEG        |
+|               |                                           |   Extended 12-bit*, especially if needing to convert to RGB         |
 +---------------+-------------------------------------------+---------------------------------------------------------------------+
 | ``pillow``    | `Pillow <pil_>`_, with support for JPEG   | * *JPEG Extended 12-bit* is only available if *Bits Allocated* is 8 |
 |               | 2000 via Pillow's `Jpeg2KImagePlugin      | * *JPEG 2000 Lossless* and *JPEG 2000* are only available           |

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -6,6 +6,13 @@ Changes
 
 * DICOM dictionary updated to 2024d.
 * Prefer using pylibjpeg over GDCM when encoding *RLE Lossless*.
+* Prefer using Pillow when decoding *JPEG Baseline 8-bit* and *JPEG Extended 12-bit*
+* Improvements made to communications with the plugins when decoding and encoding pixel
+  data and correcting for inter-frame decoding variations in multi-frame datasets (:pr:``).
+* The metadata returned by :meth:`Decoder.as_buffer
+  <pydicom.pixels.decoders.base.Decoder.as_buffer>` is now a ``dict`` containing the
+  per-frame metadata to help account for inter-frame variations in frame properties
+  when decoding.
 
 Fixes
 -----
@@ -48,10 +55,10 @@ Enhancements
 * Updated UIDs to version 2024d of the DICOM Standard
 * The following UID constants have been added:
 
-    * :attr:`~pydicom.uid.JPEGXLLossless`
-    * :attr:`~pydicom.uid.JPEGXLJPEGRecompression`
-    * :attr:`~pydicom.uid.JPEGXL`
-    * :attr:`~pydicom.uid.DeflatedImageFrameCompression`
+  * :attr:`~pydicom.uid.JPEGXLLossless`
+  * :attr:`~pydicom.uid.JPEGXLJPEGRecompression`
+  * :attr:`~pydicom.uid.JPEGXL`
+  * :attr:`~pydicom.uid.DeflatedImageFrameCompression`
 * Added ability to specify tag numbers in the CLI commands (allows private tags to be specified)
 * Removed `exec` and `eval` from tests, CLI, and scripts for improved security (:issue:`2193`)
 * Added support for up to 16-bit input images to :func:`~pydicom.pixels.convert_color_space`
@@ -63,3 +70,7 @@ Enhancements
   where an error occurred.  Activated using `with dataset:` context; already used internally in key
   locations (:issue:`2168`)
 * Added support for adding unknown public transfer syntaxes to :func:`~pydicom.uid.register_transfer_syntax`
+* When decoding JPEG pixel data use Pillow's color transformations rather than
+  :func:`~pydicom.pixels.convert_color_space` where applicable (:issue:`2228`)
+* Take the color space information from an Adobe APP14 marker into account when decoding
+  pixel data for JPEG transfer syntaxes.

--- a/src/pydicom/pixels/common.py
+++ b/src/pydicom/pixels/common.py
@@ -265,6 +265,26 @@ class CoderBase:
         )
 
 
+class FrameOptions(TypedDict, total=False):
+    """Options accepted by RunnerBase.set_frame_option()"""
+
+    ## DecodeRunner
+    decoding_plugin: str
+
+    # Pixel data description options
+    bits_allocated: int  # bits_allocated 1 indicates the frame data is bit-packed
+    photometric_interpretation: str
+    planar_configuration: int
+
+    # JPEG-LS and JPEG2000 codestream parameters
+    jls_precision: int
+    j2k_precision: int
+    j2k_is_signed: bool
+
+    ## EncodeRunner
+    encoding_plugin: str
+
+
 # TODO: Python 3.11 switch to StrEnum
 @unique
 class PhotometricInterpretation(str, Enum):
@@ -312,6 +332,12 @@ class RunnerBase:
         # The source type, one of "Dataset", "Buffer", "Array" or "BinaryIO"
         self._src_type = "UNDEFINED"
 
+        # The frame currently being encoded/decoded
+        self._index: int
+        # The frame meta information, keyed to the frame index
+        # Keys are not guaranteed to start at index 0
+        self._frame_meta: dict[int, FrameOptions] = {}
+
     @property
     def bits_allocated(self) -> int:
         """Return the expected number of bits allocated used by the data."""
@@ -358,9 +384,15 @@ class RunnerBase:
         """
         return self._opts.get("extended_offsets", None)
 
-    def frame_length(self, unit: str = "bytes") -> int | float:
+    def frame_length(
+        self, unit: str = "bytes", index: int | None = None
+    ) -> int | float:
         """Return the expected length (in number of bytes or pixels) of each
         frame of pixel data.
+
+        .. versionchanged:: 3.1
+
+            Added the `index` parameter.
 
         Parameters
         ----------
@@ -370,6 +402,11 @@ class RunnerBase:
             padding byte. If ``"pixels"`` then returns the expected length of
             the pixel data in terms of the total number of pixels (default
             ``"bytes"``).
+        index : int | None, optional
+            If ``None`` return the length determined using the expected pixel data
+            property values (default), otherwise return the length calculated using
+            the property values determined during encoding or decoding for the frame
+            at `index`.
 
         Returns
         -------
@@ -377,7 +414,7 @@ class RunnerBase:
             The expected length of a single frame of pixel data in either whole
             bytes or pixels, excluding the NULL trailing padding byte for odd
             length data. For "pixels", an integer will always be returned. For
-            "bytes", a float will be returned for images with BitsAllocated of
+            "bytes", a float will be returned for images with *Bits Allocated* of
             1 whose frames do not consist of a whole number of bytes.
         """
         length: int | float = self.rows * self.columns * self.samples_per_pixel
@@ -386,7 +423,13 @@ class RunnerBase:
             return length
 
         # Correct for the number of bytes per pixel
-        if self.bits_allocated == 1:
+        bits_allocated = self.bits_allocated
+        if index is not None:
+            bits_allocated = self.get_frame_option(
+                index, "bits_allocated", bits_allocated
+            )
+
+        if bits_allocated == 1:
             if self.transfer_syntax.is_encapsulated:
                 # Determine the nearest whole number of bytes needed to contain
                 # 1-bit pixel data. e.g. 10 x 10 1-bit pixels is 100 bits,
@@ -400,20 +443,82 @@ class RunnerBase:
                 if length.is_integer():
                     length = int(length)
         else:
-            length *= self.bits_allocated // 8
+            length *= bits_allocated // 8
 
         # DICOM Standard, Part 4, Annex C.7.6.3.1.2 - native only
         if (
             self.photometric_interpretation == PhotometricInterpretation.YBR_FULL_422
-            and not self.transfer_syntax.is_encapsulated
+            and not self.is_encapsulated
         ):
             length = length // 3 * 2
 
         return length
 
+    def get_frame_option(
+        self, index: int | None, name: str, default: Any = None
+    ) -> Any:
+        """Return the value of the option `name` for all frames or the frame at `index`.
+
+        .. versionadded:: 3.1
+
+        Parameters
+        ----------
+        index : int | None
+            The index of the frame to get the option for, or if ``None`` then the
+            corresponding value for all frames.
+        name : str
+            The name of the option to get.
+        default : Any, optional
+            The value to return if either `index` or `name` is not found.
+
+        Returns
+        -------
+        Any
+            The option value for the frame at `index` or the `default` if no such
+            frame exists or if no `name` option exists.
+
+        Raises
+        ------
+        ValueError
+            If `index` is ``None`` and multiple inconsistent values for the option are
+            found.
+        """
+        if index is None:
+            values = [
+                v[name]  # type: ignore[literal-required]
+                for v in self._frame_meta.values()
+                if name in v
+            ]
+            if not values:
+                return default
+
+            if len(set(values)) == 1:
+                return values[0]
+
+            values_str = ", ".join([str(v) for v in sorted(list(set(values)))])
+            raise ValueError(
+                f"Multiple inconsistent inter-frame values found for '{name}': "
+                f"{values_str}"
+            )
+
+        if index not in self._frame_meta:
+            return default
+
+        return self._frame_meta[index].get(name, default)
+
     def get_option(self, name: str, default: Any = None) -> Any:
         """Return the value of the option `name`."""
         return self._opts.get(name, default)
+
+    @property
+    def index(self) -> int:
+        """Return the index of the frame currently being encoded or decoded. Only
+        available for encapsulated transfer syntaxes.
+        """
+        if hasattr(self, "_index"):
+            return self._index
+
+        raise ValueError("The frame 'index' is not available")
 
     @property
     def is_array(self) -> bool:
@@ -434,6 +539,20 @@ class RunnerBase:
     def is_dataset(self) -> bool:
         """Return ``True`` if the pixel data source is a :class:`~pydicom.dataset.Dataset`"""
         return self._src_type == "Dataset"
+
+    @property
+    def is_encapsulated(self) -> bool:
+        """Return ``True`` if the corresponding *Transfer Syntax UID* uses an
+        encapsulated encoding.
+        """
+        return self.transfer_syntax.is_encapsulated
+
+    @property
+    def is_native(self) -> bool:
+        """Return ``True`` if the corresponding *Transfer Syntax UID* uses native
+        encoding.
+        """
+        return not self.transfer_syntax.is_encapsulated
 
     @property
     def number_of_frames(self) -> int:
@@ -508,6 +627,41 @@ class RunnerBase:
 
         raise AttributeError("No value for 'samples_per_pixel' has been set")
 
+    def set_frame_option(self, index: int, name: str, value: Any) -> None:
+        """Set an option for the frame at `index`.
+
+        .. versionadded:: 3.1
+
+        Parameters
+        ----------
+        index : int
+            The index of the frame to set the option for.
+        name : str
+            The name of the option to set.
+        value : Any
+            The value of the option.
+        """
+        if name == "bits_allocated" and ((value != 1 and value % 8) or value == 0):
+            raise ValueError(
+                f"Invalid 'bits_allocated' value '{value}' for frame {index}, must "
+                "be 1 or a multiple of 8"
+            )
+
+        if name == "planar_configuration" and value not in (0, 1):
+            raise ValueError(
+                f"Invalid 'planar_configuration' value '{value}' for frame {index}, "
+                "must be 0 or 1"
+            )
+
+        if name == "photometric_interpretation":
+            try:
+                value = PhotometricInterpretation(value)
+            except ValueError:
+                pass
+
+        opts = self._frame_meta.setdefault(index, {})
+        opts[name] = value  # type: ignore[literal-required]
+
     def set_option(self, name: str, value: Any) -> None:
         """Set a runner option.
 
@@ -527,15 +681,14 @@ class RunnerBase:
                 )
                 value = 1
         elif name == "photometric_interpretation":
-            if value == "PALETTE COLOR":
-                value = PhotometricInterpretation.PALETTE_COLOR
             try:
-                value = PhotometricInterpretation[value]
-            except KeyError:
+                value = PhotometricInterpretation(value)
+            except ValueError:
                 pass
 
         self._opts[name] = value  # type: ignore[literal-required]
 
+    # TODO: Python 3.11 use typing.Unpack
     def set_options(self, **kwargs: "DecodeOptions | EncodeOptions") -> None:
         """Set multiple runner options.
 
@@ -672,7 +825,6 @@ class RunnerOptions(TypedDict, total=False):
     ## Pixel data description options
     # Required
     bits_allocated: int
-    bits_stored: int
     columns: int
     number_of_frames: int
     photometric_interpretation: str
@@ -685,12 +837,9 @@ class RunnerOptions(TypedDict, total=False):
     # Conditionally required if samples_per_pixel > 1
     planar_configuration: int
 
+    # Conditionally required if pixel_keyword is PixelData
+    bits_stored: int
+
     # Optional
     # The Extended Offset Table values
     extended_offsets: tuple[bytes, bytes] | tuple[list[int], list[int]]
-
-    # Whether or not single bit data (with Bits Allocated = 1) is passed
-    # to/from encoder/decoder functions in a bit-packed format (if True) or
-    # unpacked format (if False). The unpacked stores each pixel in a uint8
-    # with value 0 or 1. Ignored if BitsAllocated > 1.
-    is_bitpacked: bool

--- a/src/pydicom/pixels/decoders/base.py
+++ b/src/pydicom/pixels/decoders/base.py
@@ -24,6 +24,7 @@ from pydicom.pixels.common import (
     RunnerOptions,
     CoderBase,
     PhotometricInterpretation as PI,
+    FrameOptions,
 )
 from pydicom.pixels.processing import convert_color_space
 from pydicom.pixels.utils import (
@@ -66,9 +67,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 DecodeFunction = Callable[[bytes, "DecodeRunner"], bytes | bytearray]
-ProcessingFunction = Callable[
-    ["np.ndarray", "DecodeRunner", dict[str, str | int]], "np.ndarray"
-]
 
 
 class DecodeOptions(RunnerOptions, total=False):
@@ -112,47 +110,127 @@ class DecodeOptions(RunnerOptions, total=False):
     gdcm_fix_big_endian: bool  # Apply fixes for GDCM on big endian systems
 
 
+ProcessingFunction = Callable[
+    ["np.ndarray", "DecodeRunner", int | None, DecodeOptions], "np.ndarray"
+]
+
+
 def _process_color_space(
-    arr: "np.ndarray", runner: "DecodeRunner", changes: dict[str, str | int]
+    arr: "np.ndarray",
+    runner: "DecodeRunner",
+    index: int | None,
+    changes: DecodeOptions,
 ) -> "np.ndarray":
-    """Convert `arr` to a given color space, typically RGB."""
+    """Convert `arr` to a given color space, typically RGB.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        The ndarray to convert, may be single or multi-framed if `index` is ``None``,
+        otherwise it will be a single frame.
+    runner : DecodeRunner
+        The decode runner.
+    index : int | None
+        If ``None`` then `arr` contains the entire pixel data (single or multi-framed),
+        otherwise this is the `index` to the single frame being converted.
+    changes : dict[str, str | int]
+        A dict containing metadata tracking changes applicable to the entire pixel
+        data, will only be updated if `index` is ``None``.
+    """
+    indices = range(runner.number_of_frames) if index is None else (index,)
+
     # If force_ybr then always do conversion (ignore as_rgb)
+    as_rgb = runner.get_option("as_rgb", False)
     force_ybr = runner.get_option("force_ybr", False)
     force_rgb = runner.get_option("force_rgb", False)
     if force_ybr and force_rgb:
         raise ValueError("'force_ybr' and 'force_rgb' cannot both be True")
 
-    ybr = (PI.YBR_FULL, PI.YBR_FULL_422, PI.YBR_PARTIAL_420, PI.YBR_PARTIAL_422)
-    to_rgb = (
-        runner.photometric_interpretation in ybr and runner.get_option("as_rgb", False)
-    ) or force_rgb
-
-    if not arr.flags.writeable and (to_rgb or force_ybr):
-        if runner.get_option("view_only", False):
-            LOGGER.warning(
-                "Unable to return an ndarray that's a view on the original "
-                "buffer if applying a color space conversion"
-            )
-
-        arr = arr.copy()
-
-    # Converting to/from YBR_FULL and YBR_FULL_422 uses the same transformation
     if force_ybr:
+        if not arr.flags.writeable:
+            if runner.is_native and runner.get_option("view_only", False):
+                LOGGER.warning(
+                    "Unable to return an ndarray that's a view on the original "
+                    "buffer if applying a color space conversion"
+                )
+
+            arr = arr.copy()
+
         arr = convert_color_space(
             arr,
             PI.RGB,
             PI.YBR_FULL,
+            per_frame=True,
             bit_depth=runner.bits_stored,
         )
-        changes["photometric_interpretation"] = str(PI.YBR_FULL)
-    elif to_rgb:
+        if index is None:
+            changes["photometric_interpretation"] = PI.YBR_FULL
+
+        for idx in indices:
+            runner.set_frame_option(idx, "photometric_interpretation", PI.YBR_FULL)
+
+        return arr
+
+    # Conversion to RGB
+    # For native all frame are the same PI
+    ybr = (PI.YBR_FULL, PI.YBR_FULL_422, PI.YBR_PARTIAL_420, PI.YBR_PARTIAL_422)
+    if runner.is_native:
+        if not (runner.photometric_interpretation in ybr and as_rgb) and not force_rgb:
+            return arr
+
+        if not arr.flags.writeable:
+            if runner.get_option("view_only", False):
+                LOGGER.warning(
+                    "Unable to return an ndarray that's a view on the original "
+                    "buffer if applying a color space conversion"
+                )
+
+            arr = arr.copy()
+
         arr = convert_color_space(
             arr,
             PI.YBR_FULL if force_rgb else runner.photometric_interpretation,
             PI.RGB,
+            per_frame=True,
             bit_depth=runner.bits_stored,
         )
-        changes["photometric_interpretation"] = str(PI.RGB)
+        if index is None:
+            changes["photometric_interpretation"] = PI.RGB
+
+        for idx in indices:
+            runner.set_frame_option(idx, "photometric_interpretation", PI.RGB)
+
+        return arr
+
+    # For encapsulated the decoder may set the PI on a per-frame basis
+    indices_pi_to_rgb = [
+        (
+            idx,
+            pi := runner.get_frame_option(idx, "photometric_interpretation"),
+            (pi in ybr and as_rgb) or force_rgb,
+        )
+        for idx in indices
+    ]
+    needs_conversion = any(v[2] for v in indices_pi_to_rgb)
+    if not needs_conversion:
+        return arr
+
+    # Either:
+    #   All frames are being converted and the frame indices match the array indices
+    #   A single frame is being converted and its index may not match the array index
+    for idx, current_pi, to_rgb in indices_pi_to_rgb:
+        if to_rgb:
+            dst = None if runner.number_of_frames == 1 or index is not None else idx
+            arr[dst] = convert_color_space(
+                arr[dst],
+                PI.YBR_FULL if force_rgb else current_pi,
+                PI.RGB,
+                bit_depth=runner.bits_stored,
+            )
+            runner.set_frame_option(idx, "photometric_interpretation", PI.RGB)
+
+    if index is None:
+        changes["photometric_interpretation"] = PI.RGB
 
     return arr
 
@@ -172,7 +250,7 @@ def _correct_unused_bits(
     if (
         log_warning
         and runner.get_option("view_only", False)
-        and not runner.transfer_syntax.is_encapsulated
+        and not runner.is_encapsulated
         and not arr.flags.writeable
     ):
         LOGGER.warning(
@@ -193,7 +271,9 @@ def _correct_unused_bits(
     return arr
 
 
-def _apply_sign_correction(arr: "np.ndarray", runner: "DecodeRunner") -> "np.ndarray":
+def _apply_sign_correction(
+    arr: "np.ndarray", runner: "DecodeRunner", index: int | None = None
+) -> "np.ndarray":
     """Convert `arr` to match the signedness required by the 'pixel_representation'."""
     # JPEG 2000 Example:
     # Dataset: Pixel Representation 1, Bits Stored 13, Bits Allocated 16
@@ -221,20 +301,71 @@ def _apply_sign_correction(arr: "np.ndarray", runner: "DecodeRunner") -> "np.nda
     #     0001 1000 0011 0000  (value 6192)
     # Which can be fixed in the same way as for signed integers.
     if runner.transfer_syntax in JPEG2000TransferSyntaxes:
-        j2k_signed = runner.get_option("j2k_is_signed", runner.pixel_representation)
-        precision = runner.get_option("j2k_precision", runner.bits_stored)
-        bit_shift = 8 * arr.dtype.itemsize - precision
-        if bit_shift and j2k_signed != runner.pixel_representation:
-            np.left_shift(arr, bit_shift, out=arr)
-            np.right_shift(arr, bit_shift, out=arr)
-    elif runner.transfer_syntax in JPEGLSTransferSyntaxes:
-        # JPEG-LS has no way to track signedness, so signed integers are
-        #   always decoded as unsigned
-        precision = runner.get_option("jls_precision", runner.bits_stored)
-        bit_shift = 8 * arr.dtype.itemsize - precision
-        if bit_shift:
-            np.left_shift(arr, bit_shift, out=arr)
-            np.right_shift(arr, bit_shift, out=arr)
+        container_size = 8 * arr.dtype.itemsize
+        pixel_representation = runner.pixel_representation
+        if index is None:
+            signs = [
+                meta.get("j2k_is_signed", pixel_representation)
+                for meta in runner._frame_meta.values()
+            ]
+        else:
+            signs = [
+                runner.get_frame_option(index, "j2k_is_signed", pixel_representation)
+            ]
+
+        bits_stored = runner.bits_stored
+        if index is None:
+            bit_shifts = [
+                container_size - meta.get("j2k_precision", bits_stored)
+                for meta in runner._frame_meta.values()
+            ]
+        else:
+            precision = runner.get_frame_option(index, "j2k_precision", bits_stored)
+            bit_shifts = [container_size - precision]
+
+        # Single or multi-framed with consistent sign and precision values
+        if len(set(signs)) == 1 and len(set(bit_shifts)) == 1:
+            if bit_shifts[0] and signs[0] != pixel_representation:
+                np.left_shift(arr, bit_shifts[0], out=arr)
+                np.right_shift(arr, bit_shifts[0], out=arr)
+
+            return arr
+
+        # Multi-framed with inconsistent sign or precision values
+        for frame, is_signed, bit_shift in zip(arr, signs, bit_shifts):
+            if bit_shift and is_signed != pixel_representation:
+                np.left_shift(frame, bit_shift, out=frame)
+                np.right_shift(frame, bit_shift, out=frame)
+
+        return arr
+
+    # JPEG-LS has no way to track signedness, so signed integers are
+    #   always decoded as unsigned and need to be corrected
+    if runner.transfer_syntax in JPEGLSTransferSyntaxes:
+        container_size = 8 * arr.dtype.itemsize
+        bits_stored = runner.bits_stored
+        if index is None:
+            bit_shifts = [
+                container_size - meta.get("jls_precision", bits_stored)
+                for meta in runner._frame_meta.values()
+            ]
+        else:
+            precision = runner.get_frame_option(index, "jls_precision", bits_stored)
+            bit_shifts = [container_size - precision]
+
+        # Single or multi-framed with consistent precision values
+        if len(set(bit_shifts)) == 1:
+            if bit_shifts[0]:
+                np.left_shift(arr, bit_shifts[0], out=arr)
+                np.right_shift(arr, bit_shifts[0], out=arr)
+
+            return arr
+
+        # Multi-framed with inconsistent precision values
+        for frame, bit_shift in zip(arr, bit_shifts):
+            if bit_shift:
+                np.left_shift(frame, bit_shift, out=frame)
+                np.right_shift(frame, bit_shift, out=frame)
 
     return arr
 
@@ -273,7 +404,14 @@ class DecodeRunner(RunnerBase):
         self._decoders: dict[str, DecodeFunction] = {}
         self._previous: tuple[str, DecodeFunction]
 
-        if self.transfer_syntax.is_encapsulated:
+        # The frame currently being decoded
+        # Not useful for native encodig with Decoder.as_array(..., index=None)
+        self._index: int
+        # The frame meta information, keyed to the frame index
+        # Frame indices are not guaranteed to start at 0, be sequential, or ordered
+        self._frame_meta: dict[int, FrameOptions] = {}
+
+        if self.is_encapsulated:
             self.set_option("pixel_keyword", "PixelData")
         else:
             self.set_option("view_only", False)
@@ -285,13 +423,15 @@ class DecodeRunner(RunnerBase):
         else:
             self.set_option("correct_unused_bits", True)
 
-    def _conform_jpg_colorspace(self, info: dict[str, Any]) -> None:
+    def _conform_jpg_colorspace(self, info: dict[str, Any], index: int) -> None:
         """Conform the photometric interpretation to the JPEG/JPEG-LS codestream.
 
         Parameters
         ----------
         info : dict[str, Any]
             A dictionary containing JPEG/JPEG-LS codestream metadata.
+        index : int
+            The index of the frame undergoing conformation.
         """
         if self.samples_per_pixel != 3:
             return
@@ -301,26 +441,43 @@ class DecodeRunner(RunnerBase):
         # Check the component IDs for RGB or rgb (in ASCII)
         has_rgb_ids = info.get("component_ids", None) in ([82, 71, 66], [114, 103, 98])
         if has_rgb_ids and pi != PI.RGB:
-            self.set_option("photometric_interpretation", PI.RGB)
+            self.set_frame_option(index, "photometric_interpretation", PI.RGB)
             warn_and_log(
                 f"The (0028,0004) 'Photometric Interpretation' value is '{pi}' "
-                "however the encoded image's codestream uses component IDs that "
-                "indicate it should be 'RGB'"
+                f"however the encoded image codestream for frame {index} uses "
+                "component IDs that indicate it should be 'RGB'"
             )
             return
 
-        # A JFIF APP marker means the decoded image should be YBR colour space
-        #   https://www.w3.org/Graphics/JPEG/jfif.pdf
+        # ISO/IEC 10918-6/ITU T.872
+        # https://www.itu.int/rec/dologin_pub.asp?lang=e&id=T-REC-T.872-201206-I!!PDF-E
         cs = (
             PI.YBR_FULL_422 if self.transfer_syntax == JPEGBaseline8Bit else PI.YBR_FULL
         )
         for marker in info.get("app", {}).values():
+            expected_cs = None
             if marker.startswith(b"JFIF") and "YBR" not in pi:
-                self.set_option("photometric_interpretation", cs)
+                # A JFIF APP marker means the decoded image should be YBR colour space
+                #   https://www.w3.org/Graphics/JPEG/jfif.pdf
+                expected_cs = cs
+                marker_name = "a JFIF APP"
+            elif marker.startswith(b"Adobe"):
+                # Adobe APP14 marker has the color space at byte 12
+                #    0: RGB or CMYK (CMYK not applicable)
+                #    1: YCbCr
+                #    2: YCCK (not applicable)
+                marker_name = "an Adobe APP14"
+                if marker[11] == 0 and "YBR" in pi:
+                    expected_cs = PI.RGB
+                elif marker[11] == 1 and "YBR" not in pi:
+                    expected_cs = cs
+
+            if expected_cs is not None:
+                self.set_frame_option(index, "photometric_interpretation", expected_cs)
                 warn_and_log(
-                    "The (0028,0004) 'Photometric Interpretation' value is "
-                    f"'{pi}' however the encoded image's codestream contains a "
-                    f"JFIF APP marker which indicates it should be '{cs}'"
+                    f"The (0028,0004) 'Photometric Interpretation' value is '{pi}' "
+                    f"however the encoded image codestream for frame {index} contains "
+                    f"{marker_name} marker which indicates it should be '{expected_cs}'"
                 )
                 return
 
@@ -337,6 +494,8 @@ class DecodeRunner(RunnerBase):
         bytes | bytearray
             The decoded frame of pixel data.
         """
+        self._index = index
+
         # For encapsulated data `self.src` should not be memoryview to avoid
         #   creating a duplicate object in memory by the encapsulation functions
         src = get_frame(
@@ -345,7 +504,7 @@ class DecodeRunner(RunnerBase):
             number_of_frames=self.number_of_frames,
             extended_offsets=self.extended_offsets,
         )
-        self._get_frame_info(src)
+        self._frame_set_options(index, src)
 
         return self._decode_frame(src)
 
@@ -394,6 +553,67 @@ class DecodeRunner(RunnerBase):
             f"plugins:\n  {messages}"
         )
 
+    def frame_dtype(self, index: int) -> "np.dtype":
+        """Return a :class:`numpy.dtype` suitable for containing the pixel data for
+        the decoded frame at `index`.
+
+        .. versionadded:: 3.1
+
+        Parameters
+        ----------
+        index : int
+            The index of the frame to return the dtype for.
+        """
+        dt = self.pixel_dtype
+        if self.pixel_keyword != "PixelData":
+            return dt
+
+        # RunnerBase.set_frame_option() checks that bits allocated is 1 or N x 8
+        bits_allocated = self.get_frame_option(
+            index, "bits_allocated", self.bits_allocated
+        )
+        itemsize = 1 if bits_allocated == 1 else bits_allocated // 8
+        if dt.itemsize == itemsize:
+            return dt
+
+        return np.dtype(f"{dt.byteorder}{dt.kind}{itemsize}")
+
+    def _frame_set_options(self, index: int, src: bytes | None = None) -> None:
+        """Set the initial metadata values for the frame at `index`."""
+        names = ["bits_allocated", "photometric_interpretation", "planar_configuration"]
+        self._frame_meta[index] = {
+            n: self._opts[n]  # type: ignore[literal-required, assignment]
+            for n in names
+            if n in self._opts
+        }
+
+        if src is None:
+            return
+
+        if self.transfer_syntax in JPEG2000TransferSyntaxes:
+            j2k_info = get_j2k_parameters(src)
+            self.set_frame_option(
+                index,
+                "j2k_is_signed",
+                j2k_info.get("is_signed", self.pixel_representation),
+            )
+            self.set_frame_option(
+                index,
+                "j2k_precision",
+                j2k_info.get("precision", self.bits_stored),
+            )
+        elif self.transfer_syntax in JPEGLSTransferSyntaxes:
+            jls_info = _get_jpg_parameters(src)
+            self.set_frame_option(
+                index,
+                "jls_precision",
+                jls_info.get("precision", self.bits_stored),
+            )
+            self._conform_jpg_colorspace(jls_info, index)
+        elif self.transfer_syntax in JPEGTransferSyntaxes:
+            jpg_info = _get_jpg_parameters(src)
+            self._conform_jpg_colorspace(jpg_info, index)
+
     def get_data(self, src: Buffer | BinaryIO, offset: int, length: int) -> bytes:
         """Return `length` bytes from `src`, starting at `offset`.
 
@@ -424,26 +644,6 @@ class DecodeRunner(RunnerBase):
         src.seek(file_offset)
         return buffer
 
-    def _get_frame_info(self, src: bytes) -> None:
-        """Parse a frame's codestream for JPEG-related parameters."""
-        if self.transfer_syntax in JPEG2000TransferSyntaxes:
-            j2k_info = get_j2k_parameters(src)
-            self.set_option(
-                "j2k_is_signed", j2k_info.get("is_signed", self.pixel_representation)
-            )
-            self.set_option(
-                "j2k_precision", j2k_info.get("precision", self.bits_stored)
-            )
-        elif self.transfer_syntax in JPEGLSTransferSyntaxes:
-            jls_info = _get_jpg_parameters(src)
-            self.set_option(
-                "jls_precision", jls_info.get("precision", self.bits_stored)
-            )
-            self._conform_jpg_colorspace(jls_info)
-        elif self.transfer_syntax in JPEGTransferSyntaxes:
-            jpg_info = _get_jpg_parameters(src)
-            self._conform_jpg_colorspace(jpg_info)
-
     def iter_decode(self) -> Iterator[bytes | bytearray]:
         """Yield decoded frames from the encoded pixel data.
 
@@ -464,8 +664,9 @@ class DecodeRunner(RunnerBase):
             number_of_frames=self.number_of_frames,
             extended_offsets=self.extended_offsets,
         )
-        for index, src in enumerate(encoded_frames):
-            self._get_frame_info(src)
+        for idx, src in enumerate(encoded_frames):
+            self._index = idx
+            self._frame_set_options(idx, src)
 
             # This may have been overridden by the plugin by the previous
             # frame
@@ -480,7 +681,7 @@ class DecodeRunner(RunnerBase):
                 except Exception:
                     LOGGER.warning(
                         f"The decoding plugin '{name}' failed to decode the "
-                        f"frame at index {index}"
+                        f"frame at index {idx}"
                     )
 
             # Otherwise try all decoders
@@ -532,15 +733,31 @@ class DecodeRunner(RunnerBase):
 
         return dtype
 
-    def pixel_properties(self, as_frame: bool = False) -> dict[str, str | int]:
+    # TODO: v4.0 - remove `as_frame`
+    def pixel_properties(
+        self, index: int | None, as_frame: bool = False
+    ) -> dict[str, str | int]:
         """Return a dict containing the :dcm:`Image Pixel
         <part03/sect_C.7.6.3.html>` module related properties.
 
+        .. versionchanged:: 3.1
+
+            Added the `index` parameter.
+
+        .. deprecated:: 3.1
+
+            The `as_frame` parameter will be removed in v4.0, use `index` instead.
+
         Parameters
         ----------
+        index : int | None
+            If ``None`` then return the properties for the entire (single or
+            multi-framed) pixel data, otherwise return the properties for the frame at
+            `index`.
         as_frame : bool, optional
-            If ``True`` then don't include properties that aren't appropriate
-            for a single frame. Default ``False``.
+            If ``True`` then return the properties for a single frame (requires passing
+            the frame's index as `index`), otherwise return the properties for the
+            entire pixel data (requires passing ``None`` as the `index`).
 
         Returns
         -------
@@ -548,7 +765,7 @@ class DecodeRunner(RunnerBase):
             A dict containing the values for:
 
             * `bits_allocated`
-            * `bits_stored`
+            * `bits_stored` (if the pixel keyword is ``"PixelData"``)
             * `columns`
             * `photometric_interpretation`
             * `samples_per_pixel`
@@ -565,52 +782,121 @@ class DecodeRunner(RunnerBase):
             the `photometric_interpretation` value will be changed to match
             after the data has been decoded.
         """
-        d = {
-            "bits_allocated": self.bits_allocated,
+        as_frame = False if config._use_future else as_frame
+        if as_frame:
+            warn_and_log(
+                "'as_frame' is deprecated and will be removed in v4.0",
+                DeprecationWarning,
+            )
+
+        if isinstance(index, bool):
+            raise TypeError("'index' must be int or None, not 'bool'")
+
+        d: dict[str, str | int] = {
             "columns": self.columns,
-            "number_of_frames": self.number_of_frames if not as_frame else 1,
-            "photometric_interpretation": str(self.photometric_interpretation),
             "rows": self.rows,
             "samples_per_pixel": self.samples_per_pixel,
         }
-
-        if self.samples_per_pixel > 1:
-            d["planar_configuration"] = self.planar_configuration
 
         if self.pixel_keyword == "PixelData":
             d["bits_stored"] = self.bits_stored
             d["pixel_representation"] = self.pixel_representation
 
-        return cast(dict[str, str | int], d)
+        index = 0 if self.number_of_frames == 1 else index
 
-    def process(self, arr: "np.ndarray") -> tuple["np.ndarray", dict[str, str | int]]:
+        # Single frame only, may or may not be the whole pixel data
+        if index is not None:
+            pi = self.get_frame_option(index, "photometric_interpretation")
+            d["bits_allocated"] = self.get_frame_option(index, "bits_allocated")
+            d["number_of_frames"] = 1
+            d["photometric_interpretation"] = str(pi)
+            if self.samples_per_pixel > 1:
+                pc = self.get_frame_option(index, "planar_configuration")
+                d["planar_configuration"] = pc
+
+            return cast(dict[str, str | int], d)
+
+        # Multi-frame only, the whole pixel data
+        d["bits_allocated"] = self.get_frame_option(
+            None, "bits_allocated", self.bits_allocated
+        )
+        d["number_of_frames"] = self.number_of_frames
+        d["photometric_interpretation"] = str(
+            self.get_frame_option(
+                None, "photometric_interpretation", self.photometric_interpretation
+            )
+        )
+        if self.samples_per_pixel > 1:
+            d["planar_configuration"] = self.get_frame_option(
+                None, "planar_configuration", self.planar_configuration
+            )
+
+        return d
+
+    def process(
+        self, arr: "np.ndarray", index: int | None
+    ) -> tuple["np.ndarray", DecodeOptions]:
         """Return `arr` after applying zero or more processing operations.
+
+        .. versionchanged:: 3.1
+
+            Added the `index` parameter.
+
+        Parameters
+        ----------
+        arr : np.ndarray
+            The image data to process, may be the entire single or multi-framed pixel
+            data and (if `index` is ``None``) or the data from a single frame
+            (if `index` is not ``None``).
+        index : int | None
+            If ``None`` then `arr` contains the entire pixel data and may be single or
+            multi-framed, otherwise `arr` contains the data from the single frame
+            at `index`.
 
         Returns
         -------
         numpy.ndarray
             The array with the applied processing.
         dict[str, int | str]
-            A :class:`dict` containing any required changes to the image pixel
-            properties due to the processing.
+            A :class:`dict` containing the changes to the image pixel properties due
+            to the processing, will be empty if `index` is not ``None``.
         """
-        changes: dict[str, str | int] = {}
+        changes: DecodeOptions = {}
         for func in PROCESSORS:
-            arr = func(arr, self, changes)
+            arr = func(arr, self, index, changes)
+
+        # Must be the entire pixel data, safe to update the corresponding options
+        if index is None:
+            self.set_options(**changes)  # type: ignore[arg-type]
 
         return arr, changes
 
-    def reshape(self, arr: "np.ndarray", as_frame: bool = False) -> "np.ndarray":
+    # TODO: v4.0 - remove `as_frame`
+    def reshape(
+        self, arr: "np.ndarray", index: int | None, as_frame: bool = False
+    ) -> "np.ndarray":
         """Return a reshaped :class:`~numpy.ndarray` `arr`.
+
+        .. versionchanged:: 3.1
+            Added the `index` parameter.
+
+        .. deprecated:: 3.1
+            The `as_frame` parameter will be removed in v4.0, use `index` instead.
 
         Parameters
         ----------
         arr : np.ndarray
-            The 1D array to be reshaped.
+            The 1D array to be reshaped. For encapsulated pixel data `arr` may only
+            contain data from a single frame and `index` may not be ``None``.
+        index : int | None
+            If ``None`` then `arr` contains the entire (single or multi-framed) pixel
+            data, otherwise `arr` contains a single frame's worth of pixel data for
+            the frame at `index`.
         as_frame : bool, optional
             If ``True`` then treat `arr` as only containing a single frame's
-            worth of pixel data, otherwise treat `arr` as containing the full
-            amount of pixel data (default).
+            worth of pixel data (requires passing the frame's index as `index`),
+            otherwise treat `arr` as containing the full amount of pixel data which
+            requires passing ``None`` as the `index` (default).
 
         Returns
         -------
@@ -622,35 +908,63 @@ class DecodeRunner(RunnerBase):
             * (frames, rows, columns) for multi-frame, single sample data
             * (frames, rows, columns, samples) for multi-frame, multi-sample data
         """
+        as_frame = False if config._use_future else as_frame
+        if as_frame:
+            warn_and_log(
+                "'as_frame' is deprecated and will be removed in v4.0",
+                DeprecationWarning,
+            )
+
+        if isinstance(index, bool):
+            raise TypeError("'index' must be int or None, not 'bool'")
+
         number_of_frames = self.number_of_frames
         samples_per_pixel = self.samples_per_pixel
         rows = self.rows
         columns = self.columns
 
-        if not as_frame and number_of_frames > 1:
-            # Multi-frame, single sample
+        index = 0 if number_of_frames == 1 else index
+
+        # Single frame, may or may not be the entire pixel data
+        if index is not None:
             if samples_per_pixel == 1:
-                return arr.reshape(number_of_frames, rows, columns)
+                return arr.reshape(rows, columns)
 
-            # Multi-frame, multiple samples, planar configuration 0
-            if self.planar_configuration == 0:
-                return arr.reshape(number_of_frames, rows, columns, samples_per_pixel)
+            # Multiple samples
+            planar_configuration = self.get_frame_option(
+                index, "planar_configuration", self.planar_configuration
+            )
+            if planar_configuration == 0:
+                return arr.reshape(rows, columns, samples_per_pixel)
 
-            # Multi-frame, multiple samples, planar configuration 1
-            arr = arr.reshape(number_of_frames, samples_per_pixel, rows, columns)
-            return arr.transpose(0, 2, 3, 1)
+            arr = arr.reshape(samples_per_pixel, rows, columns)
+            arr = arr.transpose(1, 2, 0)
+            self.set_frame_option(index, "planar_configuration", 0)
 
-        # Single frame, single sample
+            # If only a single frame then we can safely set the planar conf.
+            if number_of_frames == 1:
+                self.set_option("planar_configuration", 0)
+
+            return arr
+
+        # Multi-frame, the entire pixel data
         if samples_per_pixel == 1:
-            return arr.reshape(rows, columns)
+            return arr.reshape(number_of_frames, rows, columns)
 
-        # Single frame, multiple samples, planar configuration 0
-        if self.planar_configuration == 0:
-            return arr.reshape(rows, columns, samples_per_pixel)
+        # Multiple samples
+        planar_configuration = self.planar_configuration
+        if planar_configuration == 0:
+            return arr.reshape(number_of_frames, rows, columns, samples_per_pixel)
 
-        # Single frame, multiple samples, planar configuration 1
-        arr = arr.reshape(samples_per_pixel, rows, columns)
-        return arr.transpose(1, 2, 0)
+        arr = arr.reshape(number_of_frames, samples_per_pixel, rows, columns)
+        arr = arr.transpose(0, 2, 3, 1)
+        for idx in range(number_of_frames):
+            self.set_frame_option(idx, "planar_configuration", 0)
+
+        # `arr` contains the entire pixel data, so we can safely set planar conf.
+        self.set_option("planar_configuration", 0)
+
+        return arr
 
     def set_decoders(self, decoders: dict[str, DecodeFunction]) -> None:
         """Set the decoders use for decoding compressed pixel data.
@@ -741,7 +1055,7 @@ class DecodeRunner(RunnerBase):
 
         return "\n".join(s)
 
-    def _test_for(self, test: str) -> bool:
+    def _test_for(self, test: str, index: int | None = None) -> bool:
         """Return the result of `test` as :class:`bool`."""
         if test == "be_swap_ow":
             if self.get_option("be_swap_ow"):
@@ -782,6 +1096,18 @@ class DecodeRunner(RunnerBase):
                 and self.bits_allocated > 8
             )
 
+        if test == "bit_packed":
+            return (
+                self.bits_allocated == 1
+                and self.get_frame_option(index, "bits_allocated", 8) == 1
+            )
+
+        if test == "bit_unpacked":
+            return (
+                self.bits_allocated == 1
+                and self.get_frame_option(index, "bits_allocated", 1) != 1
+            )
+
         raise ValueError(f"Unknown test '{test}'")
 
     def validate(self) -> None:
@@ -797,7 +1123,7 @@ class DecodeRunner(RunnerBase):
         expected = ceil(frame_length * self.number_of_frames)
         actual = len(cast(Buffer, self._src))
 
-        if self.transfer_syntax.is_encapsulated:
+        if self.is_encapsulated:
             if actual in (expected, expected + expected % 2):
                 warn_and_log(
                     "The number of bytes of compressed pixel data matches the "
@@ -1016,6 +1342,9 @@ class Decoder(CoderBase):
         runner = DecodeRunner(self.UID)
         runner.set_source(src)
         runner.set_options(**kwargs)
+        if raw:
+            runner.set_option("as_rgb", False)
+
         runner.set_decoders(
             cast(
                 dict[str, "DecodeFunction"],
@@ -1030,36 +1359,25 @@ class Decoder(CoderBase):
             runner.validate()
 
         if self.is_native:
-            func = self._as_array_native
+            arr = self._as_array_native(runner, index)
             as_writeable = not runner.get_option("view_only", False)
         else:
-            func = self._as_array_encapsulated
+            arr = self._as_array_encapsulated(runner, index)
             as_writeable = True
-
-        as_frame = index is not None
-        arr = runner.reshape(func(runner, index), as_frame=as_frame)
 
         if runner._test_for("sign_correction"):
             arr = _apply_sign_correction(arr, runner)
         elif runner._test_for("shift_correction"):
             arr = _correct_unused_bits(arr, runner)
 
-        overrides: dict[str, str | int] = {}
         if not raw:
             # Processing may give us a new writeable array anyway, so do
             #   it first to avoid an unnecessary ndarray.copy()
-            arr, overrides = runner.process(arr)
+            arr, _ = runner.process(arr, index)
 
         arr = arr.copy() if not arr.flags.writeable and as_writeable else arr
 
-        # Multi-sample arrays are always returned *Planar Configuration* 0
-        if runner.samples_per_pixel > 1:
-            overrides["planar_configuration"] = 0
-
-        pixel_properties = runner.pixel_properties(as_frame=as_frame)
-        pixel_properties.update(overrides)
-
-        return arr, pixel_properties
+        return arr, runner.pixel_properties(index)
 
     @staticmethod
     def _as_array_encapsulated(runner: DecodeRunner, index: int | None) -> "np.ndarray":
@@ -1075,86 +1393,108 @@ class Decoder(CoderBase):
             The runner with the encoded data and decoding options.
         index : int | None
             The index of the frame to be returned, or ``None`` if all frames
-            are to be returned
+            are to be returned.
 
         Returns
         -------
         numpy.ndarray
-            A 1D array containing the pixel data. For single bit images (*Bits
-            Allocated* of 1), pixels are always returned "unpacked", with a
-            single pixel in each byte.
+            A writeable 2D, 3D or 4D array with the expected output dtype containing
+            the pixel data. For single bit images (*Bits Allocated* of 1), pixels are
+            always returned "unpacked", with a single pixel in each byte.
         """
-        # The initial preallocated array uses an itemsize based off the dataset's
+        # The output array's dtype uses an itemsize based off the dataset's
         #   bits allocated value, however each decoded frame may use a smaller
         #   itemsize (such as bits allocated 16 and JPEG with precision 8 only
         #   returning 8-bit data rather than 16-bit)
         # We account for this by interpreting each frame using that decoded size,
-        #   inserting it into the preallocated array, then resetting at the end
-        #   so the returned image pixel dict matches the array
-        original_bits_allocated = runner.bits_allocated
+        #   the either inserting it into the preallocated array or using
+        #   ndarray.astype() to upscale (if required)
         pixels_per_frame = cast(int, runner.frame_length(unit="pixels"))
-        number_of_frames = 1 if index is not None else runner.number_of_frames
-
-        # Preallocate output array
-        arr = np.empty(pixels_per_frame * number_of_frames, dtype=runner.pixel_dtype)
 
         # Return the specified frame only
         if index is not None:
-            # The decoding plugin may alter runner.bits_allocated to give a
-            #   different dtype itemsize
-            buffer = runner.decode(index=index)
-            runner.set_option("bits_allocated", original_bits_allocated)
-
-            if runner.get_option("is_bitpacked"):
-                frame = unpack_bits(buffer)[:pixels_per_frame]
+            # The decoding plugin may alter the frame's bits_allocated to give a
+            #   different dtype itemsize, so use frame_dtype()
+            buffer: bytes | bytearray = runner.decode(index)
+            if runner._test_for("bit_packed", index):
+                # Always ndarray[uint8]
+                frame = cast("np.ndarray", unpack_bits(buffer))[:pixels_per_frame]
+                bits_allocated = 8
             else:
-                frame = np.frombuffer(buffer, dtype=runner.pixel_dtype)
+                frame = np.frombuffer(buffer, dtype=runner.frame_dtype(index))
+                bits_allocated = runner.bits_allocated
 
-            arr[:] = frame
+            # Upscale if the frame's dtype is smaller than the required output dtype
+            # Only create a new array if the frame is read-only or if the frame's
+            #   dtype doesn't match the output dtype
+            frame = frame.astype(runner.pixel_dtype, copy=not frame.flags.writeable)
+            runner.set_frame_option(index, "bits_allocated", bits_allocated)
 
-            return arr
+            return runner.reshape(frame, index)
 
-        # Return all frames
+        # Preallocate the output array, individual frames will be placed into it
+        # The output dtype is based off the original input parameters
+        number_of_frames = runner.number_of_frames
+        shape = (
+            number_of_frames,
+            runner.rows,
+            runner.columns,
+            runner.samples_per_pixel,
+        )
+        arr = np.empty(shape, dtype=runner.pixel_dtype).squeeze()
+
         frame_generator = runner.iter_decode()
-        for idx in range(runner.number_of_frames):
+        for idx in range(number_of_frames):
             buffer = next(frame_generator)
-
-            if runner.get_option("is_bitpacked"):
-                frame = unpack_bits(buffer)[:pixels_per_frame]
+            if runner._test_for("bit_packed", idx):
+                frame = cast("np.ndarray", unpack_bits(buffer))[:pixels_per_frame]
+                bits_allocated = 8
             else:
-                frame = np.frombuffer(buffer, dtype=runner.pixel_dtype)
+                frame = np.frombuffer(buffer, dtype=runner.frame_dtype(idx))
+                bits_allocated = runner.bits_allocated
 
-            start = idx * pixels_per_frame
-            arr[start : start + pixels_per_frame] = frame
+            dst = None if number_of_frames == 1 else idx
+            arr[dst] = runner.reshape(frame, idx)
+            runner.set_frame_option(idx, "bits_allocated", bits_allocated)
 
         # Check to see if we have any more frames available
         #   Should only apply to JPEG transfer syntaxes
-        if runner.get_option("allow_excess_frames", False):
-            excess = []
-            original_nr_frames = runner.number_of_frames
-            for buffer in frame_generator:
-                if len(buffer) == runner.frame_length(unit="bytes"):
-                    if runner.get_option("is_bitpacked"):
-                        frame = unpack_bits(buffer)[:pixels_per_frame]
-                    else:
-                        frame = np.frombuffer(buffer, runner.pixel_dtype)
+        if not runner.get_option("allow_excess_frames", False):
+            return arr
 
-                    excess.append(frame)
-                    runner.set_option("number_of_frames", runner.number_of_frames + 1)
+        excess = []
+        for buffer in frame_generator:
+            idx += 1  # Continuing on from above
+            if len(buffer) == runner.frame_length(unit="bytes", index=idx):
+                if runner._test_for("bit_packed", idx):
+                    frame = cast("np.ndarray", unpack_bits(buffer))[:pixels_per_frame]
+                    bits_allocated = 8
+                else:
+                    frame = np.frombuffer(buffer, runner.frame_dtype(idx))
+                    bits_allocated = runner.bits_allocated
 
-            if excess:
-                warn_and_log(
-                    f"{len(excess) + original_nr_frames} frames have been found in "
-                    "the encapsulated pixel data, which is larger than the given "
-                    f"(0028,0008) 'Number of Frames' value of {original_nr_frames}. "
-                    "The returned data will include these extra frames and if it's "
-                    "correct then you should update 'Number of Frames' accordingly, "
-                    "otherwise pass 'allow_excess_frames=False' to return only the "
-                    f"first {original_nr_frames} frames."
-                )
-                arr = np.concatenate([arr, *excess])
+                # The frame dtype is reconciled to pixel_dtype in concatenate()
+                runner.set_frame_option(idx, "bits_allocated", bits_allocated)
+                frame = runner.reshape(frame, idx)
 
-        runner.set_option("bits_allocated", original_bits_allocated)
+                excess.append(frame)
+
+        if excess:
+            warn_and_log(
+                f"{len(excess) + number_of_frames} frames have been found in "
+                "the encapsulated pixel data, which is larger than the given "
+                f"(0028,0008) 'Number of Frames' value of {number_of_frames}. "
+                "The returned data will include these extra frames and if it's "
+                "correct then you should update 'Number of Frames' accordingly, "
+                "otherwise pass 'allow_excess_frames=False' to return only the "
+                f"first {number_of_frames} frames."
+            )
+            # If concatenating to a single frame its shape must be (1, R, C [, 3])
+            if number_of_frames == 1:
+                arr = arr.reshape(1, *arr.shape)
+
+            arr = np.concatenate((arr, excess))
+            runner.set_option("number_of_frames", number_of_frames + len(excess))
 
         return arr
 
@@ -1174,11 +1514,16 @@ class Decoder(CoderBase):
         Returns
         -------
         numpy.ndarray
-            A 1D array containing the pixel data.
+            A 2D, 3D or 4D array of the expected output dtype containing the pixel
+            data. May or may not be writeable.
         """
         length_bytes = runner.frame_length(unit="bytes")
         length_pixels = int(runner.frame_length(unit="pixels"))
         dtype = runner.pixel_dtype
+
+        indices = (index,) if index is not None else range(runner.number_of_frames)
+        for idx in indices:
+            runner._frame_set_options(idx)
 
         src: memoryview | BinaryIO
         if runner.is_dataset or runner.is_buffer:
@@ -1284,10 +1629,10 @@ class Decoder(CoderBase):
             # boundaries are not byte-aligned
             unpacked = unpacked[bit_offset_start : bit_offset_start + length_pixels]
 
-            return unpacked
+            return runner.reshape(unpacked, index)
 
         if runner.photometric_interpretation != PI.YBR_FULL_422:
-            return arr
+            return runner.reshape(arr, index)
 
         # Expand YBR_FULL_422 (if required)
         if runner.get_option("view_only", False):
@@ -1299,15 +1644,20 @@ class Decoder(CoderBase):
 
         # PS3.3 C.7.6.3.1.2: YBR_FULL_422 data needs to be resampled
         # Y1 Y2 B1 R1 -> Y1 B1 R1 Y2 B1 R1
-        out = np.empty(arr.shape[0] // 2 * 3, dtype=dtype)
+        out = np.empty(arr.size // 2 * 3, dtype=dtype)
         out[::6] = arr[::4]  # Y1
         out[3::6] = arr[1::4]  # Y2
         out[1::6], out[4::6] = arr[2::4], arr[2::4]  # B
         out[2::6], out[5::6] = arr[3::4], arr[3::4]  # R
 
+        # Resampling affects entire pixel data, can safely set the photometric interp.
         runner.set_option("photometric_interpretation", PI.YBR_FULL)
 
-        return out
+        # FIXME: Can this only affect a single frame?
+        for idx in range(runner.number_of_frames):
+            runner.set_frame_option(idx, "photometric_interpretation", PI.YBR_FULL)
+
+        return runner.reshape(out, index)
 
     def as_buffer(
         self,
@@ -1317,15 +1667,21 @@ class Decoder(CoderBase):
         validate: bool = True,
         decoding_plugin: str = "",
         **kwargs: Any,
-    ) -> tuple[Buffer, dict[str, str | int]]:
+    ) -> tuple[Buffer, dict[int, dict[str, str | int]]]:
         """Return the raw decoded pixel data as a buffer-like.
 
         .. versionchanged:: 3.1
 
             Native single-bit images (*Bits Allocated = 1*) are now always
             returned with the start of a frame aligned to a byte boundary, and
-            with pixels from neighboring frames masked. Add support for
+            with pixels from neighboring frames masked. Added support for
             encapsulated single-bit images.
+
+        .. versionchanged:: 3.1
+            The returned :class:`dict` containing the metadata has been changed to a
+            ``dict`` containing the metadata for individual frames, using the frame
+            indexes as keys. This is to provide more information where inter-frame
+            property values such as the planar configuration may not be consistent.
 
         .. warning::
 
@@ -1367,7 +1723,9 @@ class Decoder(CoderBase):
             The name of the decoding plugin to use when decoding compressed
             pixel data. If no `decoding_plugin` is specified (default) then all
             available plugins will be tried and the result from the first successful
-            one returned. For information on the available plugins for each
+            one returned. For multi-frame pixel data its strongly recommended you
+            specify the decoding plugin to help ensure inter-frame consistency
+            in frame properties. For information on the available plugins for each
             decoder see the :doc:`API documentation</reference/pixels.decoders>`.
         **kwargs
             Optional keyword parameters for controlling decoding are also
@@ -1390,10 +1748,11 @@ class Decoder(CoderBase):
             an extra byte before the expected start (for an odd `index`) or after
             the expected end (for an even `index`) is returned if the frame contains
             an odd number of pixels.
-        dict[str, str | int]
-            The :dcm:`Image Pixel<part03/sect_C.7.6.3.html>` module element
-            values resulting from the decoding process that describe the
-            decoded pixel data. See :meth:`DecodeRunner.pixel_properties()
+        dict[int, dict[str, str | int]]
+            A :class:`dict` containing the :dcm:`Image Pixel<part03/sect_C.7.6.3.html>`
+            module element values resulting from the decoding process that describe the
+            decoded pixel data, indexed by frame number.
+            See :meth:`DecodeRunner.pixel_properties()
             <pydicom.pixels.decoders.base.DecodeRunner.pixel_properties>` for the
             possible contents.
         """
@@ -1416,7 +1775,10 @@ class Decoder(CoderBase):
         else:
             buffer = self._as_buffer_encapsulated(runner, index)
 
-        return buffer, runner.pixel_properties(as_frame=index is not None)
+        indices = (index,) if index is not None else range(runner.number_of_frames)
+        meta = {idx: runner.pixel_properties(idx) for idx in indices}
+
+        return buffer, meta
 
     @staticmethod
     def _as_buffer_encapsulated(
@@ -1447,17 +1809,17 @@ class Decoder(CoderBase):
         original_bits_allocated = runner.bits_allocated
 
         if index is not None:
-            frame = runner.decode(index=index)
-
-            length_bytes = runner.frame_length(unit="bytes")
+            frame = runner.decode(index)
+            length_bytes = runner.frame_length(unit="bytes", index=index)
             if (actual := len(frame)) != length_bytes:
                 raise ValueError(
                     "Unexpected number of bytes in the decoded frame with index "
                     f"{index} ({actual} bytes actual vs {length_bytes} expected)"
                 )
 
-            if original_bits_allocated == 1 and not runner.get_option("is_bitpacked"):
+            if runner._test_for("bit_unpacked", index):
                 frame = pack_bits(frame, pad=False)
+                runner.set_frame_option(index, "bits_allocated", 1)
 
             return frame
 
@@ -1467,18 +1829,16 @@ class Decoder(CoderBase):
         frame_generator = runner.iter_decode()
         for idx in range(runner.number_of_frames):
             frame = next(frame_generator)
-
-            bits_allocated.append(runner.bits_allocated)
-
-            length_bytes = runner.frame_length(unit="bytes")
+            length_bytes = runner.frame_length(unit="bytes", index=idx)
             if (actual := len(frame)) != length_bytes:
                 raise ValueError(
                     "Unexpected number of bytes in the decoded frame with index "
                     f"{idx} ({actual} bytes actual vs {length_bytes} expected)"
                 )
 
-            if original_bits_allocated == 1 and not runner.get_option("is_bitpacked"):
+            if runner._test_for("bit_unpacked", idx):
                 frame = pack_bits(frame, pad=False)
+                runner.set_frame_option(runner.index, "bits_allocated", 1)
 
             frames.append(frame)
 
@@ -1489,34 +1849,35 @@ class Decoder(CoderBase):
         #   Should only apply to JPEG transfer syntaxes
         if runner.get_option("allow_excess_frames", False):
             excess = []
-            original_nr_frames = runner.number_of_frames
             for frame in frame_generator:
-                if len(frame) == runner.frame_length(unit="bytes"):
-                    if original_bits_allocated == 1 and not runner.get_option(
-                        "is_bitpacked"
-                    ):
+                idx += 1  # Continuing on from above
+                if len(frame) == runner.frame_length(unit="bytes", index=idx):
+                    if runner._test_for("bit_unpacked", idx):
                         frame = pack_bits(frame, pad=False)
+                        runner.set_frame_option(runner.index, "bits_allocated", 1)
+
                     excess.append(frame)
-                    runner.set_option("number_of_frames", runner.number_of_frames + 1)
-                    bits_allocated.append(runner.bits_allocated)
 
             if excess:
+                number_of_frames = runner.number_of_frames
                 warn_and_log(
                     f"{len(excess) + len(frames)} frames have been found in the "
                     "encapsulated pixel data, which is larger than the given "
-                    f"(0028,0008) 'Number of Frames' value of {original_nr_frames}. "
+                    f"(0028,0008) 'Number of Frames' value of {number_of_frames}. "
                     "The returned data will include these extra frames and if it's "
                     "correct then you should update 'Number of Frames' accordingly, "
                     "otherwise pass 'allow_excess_frames=False' to return only the "
-                    f"first {original_nr_frames} frames."
+                    f"first {number_of_frames} frames."
                 )
                 frames.extend(excess)
+                runner.set_option("number_of_frames", number_of_frames + len(excess))
 
         # Each frame may have been encoded using a different precision. On
         #   decoding this may result in different container sizes per frame
         #   (such as 7-bit and 12-bit precisions being decoded as 8-bit and
         #   16-bit respectively, even if *Bits Stored* is 12). In that case we
         #   pad to match the largest container size.
+        bits_allocated = [v["bits_allocated"] for v in runner._frame_meta.values()]
         if len(set(bits_allocated)) != 1:
             target = max(bits_allocated)
             target_step = target // 8
@@ -1531,19 +1892,14 @@ class Decoder(CoderBase):
 
                     frames[idx] = out
 
-            runner.set_option("bits_allocated", target)
-        else:
-            # The bits allocated may have been reset above, so return it to the
-            # value actually set by the decoding function
-            runner.set_option("bits_allocated", bits_allocated[0])
+                runner.set_frame_option(idx, "bits_allocated", target)
 
-        if original_bits_allocated == 1:
+        if runner.bits_allocated == 1:
             return concatenate_packed_frames(
-                frames,
-                frame_length=runner.rows * runner.columns,
+                frames, frame_length=runner.rows * runner.columns
             )
 
-        return b"".join(b for b in frames)
+        return b"".join(frames)
 
     @staticmethod
     def _as_buffer_native(runner: DecodeRunner, index: int | None) -> Buffer:
@@ -1574,6 +1930,10 @@ class Decoder(CoderBase):
         """
         length_bytes = runner.frame_length(unit="bytes")
 
+        indices = (index,) if index is not None else range(runner.number_of_frames)
+        for idx in indices:
+            runner._frame_set_options(idx)
+
         src: Buffer | BinaryIO
         if runner.is_dataset or runner.is_buffer:
             if runner.get_option("view_only", False):
@@ -1589,7 +1949,6 @@ class Decoder(CoderBase):
             length_source = length_bytes * runner.number_of_frames
 
         if runner._test_for("be_swap_ow"):
-
             # Since we are using 8 bit images, frames will always be an integer
             # number of bytes
             length_bytes = cast(int, length_bytes)
@@ -1763,6 +2122,9 @@ class Decoder(CoderBase):
         runner = DecodeRunner(self.UID)
         runner.set_source(src)
         runner.set_options(**kwargs)
+        if raw:
+            runner.set_option("as_rgb", False)
+
         runner.set_decoders(
             cast(
                 dict[str, "DecodeFunction"],
@@ -1784,60 +2146,57 @@ class Decoder(CoderBase):
             as_writeable = True
 
         log_warning = True
+        # Encapsulated: all frames, separated out to allow for including excess frames
         if self.is_encapsulated and not indices:
-            for frame in runner.iter_decode():
-                if runner.get_option("is_bitpacked"):
-                    arr = unpack_bits(frame)[: cast(int, runner.frame_length("pixels"))]
+            pixel_dtype = runner.pixel_dtype
+            pixels_per_frame = cast(int, runner.frame_length("pixels"))
+            # iter_decode() yields bytes | bytearray and may yield more frames
+            #   than number_of_frames if excess frames exist
+            for idx, buffer in enumerate(runner.iter_decode()):
+                if runner._test_for("bit_packed", idx):
+                    arr = cast("np.ndarray", unpack_bits(buffer)[:pixels_per_frame])
+                    bits_allocated = 8
                 else:
-                    arr = np.frombuffer(frame, dtype=runner.pixel_dtype)
-                arr = runner.reshape(arr, as_frame=True)
+                    arr = np.frombuffer(buffer, dtype=runner.frame_dtype(idx))
+                    bits_allocated = runner.bits_allocated
+
+                # The `copy` arg will only create a new array if the frame is read-only
+                #   or if the frame's dtype doesn't match the output dtype
+                arr = arr.astype(pixel_dtype, copy=not arr.flags.writeable)
+                runner.set_frame_option(idx, "bits_allocated", bits_allocated)
+
+                arr = runner.reshape(arr, idx)
                 if runner._test_for("sign_correction"):
-                    arr = _apply_sign_correction(arr, runner)
+                    arr = _apply_sign_correction(arr, runner, idx)
                 elif runner._test_for("shift_correction"):
                     arr = _correct_unused_bits(arr, runner, log_warning=log_warning)
                     log_warning = False
 
-                overrides: dict[str, str | int] = {}
                 if not raw:
-                    # Processing may give us a new writeable array anyway, so do
-                    #   it first to avoid an unnecessary ndarray.copy()
-                    arr, overrides = runner.process(arr)
+                    arr, _ = runner.process(arr, idx)
 
-                arr = arr if arr.flags.writeable else arr.copy()
-
-                # Multi-sample arrays are always returned *Planar Configuration* 0
-                if runner.samples_per_pixel > 1:
-                    overrides["planar_configuration"] = 0
-
-                pixel_properties = runner.pixel_properties(as_frame=True)
-                pixel_properties.update(overrides)
-
-                yield arr, pixel_properties
+                yield arr, runner.pixel_properties(idx)
 
             return
 
+        # Native: all or specific frames
+        # Encapsulated: specific frames
         indices = indices if indices else range(runner.number_of_frames)
-        for index in indices:
-            arr = runner.reshape(func(runner, index), as_frame=True)
+        for idx in indices:
+            arr = func(runner, idx)
+
             if runner._test_for("sign_correction"):
-                arr = _apply_sign_correction(arr, runner)
+                arr = _apply_sign_correction(arr, runner, idx)
             elif runner._test_for("shift_correction"):
                 arr = _correct_unused_bits(arr, runner, log_warning=log_warning)
                 log_warning = False
 
-            overrides = {}
             if not raw:
-                arr, overrides = runner.process(arr)
+                arr, _ = runner.process(arr, idx)
 
             arr = arr.copy() if not arr.flags.writeable and as_writeable else arr
 
-            if runner.samples_per_pixel > 1:
-                overrides["planar_configuration"] = 0
-
-            pixel_properties = runner.pixel_properties(as_frame=True)
-            pixel_properties.update(overrides)
-
-            yield arr, pixel_properties
+            yield arr, runner.pixel_properties(idx)
 
     def iter_buffer(
         self,
@@ -1892,7 +2251,9 @@ class Decoder(CoderBase):
             The name of the decoding plugin to use when decoding compressed
             pixel data. If no `decoding_plugin` is specified (default) then all
             available plugins will be tried and the result from the first successful
-            one yielded. For information on the available plugins for each
+            one yielded. For multi-frame pixel data its strongly recommended you
+            specify the decoding plugin to help ensure inter-frame consistency
+            in frame properties. For information on the available plugins for each
             decoder see the :doc:`API documentation</reference/pixels.decoders>`.
         **kwargs
             Optional keyword parameters for controlling decoding are also
@@ -1933,16 +2294,16 @@ class Decoder(CoderBase):
             ),
         )
 
-        bits_allocated = runner.bits_allocated
-
         if validate:
             runner.validate()
 
         if self.is_encapsulated and not indices:
-            for buffer in runner.iter_decode():
-                if bits_allocated == 1 and not runner.get_option("is_bitpacked"):
+            for idx, buffer in enumerate(runner.iter_decode()):
+                if runner._test_for("bit_unpacked", idx):
                     buffer = pack_bits(buffer, pad=False)
-                yield buffer, runner.pixel_properties(as_frame=True)
+                    runner.set_frame_option(runner.index, "bits_allocated", 1)
+
+                yield buffer, runner.pixel_properties(idx)
 
             return
 
@@ -1952,8 +2313,8 @@ class Decoder(CoderBase):
             func = self._as_buffer_encapsulated
 
         indices = indices if indices else range(runner.number_of_frames)
-        for index in indices:
-            yield func(runner, index), runner.pixel_properties(as_frame=True)
+        for idx in indices:
+            yield func(runner, idx), runner.pixel_properties(idx)
 
 
 # Decoder names should be f"{UID.keyword}Decoder"
@@ -1967,18 +2328,18 @@ DeflatedExplicitVRLittleEndianDecoder = Decoder(DeflatedExplicitVRLittleEndian)
 JPEGBaseline8BitDecoder = Decoder(JPEGBaseline8Bit)
 JPEGBaseline8BitDecoder.add_plugins(
     [
+        ("pillow", ("pydicom.pixels.decoders.pillow", "_decode_frame")),
         ("gdcm", ("pydicom.pixels.decoders.gdcm", "_decode_frame")),
         ("pylibjpeg", ("pydicom.pixels.decoders.pylibjpeg", "_decode_frame")),
-        ("pillow", ("pydicom.pixels.decoders.pillow", "_decode_frame")),
     ]
 )
 
 JPEGExtended12BitDecoder = Decoder(JPEGExtended12Bit)
 JPEGExtended12BitDecoder.add_plugins(
     [
+        ("pillow", ("pydicom.pixels.decoders.pillow", "_decode_frame")),
         ("gdcm", ("pydicom.pixels.decoders.gdcm", "_decode_frame")),
         ("pylibjpeg", ("pydicom.pixels.decoders.pylibjpeg", "_decode_frame")),
-        ("pillow", ("pydicom.pixels.decoders.pillow", "_decode_frame")),
     ]
 )
 

--- a/src/pydicom/pixels/decoders/native.py
+++ b/src/pydicom/pixels/decoders/native.py
@@ -52,6 +52,8 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytearray:
     bytearray
         The decoded frame, ordered as planar configuration 1.
     """
+    runner.set_frame_option(runner.index, "decoding_plugin", "pydicom")
+
     if runner.transfer_syntax == RLELossless:
         frame = _rle_decode_frame(
             src,
@@ -62,15 +64,14 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytearray:
             runner.get_option("rle_segment_order", ">"),
         )
 
-        # Update the runner options to ensure the reshaping is correct
-        # Only do this if we successfully decoded the frame
-        runner.set_option("planar_configuration", 1)
+        # Update the frame's options to ensure the reshaping is correct
+        runner.set_frame_option(runner.index, "planar_configuration", 1)
     else:
         frame = _deflated_decode_frame(src)
 
     # Signal that single bit data is represented in bit-packed form
     if runner.bits_allocated == 1:
-        runner.set_option("is_bitpacked", True)
+        runner.set_frame_option(runner.index, "bits_allocated", 1)
 
     return frame
 

--- a/src/pydicom/pixels/decoders/pillow.py
+++ b/src/pydicom/pixels/decoders/pillow.py
@@ -55,8 +55,10 @@ def is_available(uid: str) -> bool:
 
 def _decode_frame(src: bytes, runner: DecodeRunner) -> bytes:
     """Return the decoded image data in `src` as a :class:`bytes`."""
+    runner.set_frame_option(runner.index, "decoding_plugin", "pillow")
+
     tsyntax = runner.transfer_syntax
-    original_bits_allocated = runner.bits_allocated
+    bits_allocated = runner.bits_allocated
 
     # libjpeg only supports 8-bit JPEG Extended (can be 8 or 12 in the JPEG standard)
     if tsyntax == uid.JPEGExtended12Bit and runner.bits_stored != 8:
@@ -67,24 +69,42 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytes:
     image = Image.open(BytesIO(src), formats=("JPEG", "JPEG2000"))
     if tsyntax in _LIBJPEG_SYNTAXES:
         if runner.samples_per_pixel != 1:
-            # If the Adobe APP14 marker is not present then Pillow assumes
-            #   that JPEG images were transformed into YCbCr color space prior
-            #   to compression, so setting the image mode to YCbCr signals we
-            #   don't want any color transformations.
-            # Any color transformations would be inconsistent with the
-            #   behavior required by the `raw` flag
+            # Multi-sample image: ensure the output color space is correct
+            cs = runner.get_frame_option(runner.index, "photometric_interpretation")
+            convert_to_rgb = runner.get_option("as_rgb", False) and "YBR" in cs
+
             if "adobe_transform" not in image.info:
-                image.draft("YCbCr", image.size)  # type: ignore[no-untyped-call]
+                # If the Adobe APP14 marker is not present then Pillow assumes that JPEG
+                #    images were transformed into YCbCr color space prior to compression
+                if convert_to_rgb:
+                    # Pillow will default to applying a YCbCr -> RGB conversion
+                    runner.set_frame_option(
+                        runner.index, "photometric_interpretation", PI.RGB
+                    )
+                else:
+                    # Use Image.draft() to signal no color transformation
+                    image.draft("YCbCr", image.size)  # type: ignore[no-untyped-call]
+            elif image.info["adobe_transform"] == 1:  # 0: RGB, 1: YCbCr
+                # If the Adobe APP14 marker is present then Pillow uses the value to
+                #   determine the color space and defaults to returning RGB
+                if convert_to_rgb:
+                    runner.set_frame_option(
+                        runner.index, "photometric_interpretation", PI.RGB
+                    )
+                elif "YBR" in cs:
+                    image.draft("YCbCr", image.size)  # type: ignore[no-untyped-call]
 
         return cast(bytes, image.tobytes())
 
     # JPEG 2000
     # The precision from the J2K codestream is more appropriate because the
     #   decoder will use it to create the output integers
-    precision = runner.get_option("j2k_precision", runner.bits_stored)
+    precision = runner.get_frame_option(
+        runner.index, "j2k_precision", runner.bits_stored
+    )
     # pillow's pixel container size is based on precision
     if 0 < precision <= 8:
-        runner.set_option("bits_allocated", 8)
+        bits_allocated = 8
     elif 8 < precision <= 16:
         # Pillow converts >= 9-bit RGB/YCbCr data to 8-bit
         if runner.samples_per_pixel > 1:
@@ -92,22 +112,24 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytes:
                 f"Pillow cannot decode {precision}-bit multi-sample data correctly"
             )
 
-        runner.set_option("bits_allocated", 16)
+        bits_allocated = 16
     else:
         raise ValueError(
             "only (0028,0101) 'Bits Stored' values of up to 16 are supported"
         )
 
+    runner.set_frame_option(runner.index, "bits_allocated", bits_allocated)
+
     # Pillow converts N-bit signed/unsigned data to 8- or 16-bit unsigned data
     #   See Pillow src/libImaging/Jpeg2KDecode.c::j2ku_gray_i
     buffer = bytearray(image.tobytes())  # so the array is writeable
     del image
-    dtype = runner.pixel_dtype
+    dtype = runner.frame_dtype(runner.index)
     arr = np.frombuffer(buffer, dtype=f"<u{dtype.itemsize}")
 
     is_signed = runner.pixel_representation
     if runner.get_option("apply_j2k_sign_correction", False):
-        is_signed = runner.get_option("j2k_is_signed", is_signed)
+        is_signed = runner.get_frame_option(runner.index, "j2k_is_signed", is_signed)
 
     if is_signed and runner.pixel_representation == 1:
         # Re-view the unsigned integers as signed
@@ -115,18 +137,18 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytes:
         arr = arr.view(dtype)
         # Level-shift to match the unsigned integers range
         #   e.g. [0, 127, -128, -1] -> [-128, -1, 0, 127]
-        arr -= np.int32(2 ** (runner.bits_allocated - 1))
+        arr -= np.int32(2 ** (bits_allocated - 1))
 
-    if bit_shift := (runner.bits_allocated - precision):
+    if bit_shift := (bits_allocated - precision):
         # Bit shift to undo the upscaling of N-bit to 8- or 16-bit
         np.right_shift(arr, bit_shift, out=arr)
 
     # pillow returns YBR_ICT and YBR_RCT as RGB
     if runner.photometric_interpretation in (PI.YBR_ICT, PI.YBR_RCT):
-        runner.set_option("photometric_interpretation", PI.RGB)
+        runner.set_frame_option(runner.index, "photometric_interpretation", PI.RGB)
 
     # Signal that single-bit data is represented in unpacked form
-    if original_bits_allocated == 1:
-        runner.set_option("is_bitpacked", False)
+    if runner.bits_allocated == 1:
+        runner.set_frame_option(runner.index, "bits_allocated", 8)
 
     return cast(bytes, arr.tobytes())

--- a/src/pydicom/pixels/decoders/pyjpegls.py
+++ b/src/pydicom/pixels/decoders/pyjpegls.py
@@ -30,18 +30,20 @@ def is_available(uid: str) -> bool:
 
 def _decode_frame(src: bytes, runner: DecodeRunner) -> bytearray:
     """Return the decoded image data in `src` as a :class:`bytearray`."""
+    runner.set_frame_option(runner.index, "decoding_plugin", "pyjpegls")
+
     buffer, info = jpeg_ls.decode_pixel_data(src)
     # Interleave mode 0 is colour-by-plane, 1 and 2 are colour-by-pixel
     if info["components"] > 1:
         if info["interleave_mode"] == 0:
-            runner.set_option("planar_configuration", 1)
+            runner.set_frame_option(runner.index, "planar_configuration", 1)
         else:
-            runner.set_option("planar_configuration", 0)
+            runner.set_frame_option(runner.index, "planar_configuration", 0)
 
     precision = info["bits_per_sample"]
     if 0 < precision <= 8:
-        runner.set_option("bits_allocated", 8)
+        runner.set_frame_option(runner.index, "bits_allocated", 8)
     elif 8 < precision <= 16:
-        runner.set_option("bits_allocated", 16)
+        runner.set_frame_option(runner.index, "bits_allocated", 16)
 
     return cast(bytearray, buffer)

--- a/src/pydicom/pixels/decoders/pylibjpeg.py
+++ b/src/pydicom/pixels/decoders/pylibjpeg.py
@@ -75,13 +75,14 @@ def is_available(uid: str) -> bool:
 
 def _decode_frame(src: bytes, runner: DecodeRunner) -> bytearray:  # type: ignore[return]
     """Return the decoded image data in `src` as a :class:`bytearray`."""
+    runner.set_frame_option(runner.index, "decoding_plugin", "pylibjpeg")
     tsyntax = runner.transfer_syntax
-    original_bits_allocated = runner.bits_allocated
+    bits_allocated = runner.bits_allocated
 
     if tsyntax == uid.RLELossless and runner.bits_allocated == 1:
         raise NotImplementedError(
             "pylibjpeg cannot decompress RLE Lossless encoded data "
-            "with bits allocated = 1."
+            "with (0028,0100) 'Bits Allocated' = 1"
         )
 
     # Currently only one pylibjpeg plugin is available per UID
@@ -92,7 +93,7 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytearray:  # type: ignor
 
         # pylibjpeg-rle returns decoded data as planar configuration 1
         if tsyntax == uid.RLELossless:
-            runner.set_option("planar_configuration", 1)
+            runner.set_frame_option(runner.index, "planar_configuration", 1)
 
         if tsyntax in _OPENJPEG_SYNTAXES:
             # pylibjpeg-openjpeg returns YBR_ICT and YBR_RCT as RGB
@@ -100,31 +101,35 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytearray:  # type: ignor
                 runner.set_option("photometric_interpretation", PI.RGB)
 
             # pylibjpeg-openjpeg pixel container size is based on J2K precision
-            precision = runner.get_option("j2k_precision", runner.bits_stored)
+            precision = runner.get_frame_option(
+                runner.index, "j2k_precision", runner.bits_stored
+            )
             if 0 < precision <= 8:
-                runner.set_option("bits_allocated", 8)
+                bits_allocated = 8
             elif 8 < precision <= 16:
-                runner.set_option("bits_allocated", 16)
+                bits_allocated = 16
             elif 16 < precision <= 32:
-                runner.set_option("bits_allocated", 32)
+                bits_allocated = 32
 
         if tsyntax in uid.JPEGLSTransferSyntaxes:
             # pylibjpeg-libjpeg always returns JPEG-LS data as color-by-pixel
-            runner.set_option("planar_configuration", 0)
+            runner.set_frame_option(runner.index, "planar_configuration", 0)
 
             # pylibjpeg-libjpeg pixel container size is based on JPEG-LS precision
-            precision = runner.get_option("jls_precision", runner.bits_stored)
+            precision = runner.get_frame_option(
+                runner.index, "jls_precision", runner.bits_stored
+            )
             if 0 < precision <= 8:
-                runner.set_option("bits_allocated", 8)
+                bits_allocated = 8
             elif 8 < precision <= 16:
-                runner.set_option("bits_allocated", 16)
+                bits_allocated = 16
+
+        runner.set_frame_option(runner.index, "bits_allocated", bits_allocated)
 
         # Signal whether single-bit data is represented in unpacked form
-        if original_bits_allocated == 1:
-            if tsyntax == uid.RLELossless:
-                # In case pylibjpeg supports this case in the future
-                runner.set_option("is_bitpacked", True)
-            else:
-                runner.set_option("is_bitpacked", False)
+        if runner.bits_allocated == 1:
+            runner.set_frame_option(
+                runner.index, "bits_allocated", 1 if tsyntax == uid.RLELossless else 8
+            )
 
         return frame

--- a/src/pydicom/pixels/encoders/gdcm.py
+++ b/src/pydicom/pixels/encoders/gdcm.py
@@ -46,6 +46,8 @@ def encode_pixel_data(src: bytes, runner: EncodeRunner) -> bytes:
     bytes
         The encoded image data.
     """
+    runner.set_frame_option(runner.index, "encoding_plugin", "gdcm")
+
     byteorder = runner.get_option("byteorder", "<")
     if byteorder == ">":
         raise ValueError("Unsupported option \"byteorder = '>'\"")

--- a/src/pydicom/pixels/encoders/pyjpegls.py
+++ b/src/pydicom/pixels/encoders/pyjpegls.py
@@ -30,6 +30,8 @@ def is_available(uid: str) -> bool:
 
 def _encode_frame(src: bytes, runner: EncodeRunner) -> bytearray:
     """Return the image data in `src` as a JPEG-LS encoded codestream."""
+    runner.set_frame_option(runner.index, "encoding_plugin", "pylibjpeg")
+
     lossy_error = runner.get_option("jls_error", 0)
     if lossy_error and runner.transfer_syntax == uid.JPEGLSLossless:
         raise ValueError(

--- a/tests/pixels/test_decoder_base.py
+++ b/tests/pixels/test_decoder_base.py
@@ -14,7 +14,12 @@ from pydicom.encaps import get_frame, generate_frames, encapsulate
 from pydicom.pixels import get_decoder
 from pydicom.pixels.common import PhotometricInterpretation as PI
 from pydicom.pixels.decoders import ExplicitVRLittleEndianDecoder
-from pydicom.pixels.decoders.base import DecodeRunner, Decoder
+from pydicom.pixels.decoders.base import (
+    DecodeRunner,
+    Decoder,
+    _apply_sign_correction,
+    _process_color_space,
+)
 from pydicom.pixels.processing import convert_color_space
 from pydicom.pixels.utils import get_packed_frame, pack_bits
 
@@ -26,6 +31,8 @@ from pydicom.uid import (
     JPEGBaseline8Bit,
     RLELossless,
     SMPTEST211030PCMDigitalAudio,
+    JPEG2000,
+    JPEGLSLossless,
 )
 
 try:
@@ -266,6 +273,39 @@ class TestDecodeRunner:
             runner._opts["transfer_syntax_uid"] = ExplicitVRBigEndian
             assert runner.pixel_dtype.byteorder in [">", "="]
 
+    @pytest.mark.skipif(not HAVE_NP, reason="Numpy is not available")
+    def test_frame_dtype_float(self):
+        """Test frame_dtype defaults to pixel_dtype for float pixel data."""
+        runner = DecodeRunner(RLELossless)
+        runner.set_option("bits_allocated", 16)
+        runner.set_option("pixel_representation", 0)
+        runner.set_option("pixel_keyword", "FloatPixelData")
+        assert runner.frame_dtype(0) == runner.pixel_dtype
+
+    @pytest.mark.skipif(not HAVE_NP, reason="Numpy is not available")
+    def test_frame_dtype(self):
+        """Test frame_dtype sets itemsize from frame properties."""
+        runner = DecodeRunner(RLELossless)
+        runner.set_option("bits_allocated", 16)
+        runner.set_option("pixel_representation", 0)
+        runner.set_option("pixel_keyword", "PixelData")
+        assert runner._frame_meta == {}
+        assert runner.frame_dtype(0).itemsize == 2  # falls back to expected
+        runner._frame_meta[0] = {"bits_allocated": 1}  # bit packed uses u1
+        assert runner.frame_dtype(0).itemsize == 1
+        assert runner.frame_dtype(0).kind == "u"
+        runner._frame_meta[0] = {"bits_allocated": 8}
+        assert runner.frame_dtype(0).itemsize == 1
+        assert runner.frame_dtype(0).kind == "u"
+
+        runner.set_option("pixel_representation", 1)
+        runner._frame_meta[0] = {"bits_allocated": 16}
+        assert runner.frame_dtype(0).itemsize == 2
+        assert runner.frame_dtype(0).kind == "i"
+        runner._frame_meta[0] = {"bits_allocated": 32}
+        assert runner.frame_dtype(0).itemsize == 4
+        assert runner.frame_dtype(0).kind == "i"
+
     def test_validate_buffer(self):
         """Tests for validate_buffer()"""
         runner = DecodeRunner(RLELossless)
@@ -385,12 +425,12 @@ class TestDecodeRunner:
         assert runner._previous[1] == runner._decoders["pydicom"]
 
         arr = np.frombuffer(buffer, dtype=runner.pixel_dtype)
-        arr = runner.reshape(arr, as_frame=True)
+        arr = runner.reshape(arr, 0)
         RLE_16_1_10F.test(arr, index=0)
 
         buffer = runner.decode(9)
         arr = np.frombuffer(buffer, dtype=runner.pixel_dtype)
-        arr = runner.reshape(arr, as_frame=True)
+        arr = runner.reshape(arr, 9)
         RLE_16_1_10F.test(arr, index=9)
 
         def decode1(src, opts):
@@ -429,14 +469,14 @@ class TestDecodeRunner:
         assert runner._previous[1] == runner._decoders["pydicom"]
 
         arr = np.frombuffer(buffer, dtype=runner.pixel_dtype)
-        arr = runner.reshape(arr, as_frame=True)
+        arr = runner.reshape(arr, 0)
         RLE_16_1_10F.test(arr, index=0)
 
         for ii in range(9):
             buffer = next(data)
 
         arr = np.frombuffer(buffer, dtype=runner.pixel_dtype)
-        arr = runner.reshape(arr, as_frame=True)
+        arr = runner.reshape(arr, 9)
         RLE_16_1_10F.test(arr, index=9)
 
         pytest.raises(StopIteration, next, data)
@@ -507,8 +547,15 @@ class TestDecodeRunner:
         assert runner.get_data(src, 3, 4) == b"\x03\x04\x05"
         assert src.tell() == 2
 
-    def test_pixel_properties(self):
-        """Test pixel_properties()"""
+    def test_pixel_properties_raises(self):
+        """Test pixel_properties() raises if index invalid"""
+        runner = DecodeRunner(RLELossless)
+        msg = "'index' must be int or None, not 'bool'"
+        with pytest.raises(TypeError, match=msg):
+            runner.pixel_properties(True)
+
+    def test_pixel_properties_none(self):
+        """Test pixel_properties(index = None)"""
         runner = DecodeRunner(RLELossless)
         opts = {
             "columns": 9,
@@ -522,7 +569,7 @@ class TestDecodeRunner:
             "bits_stored": 8,
         }
         runner.set_options(**opts)
-        d = runner.pixel_properties()
+        d = runner.pixel_properties(None)
         assert d["columns"] == 9
         assert d["rows"] == 10
         assert d["samples_per_pixel"] == 1
@@ -531,15 +578,46 @@ class TestDecodeRunner:
         assert d["pixel_representation"] == 0
         assert d["bits_allocated"] == 16
         assert d["bits_stored"] == 8
-        assert d["number_of_frames"] == 3
         assert "planar_configuration" not in d
 
         runner.set_option("pixel_keyword", "FloatPixelData")
-        assert "pixel_representation" not in runner.pixel_properties()
+        assert "pixel_representation" not in runner.pixel_properties(None)
 
         runner.set_option("samples_per_pixel", 3)
         runner.set_option("planar_configuration", 1)
-        assert runner.pixel_properties()["planar_configuration"] == 1
+        assert runner.pixel_properties(None)["planar_configuration"] == 1
+
+    def test_pixel_properties_as_frame_warns(self):
+        """Test pixel_properties() warns for as_frame"""
+        runner = DecodeRunner(RLELossless)
+        opts = {
+            "columns": 9,
+            "rows": 10,
+            "samples_per_pixel": 1,
+            "number_of_frames": 3,
+            "pixel_keyword": "PixelData",
+            "photometric_interpretation": PI.RGB,
+            "pixel_representation": 0,
+            "bits_allocated": 16,
+            "bits_stored": 8,
+        }
+        runner.set_options(**opts)
+        runner.set_frame_option(0, "photometric_interpretation", "RGB")
+        runner.set_frame_option(0, "bits_allocated", 8)
+
+        msg = "'as_frame' is deprecated and will be removed in v4.0"
+        with pytest.warns(DeprecationWarning, match=msg):
+            d = runner.pixel_properties(0, as_frame=True)
+
+        assert d["columns"] == 9
+        assert d["rows"] == 10
+        assert d["samples_per_pixel"] == 1
+        assert d["number_of_frames"] == 1
+        assert d["photometric_interpretation"] == PI.RGB
+        assert d["pixel_representation"] == 0
+        assert d["bits_allocated"] == 8
+        assert d["bits_stored"] == 8
+        assert "planar_configuration" not in d
 
 
 @pytest.mark.skipif(not HAVE_NP, reason="Numpy is not available")
@@ -774,7 +852,7 @@ class TestDecodeRunner_Reshape:
     def test_1frame_1sample(self, _1frame_1sample):
         """Test reshaping 1 frame, 1 sample/pixel."""
         self.runner.set_option("samples_per_pixel", 1)
-        arr = self.runner.reshape(_1frame_1sample)
+        arr = self.runner.reshape(_1frame_1sample, None)
         assert (4, 5) == arr.shape
         assert np.array_equal(arr, self.ref_1_1)
 
@@ -782,7 +860,7 @@ class TestDecodeRunner_Reshape:
         buffer = arr.tobytes()
         out = np.frombuffer(buffer, arr.dtype)
         assert not out.flags.writeable
-        out = self.runner.reshape(out)
+        out = self.runner.reshape(out, None)
         assert not out.flags.writeable
 
     def test_1frame_3sample_0conf(self, _1frame_3sample_0config):
@@ -790,15 +868,18 @@ class TestDecodeRunner_Reshape:
         self.runner.set_option("number_of_frames", 1)
         self.runner.set_option("samples_per_pixel", 3)
         self.runner.set_option("planar_configuration", 0)
-        arr = self.runner.reshape(_1frame_3sample_0config)
+        self.runner.set_frame_option(0, "planar_configuration", 0)
+        arr = self.runner.reshape(_1frame_3sample_0config, None)
         assert (4, 5, 3) == arr.shape
         assert np.array_equal(arr, self.ref_1_3)
+        assert self.runner.planar_configuration == 0
+        assert self.runner.get_frame_option(0, "planar_configuration") == 0
 
         # Test reshape to (rows, cols, planes) is view-only
         buffer = arr.tobytes()
         out = np.frombuffer(buffer, arr.dtype)
         assert not out.flags.writeable
-        out = self.runner.reshape(out)
+        out = self.runner.reshape(out, None)
         assert not out.flags.writeable
 
     def test_1frame_3sample_1conf(self, _1frame_3sample_1config):
@@ -806,22 +887,25 @@ class TestDecodeRunner_Reshape:
         self.runner.set_option("number_of_frames", 1)
         self.runner.set_option("samples_per_pixel", 3)
         self.runner.set_option("planar_configuration", 1)
-        arr = self.runner.reshape(_1frame_3sample_1config)
+        self.runner.set_frame_option(0, "planar_configuration", 1)
+        arr = self.runner.reshape(_1frame_3sample_1config, None)
         assert (4, 5, 3) == arr.shape
         assert np.array_equal(arr, self.ref_1_3)
+        assert self.runner.planar_configuration == 0
+        assert self.runner.get_frame_option(0, "planar_configuration") == 0
 
         # Test reshape to (rows, cols, planes) is view-only
         buffer = arr.tobytes()
         out = np.frombuffer(buffer, arr.dtype)
         assert not out.flags.writeable
-        out = self.runner.reshape(out)
+        out = self.runner.reshape(out, None)
         assert not out.flags.writeable
 
     def test_2frame_1sample(self, _1frame_1sample, _2frame_1sample):
         """Test reshaping 2 frame, 1 sample/pixel."""
         self.runner.set_option("number_of_frames", 2)
         self.runner.set_option("samples_per_pixel", 1)
-        arr = self.runner.reshape(_2frame_1sample)
+        arr = self.runner.reshape(_2frame_1sample, None)
         assert (2, 4, 5) == arr.shape
         assert np.array_equal(arr, self.ref_2_1)
 
@@ -829,10 +913,10 @@ class TestDecodeRunner_Reshape:
         buffer = arr.tobytes()
         out = np.frombuffer(buffer, arr.dtype)
         assert not out.flags.writeable
-        out = self.runner.reshape(out)
+        out = self.runner.reshape(out, None)
         assert not out.flags.writeable
 
-        arr = self.runner.reshape(_1frame_1sample, as_frame=True)
+        arr = self.runner.reshape(_1frame_1sample, 0)
         assert (4, 5) == arr.shape
         assert np.array_equal(arr, self.ref_1_1)
 
@@ -843,20 +927,25 @@ class TestDecodeRunner_Reshape:
         self.runner.set_option("number_of_frames", 2)
         self.runner.set_option("samples_per_pixel", 3)
         self.runner.set_option("planar_configuration", 0)
-        arr = self.runner.reshape(_2frame_3sample_0config)
+        self.runner.set_frame_option(0, "planar_configuration", 0)
+        self.runner.set_frame_option(1, "planar_configuration", 0)
+        arr = self.runner.reshape(_2frame_3sample_0config, None)
         assert (2, 4, 5, 3) == arr.shape
         assert np.array_equal(arr, self.ref_2_3)
+        assert self.runner.planar_configuration == 0
 
         # Test reshape to (frames, rows, cols, planes) is view-only
         buffer = arr.tobytes()
         out = np.frombuffer(buffer, arr.dtype)
         assert not out.flags.writeable
-        out = self.runner.reshape(out)
+        out = self.runner.reshape(out, None)
         assert not out.flags.writeable
 
-        arr = self.runner.reshape(_1frame_3sample_0config, as_frame=True)
+        arr = self.runner.reshape(_1frame_3sample_0config, 0)
         assert (4, 5, 3) == arr.shape
         assert np.array_equal(arr, self.ref_1_3)
+        assert self.runner.planar_configuration == 0
+        assert self.runner.get_frame_option(0, "planar_configuration") == 0
 
     def test_2frame_3sample_1conf(
         self, _1frame_3sample_1config, _2frame_3sample_1config
@@ -865,20 +954,44 @@ class TestDecodeRunner_Reshape:
         self.runner.set_option("number_of_frames", 2)
         self.runner.set_option("samples_per_pixel", 3)
         self.runner.set_option("planar_configuration", 1)
-        arr = self.runner.reshape(_2frame_3sample_1config)
+        self.runner.set_frame_option(0, "planar_configuration", 1)
+        self.runner.set_frame_option(1, "planar_configuration", 1)
+        arr = self.runner.reshape(_2frame_3sample_1config, None)
         assert (2, 4, 5, 3) == arr.shape
         assert np.array_equal(arr, self.ref_2_3)
+        assert self.runner.planar_configuration == 0
 
         # Test reshape to (frames, rows, cols, planes) is view-only
+        self.runner._frame_meta = {}
+        self.runner.set_option("planar_configuration", 1)
         buffer = arr.tobytes()
         out = np.frombuffer(buffer, arr.dtype)
         assert not out.flags.writeable
-        out = self.runner.reshape(out)
+        out = self.runner.reshape(out, None)
         assert not out.flags.writeable
 
-        arr = self.runner.reshape(_1frame_3sample_1config, as_frame=True)
+        self.runner._frame_meta = {}
+        self.runner.set_option("planar_configuration", 1)
+        arr = self.runner.reshape(_1frame_3sample_1config, 0)
         assert (4, 5, 3) == arr.shape
         assert np.array_equal(arr, self.ref_1_3)
+        assert self.runner.get_frame_option(0, "planar_configuration") == 0
+
+    def test_as_frame_warns(self, _1frame_1sample):
+        """Test DecodeRunner.reshape() warns if as_frame is used"""
+        self.runner.set_option("samples_per_pixel", 1)
+        msg = "'as_frame' is deprecated and will be removed in v4.0"
+        with pytest.warns(DeprecationWarning, match=msg):
+            arr = self.runner.reshape(_1frame_1sample, 0, as_frame=True)
+
+        assert (4, 5) == arr.shape
+
+    def test_index_raises(self, _1frame_1sample):
+        """Test DecodeRunner.reshape() warns if as_frame is used"""
+        self.runner.set_option("samples_per_pixel", 1)
+        msg = "'index' must be int or None, not 'bool'"
+        with pytest.raises(TypeError, match=msg):
+            self.runner.reshape(_1frame_1sample, True)
 
 
 class TestDecoder:
@@ -1009,11 +1122,22 @@ class TestDecoder_Array:
                 "interpretation of 'YBR_FULL_422'"
             ) in caplog.text
 
-    def test_colorspace_change_view_warns(self, caplog):
+    def test_colorspace_rgb_view_warns(self, caplog):
         """Test warning for color space change with `view_only`"""
         decoder = get_decoder(ExplicitVRLittleEndian)
         with caplog.at_level(logging.WARNING, logger="pydicom"):
             decoder.as_array(EXPL_8_3_1F_YBR.ds, view_only=True)
+
+            assert (
+                "Unable to return an ndarray that's a view on the original "
+                "buffer if applying a color space conversion"
+            ) in caplog.text
+
+    def test_colorspace_force_ybr_view_warns(self, caplog):
+        """Test warning for color space change with `view_only`"""
+        decoder = get_decoder(ExplicitVRLittleEndian)
+        with caplog.at_level(logging.WARNING, logger="pydicom"):
+            decoder.as_array(EXPL_8_3_1F_YBR.ds, force_ybr=True, view_only=True)
 
             assert (
                 "Unable to return an ndarray that's a view on the original "
@@ -1202,6 +1326,55 @@ class TestDecoder_Array:
 
         runner.set_option("allow_excess_frames", False)
         arr, meta = decoder.as_array(src, **runner.options)
+        assert arr.shape == (10, 64, 64)
+        assert meta["number_of_frames"] == 10
+
+    def test_encapsulated_excess_frames_combinations(self):
+        """Test returning excess frame data for the various combinations"""
+        decoder = get_decoder(RLELossless)
+        reference = RLE_16_1_10F
+        ds = dcmread(reference.path)
+
+        # 1 + many
+        ds.NumberOfFrames = 1
+        runner = DecodeRunner(RLELossless)
+        runner.set_source(ds)
+        with pytest.warns(UserWarning, match="10 frames have been found"):
+            arr, meta = decoder.as_array(ds.PixelData, **runner.options)
+
+        assert arr.shape == (10, 64, 64)
+        assert meta["number_of_frames"] == 10
+
+        # 1 + 1
+        ds.NumberOfFrames = 1
+        runner = DecodeRunner(RLELossless)
+        runner.set_source(ds)
+        frames = [x for x in generate_frames(reference.ds.PixelData)]
+        src = encapsulate(frames[:2])
+
+        with pytest.warns(UserWarning, match="2 frames have been found"):
+            arr, meta = decoder.as_array(src, **runner.options)
+
+        assert arr.shape == (2, 64, 64)
+        assert meta["number_of_frames"] == 2
+
+        # many + 1
+        ds.NumberOfFrames = 9
+        runner = DecodeRunner(RLELossless)
+        runner.set_source(ds)
+        with pytest.warns(UserWarning, match="10 frames have been found"):
+            arr, meta = decoder.as_array(ds.PixelData, **runner.options)
+
+        assert arr.shape == (10, 64, 64)
+        assert meta["number_of_frames"] == 10
+
+        # many + many
+        ds.NumberOfFrames = 5
+        runner = DecodeRunner(RLELossless)
+        runner.set_source(ds)
+        with pytest.warns(UserWarning, match="10 frames have been found"):
+            arr, meta = decoder.as_array(ds.PixelData, **runner.options)
+
         assert arr.shape == (10, 64, 64)
         assert meta["number_of_frames"] == 10
 
@@ -1603,7 +1776,7 @@ class TestDecoder_Buffer:
             arr, meta_a = decoder.as_array(reference.ds, index=index)
             buffer, meta_b = decoder.as_buffer(reference.ds, index=index)
             assert arr.tobytes() == buffer
-            assert meta_a == meta_b
+            assert meta_a == meta_b[index]
             assert meta_a["number_of_frames"] == 1
 
         msg = "There is insufficient pixel data to contain 11 frames"
@@ -1622,7 +1795,7 @@ class TestDecoder_Buffer:
         assert isinstance(buffer, memoryview)
         assert arr.tobytes() == buffer
         assert buffer.obj is reference.ds.PixelData
-        assert meta_a == meta_b
+        assert meta_a == meta_b[0]
 
         # mutable source buffer
         # Also tests buffer-like `src`
@@ -1712,8 +1885,8 @@ class TestDecoder_Buffer:
             buffer, meta = decoder.as_buffer(reference.ds, index=index)
             assert isinstance(buffer, bytes | bytearray)
             assert arr.tobytes() == buffer
-            assert meta["bits_stored"] == 12
-            assert meta["number_of_frames"] == 1
+            assert meta[index]["bits_stored"] == 12
+            assert meta[index]["number_of_frames"] == 1
 
     def test_encapsulated_plugin(self):
         """Test `decoding_plugin` with an encapsulated pixel data."""
@@ -1769,14 +1942,14 @@ class TestDecoder_Buffer:
             buffer, meta = decoder.as_buffer(src, **runner.options)
 
         assert len(buffer) == 11 * 64 * 64 * 2
-        assert meta["number_of_frames"] == 11
+        assert len(meta) == 11
 
         runner.set_option("allow_excess_frames", False)
         buffer, meta = decoder.as_buffer(src, **runner.options)
         assert len(buffer) == 10 * 64 * 64 * 2
-        assert meta["number_of_frames"] == 10
+        assert len(meta) == 10
 
-    def test_encapsulated_excess_frames_singlebit(self):
+    def test_encapsulated_excess_frames_singlebit_packed(self):
         """Test returning excess frame data"""
         decoder = get_decoder(RLELossless)
         reference = RLE_1_1_3F
@@ -1798,12 +1971,12 @@ class TestDecoder_Buffer:
             buffer, meta = decoder.as_buffer(src, **runner.options)
 
         assert len(buffer) == (4 * 512 * 512) // 8
-        assert meta["number_of_frames"] == 4
+        assert len(meta) == 4
 
         runner.set_option("allow_excess_frames", False)
         buffer, meta = decoder.as_buffer(src, **runner.options)
         assert len(buffer) == (3 * 512 * 512) // 8
-        assert meta["number_of_frames"] == 3
+        assert len(meta) == 3
 
     def test_expb_ow_index_invalid_raises(self):
         """Test invalid index with BE swapped OW raises"""
@@ -1954,3 +2127,168 @@ def test_get_decoder():
     )
     with pytest.raises(NotImplementedError, match=msg):
         get_decoder(SMPTEST211030PCMDigitalAudio)
+
+
+class TestApplySignCorrection:
+    """Tests for _apply_sign_correction()"""
+
+    def test_j2k_sign_correction_multi(self):
+        """Test multiframe J2K with inconsistent values."""
+        runner = DecodeRunner(JPEG2000)
+        runner.set_option("bits_stored", 12)
+        runner.set_option("pixel_representation", 0)
+        runner._frame_meta = {
+            0: {"j2k_precision": 12, "j2k_is_signed": True},
+            1: {"j2k_precision": 11, "j2k_is_signed": True},
+        }
+        frame = np.asarray(
+            [
+                [4097, 4096, 4095, 4094],
+                [4093, 4092, 4091, 4090],
+            ],
+            dtype="u2",
+        )
+        arr = np.asarray([frame, frame])
+        out = _apply_sign_correction(arr, runner, None)
+        assert out[0].tolist() == [[1, 0, 4095, 4094], [4093, 4092, 4091, 4090]]
+        assert out[1].tolist() == [[1, 0, 2047, 2046], [2045, 2044, 2043, 2042]]
+
+        runner._frame_meta = {
+            0: {"j2k_precision": 12, "j2k_is_signed": True},
+            1: {"j2k_precision": 11, "j2k_is_signed": False},
+        }
+        arr = np.asarray([frame, frame])
+        out = _apply_sign_correction(arr, runner, None)
+        assert out[0].tolist() == [[1, 0, 4095, 4094], [4093, 4092, 4091, 4090]]
+        assert out[1].tolist() == [[4097, 4096, 4095, 4094], [4093, 4092, 4091, 4090]]
+
+    def test_jls_sign_correction_multi(self):
+        """Test multiframe JLS with inconsistent values."""
+        runner = DecodeRunner(JPEGLSLossless)
+        runner.set_option("bits_stored", 12)
+        runner.set_option("pixel_representation", 1)
+        runner._frame_meta = {0: {"jls_precision": 12}, 1: {"jls_precision": 11}}
+        frame = np.asarray(
+            [
+                [4097, 4096, 4095, 4094],
+                [4093, 4092, 4091, 4090],
+            ],
+            dtype="i2",
+        )
+        arr = np.asarray([frame, frame])
+        out = _apply_sign_correction(arr, runner, None)
+        assert out[0].tolist() == [[1, 0, -1, -2], [-3, -4, -5, -6]]
+        assert out[1].tolist() == [[1, 0, -1, -2], [-3, -4, -5, -6]]
+
+
+class TestProcessColorSpace:
+    """Tests for _process_color_space()"""
+
+    def test_encapsulated_none(self):
+        """Test RGB conversion with index = None"""
+        runner = DecodeRunner(JPEGBaseline8Bit)
+        runner._frame_meta = {
+            0: {"photometric_interpretation": "YBR_FULL"},
+            1: {"photometric_interpretation": "YBR_FULL"},
+        }
+        runner.set_option("photometric_interpretation", "YBR_FULL")
+        runner.set_option("number_of_frames", 2)
+        runner.set_option("bits_stored", 8)
+        runner.set_option("to_rgb", True)
+
+        arr = EXPL_8_3_1F_YBR.ds.pixel_array
+        frames = np.asarray([arr, arr])
+        assert frames.shape == (2, 100, 100, 3)
+
+        changes = {}
+        _ = _process_color_space(frames, runner, None, changes)
+        assert changes["photometric_interpretation"] == "RGB"
+        assert runner._frame_meta[0]["photometric_interpretation"] == "RGB"
+        assert runner._frame_meta[1]["photometric_interpretation"] == "RGB"
+        assert np.array_equal(frames[0], convert_color_space(arr, "YBR_FULL", "RGB"))
+
+    def test_encapsulated_none_single(self):
+        """Test RGB conversion with a single frame with index = None"""
+        runner = DecodeRunner(JPEGBaseline8Bit)
+        runner._frame_meta = {
+            0: {"photometric_interpretation": "YBR_FULL"},
+        }
+        runner.set_option("photometric_interpretation", "YBR_FULL")
+        runner.set_option("number_of_frames", 1)
+        runner.set_option("bits_stored", 8)
+        runner.set_option("to_rgb", True)
+
+        arr = EXPL_8_3_1F_YBR.ds.pixel_array
+        frames = np.asarray([arr]).squeeze()
+        assert frames.shape == (100, 100, 3)
+
+        changes = {}
+        out = _process_color_space(frames, runner, None, changes)
+        assert changes["photometric_interpretation"] == "RGB"
+        assert runner._frame_meta[0]["photometric_interpretation"] == "RGB"
+        assert np.array_equal(out, convert_color_space(arr, "YBR_FULL", "RGB"))
+
+    def test_encapsulated_none_multi_inconsistent(self):
+        """Test RGB conversion with multiple frames with index = None"""
+        runner = DecodeRunner(JPEGBaseline8Bit)
+        runner._frame_meta = {
+            0: {"photometric_interpretation": "RGB"},  # Don't convert frame 1
+            1: {"photometric_interpretation": "YBR_FULL"},
+        }
+        runner.set_option("photometric_interpretation", "YBR_FULL")
+        runner.set_option("number_of_frames", 2)
+        runner.set_option("bits_stored", 8)
+        runner.set_option("to_rgb", True)
+
+        arr = EXPL_8_3_1F_YBR.ds.pixel_array
+        frames = np.asarray([arr, arr])
+        assert frames.shape == (2, 100, 100, 3)
+
+        changes = {}
+        out = _process_color_space(frames, runner, None, changes)
+        assert changes["photometric_interpretation"] == "RGB"
+        assert runner._frame_meta[0]["photometric_interpretation"] == "RGB"
+        assert runner._frame_meta[1]["photometric_interpretation"] == "RGB"
+        assert np.array_equal(out[0], arr)
+        assert np.array_equal(out[1], convert_color_space(arr, "YBR_FULL", "RGB"))
+
+    def test_encapsulated_indexed_single(self):
+        """Test RGB conversion with a single frame with index != None"""
+        runner = DecodeRunner(JPEGBaseline8Bit)
+        runner._frame_meta = {
+            0: {"photometric_interpretation": "YBR_FULL"},
+            1: {"photometric_interpretation": "YBR_FULL"},
+        }
+        runner.set_option("photometric_interpretation", "YBR_FULL")
+        runner.set_option("number_of_frames", 2)
+        runner.set_option("bits_stored", 8)
+        runner.set_option("to_rgb", True)
+
+        arr = EXPL_8_3_1F_YBR.ds.pixel_array
+        frames = np.asarray([arr]).squeeze()
+        assert frames.shape == (100, 100, 3)
+
+        changes = {}
+        out = _process_color_space(frames, runner, 0, changes)
+        assert "photometric_interpretation" not in changes
+        assert runner._frame_meta[0]["photometric_interpretation"] == "RGB"
+        assert runner._frame_meta[1]["photometric_interpretation"] == "YBR_FULL"
+        assert np.array_equal(out, convert_color_space(arr, "YBR_FULL", "RGB"))
+
+        runner._frame_meta = {
+            0: {"photometric_interpretation": "YBR_FULL"},
+            1: {"photometric_interpretation": "YBR_FULL"},
+        }
+        runner.set_option("photometric_interpretation", "YBR_FULL")
+        runner.set_option("number_of_frames", 2)
+        runner.set_option("bits_stored", 8)
+        runner.set_option("to_rgb", True)
+
+        frames = np.asarray([arr]).squeeze()
+        assert frames.shape == (100, 100, 3)
+
+        out = _process_color_space(frames, runner, 1, changes)
+        assert "photometric_interpretation" not in changes
+        assert runner._frame_meta[0]["photometric_interpretation"] == "YBR_FULL"
+        assert runner._frame_meta[1]["photometric_interpretation"] == "RGB"
+        assert np.array_equal(out, convert_color_space(arr, "YBR_FULL", "RGB"))

--- a/tests/pixels/test_decoder_pydicom.py
+++ b/tests/pixels/test_decoder_pydicom.py
@@ -262,7 +262,7 @@ class TestAsBuffer:
             if ds.SamplesPerPixel == 1:
                 assert arr_frame.tobytes() == buffer_frame
             else:
-                assert meta["planar_configuration"] == 1
+                assert meta[index]["planar_configuration"] == 1
                 # Red
                 arr_plane = arr_frame[..., 0].tobytes()
                 plane_length = len(arr_plane)

--- a/tests/pixels/test_encoder_base.py
+++ b/tests/pixels/test_encoder_base.py
@@ -468,7 +468,7 @@ class TestEncodeRunner_GetFrame:
         # Output data should be bitpacked
         assert len(out) == 1
         assert b"\x05" == out
-        assert self.runner.get_option("is_bitpacked") is None
+        assert self.runner.get_frame_option(0, "bits_allocated") == 8
 
     def test_arr_u01_1s_unpacked_source(self):
         """Test processing u1/1s with unpacked source"""
@@ -489,7 +489,7 @@ class TestEncodeRunner_GetFrame:
 
         assert len(out) == 8
         assert b"\x01\x00\x01\x00\x00\x00\x00\x00" == out
-        assert self.runner.get_option("is_bitpacked") is None
+        assert self.runner.get_frame_option(0, "bits_allocated") == 8
 
     def test_arr_u08_1s(self):
         """Test processing u8/1s"""
@@ -980,8 +980,9 @@ class TestEncodeRunner_GetFrame:
         assert runner.get_frame(0) == f1
         assert runner.get_frame(1) == f2
         assert runner.get_frame(2) == f3
-        is_bitpacked = runner.get_option("is_bitpacked")
-        assert isinstance(is_bitpacked, bool) and is_bitpacked
+        assert runner.get_frame_option(0, "bits_allocated") == 1
+        assert runner.get_frame_option(1, "bits_allocated") == 1
+        assert runner.get_frame_option(2, "bits_allocated") == 1
 
         # Repeated with unpacked single bit data
         f1 = unpack_bits(f1, as_array=False)
@@ -998,8 +999,9 @@ class TestEncodeRunner_GetFrame:
 
         # The fact that the data are not bit packed should have been deduced
         # from the length
-        is_bitpacked = runner.get_option("is_bitpacked")
-        assert isinstance(is_bitpacked, bool) and not is_bitpacked
+        assert runner.get_frame_option(0, "bits_allocated") != 1
+        assert runner.get_frame_option(1, "bits_allocated") != 1
+        assert runner.get_frame_option(2, "bits_allocated") != 1
 
     def test_buffer_08(self):
         """Test get_frame() using [0, 8)-bit samples with N-bit containers."""

--- a/tests/pixels/test_encoder_pydicom.py
+++ b/tests/pixels/test_encoder_pydicom.py
@@ -153,10 +153,11 @@ class TestEncodeRLEFrame:
             "bits_allocated": ds.BitsAllocated,
             "bits_stored": ds.BitsStored,
             "number_of_frames": n_frames,
-            "is_bitpacked": pass_as_packed,
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner.set_frame_option(0, "bits_allocated", 1 if pass_as_packed else 8)
+        runner._index = 0
 
         if pass_as_packed:
             input_arr = ds.PixelData
@@ -194,6 +195,7 @@ class TestEncodeRLEFrame:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_rle_frame(ds.PixelData, runner)
         decoded = _rle_decode_frame(
@@ -225,6 +227,7 @@ class TestEncodeRLEFrame:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_rle_frame(ds.PixelData, runner)
         decoded = _rle_decode_frame(
@@ -256,6 +259,7 @@ class TestEncodeRLEFrame:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_rle_frame(ds.PixelData, runner)
         decoded = _rle_decode_frame(
@@ -287,6 +291,7 @@ class TestEncodeRLEFrame:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_rle_frame(ds.PixelData, runner)
         decoded = _rle_decode_frame(
@@ -318,6 +323,7 @@ class TestEncodeRLEFrame:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_rle_frame(ds.PixelData, runner)
         decoded = _rle_decode_frame(
@@ -349,6 +355,7 @@ class TestEncodeRLEFrame:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_rle_frame(ds.PixelData, runner)
         decoded = _rle_decode_frame(
@@ -377,6 +384,7 @@ class TestEncodeRLEFrame:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         msg = (
             r"Unable to encode as the DICOM standard only allows "
@@ -401,6 +409,7 @@ class TestEncodeRLEFrame:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_rle_frame(arr.tobytes(), runner)
         header = (
@@ -440,6 +449,7 @@ class TestEncodeRLEFrame:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_rle_frame(arr.tobytes(), runner)
         header = b"\x01\x00\x00\x00\x40\x00\x00\x00" + b"\x00" * 56
@@ -461,6 +471,7 @@ class TestEncodeRLEFrame:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_rle_frame(arr.tobytes(), runner)
         header = (
@@ -488,6 +499,7 @@ class TestEncodeRLEFrame:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         msg = r"Unsupported option \"byteorder = '>'\""
         with pytest.raises(ValueError, match=msg):
@@ -564,10 +576,11 @@ class TestEncodeDeflatedFrame:
             "bits_allocated": ds.BitsAllocated,
             "bits_stored": ds.BitsStored,
             "number_of_frames": 1,
-            "is_bitpacked": pass_as_packed,
         }
         runner = EncodeRunner(DeflatedImageFrameCompression)
         runner.set_options(**kwargs)
+        runner.set_frame_option(0, "bits_allocated", 1 if pass_as_packed else 8)
+        runner._index = 0
 
         input_pixel_data = ds.PixelData
         if not pass_as_packed:
@@ -601,6 +614,7 @@ class TestEncodeDeflatedFrame:
         }
         runner = EncodeRunner(DeflatedImageFrameCompression)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_deflated_frame(ds.PixelData, runner)
         decoded = _deflated_decode_frame(encoded)
@@ -630,6 +644,7 @@ class TestEncodeDeflatedFrame:
         }
         runner = EncodeRunner(DeflatedImageFrameCompression)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_deflated_frame(ds.PixelData, runner)
         decoded = _deflated_decode_frame(encoded)
@@ -659,6 +674,7 @@ class TestEncodeDeflatedFrame:
         }
         runner = EncodeRunner(DeflatedImageFrameCompression)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_deflated_frame(ds.PixelData, runner)
         decoded = _deflated_decode_frame(encoded)
@@ -689,6 +705,7 @@ class TestEncodeDeflatedFrame:
         }
         runner = EncodeRunner(DeflatedImageFrameCompression)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_deflated_frame(ds.PixelData, runner)
         decoded = _deflated_decode_frame(encoded)
@@ -718,6 +735,7 @@ class TestEncodeDeflatedFrame:
         }
         runner = EncodeRunner(DeflatedImageFrameCompression)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_deflated_frame(ds.PixelData, runner)
         decoded = _deflated_decode_frame(encoded)
@@ -748,6 +766,7 @@ class TestEncodeDeflatedFrame:
         }
         runner = EncodeRunner(DeflatedImageFrameCompression)
         runner.set_options(**kwargs)
+        runner._index = 0
 
         encoded = _encode_deflated_frame(ds.PixelData, runner)
         decoded = _deflated_decode_frame(encoded)

--- a/tests/pixels/test_encoder_pylibjpeg.py
+++ b/tests/pixels/test_encoder_pylibjpeg.py
@@ -417,7 +417,7 @@ class TestJ2KLosslessEncoding:
                 assert np.array_equal(out, ref)
 
     def test_arr_i2_spp1(self):
-        """Test signed bits allocated 8, bits stored (1, 16), samples per pixel 1"""
+        """Test signed bits allocated 16, bits stored (1, 16), samples per pixel 1"""
         ds = examples.ct
         opts = {
             "rows": ds.Rows,
@@ -447,6 +447,7 @@ class TestJ2KLosslessEncoding:
             )
 
             for plugin in plugins:
+                print(plugin, bits_stored)
                 out, _ = JPEG2000LosslessDecoder.as_array(
                     encapsulate([cs]),
                     decoding_plugin=plugin,
@@ -455,7 +456,7 @@ class TestJ2KLosslessEncoding:
                 assert np.array_equal(out, ref)
 
     def test_arr_i4_spp1(self):
-        """Test signed bits allocated 8, bits stored (1, 24), samples per pixel 1"""
+        """Test signed bits allocated 32, bits stored (1, 24), samples per pixel 1"""
         ds = examples.ct
         opts = {
             "rows": ds.Rows,

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -2918,6 +2918,7 @@ class TestConvertRLEEndianness:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
         encoded = _encode_rle_frame(ds.PixelData, runner)
 
         # Only the header should be changed
@@ -2949,6 +2950,7 @@ class TestConvertRLEEndianness:
         }
         runner = EncodeRunner(RLELossless)
         runner.set_options(**kwargs)
+        runner._index = 0
         encoded = _encode_rle_frame(ref.tobytes(), runner)
 
         # Original encoded lengths are 4454, 16840, 3600, 16840, 4428, 16840

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -548,9 +548,9 @@ class TestNumeric:
         assert ds_json["00091014"]["Value"] == [42]
         assert ds_json["00091015"]["Value"] == [3.14159265]
         assert ds_json["00091102"]["Value"] == [2]
-        assert not "Value" in ds_json["00091103"]
-        assert not "Value" in ds_json["00091104"]
-        assert not "Value" in ds_json["00091105"]
+        assert "Value" not in ds_json["00091103"]
+        assert "Value" not in ds_json["00091104"]
+        assert "Value" not in ds_json["00091105"]
 
     def test_numeric_types(self):
         ds = Dataset()


### PR DESCRIPTION
#### Describe the changes
* Adds the ability to set per-frame property values when encoding and decoding
  * Adds an `index` parameter to various runner methods
  * Adds the `RunnerBase.get_frame_option()` and `RunnerBase.set_frame_option()` methods
  * Adds `RunnerBase.index` property
  * Adds `DecodeRunner.frame_dtype()`
  * Deprecates the `as_frame` parameter for `DecodeRunner.pixel_properties` and `DecodeRunner.reshape()`
  * Changes the returned metadata `dict` for Decoder.as_buffer to return the data for individual frames
* Changes the `is_bitpacked` runner option to use a per-frame level `bits_allocated` option instead
* Use Pillow's native RGB conversion instead of `convert_color_space()` when it makes sense to do so (closes #2228)
* Adds parsing of the Adobe APP14 marker to help determine the colour space of JPEG images


#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
- [ ] Unit tests passing and overall coverage the same or better
