### PR TITLE
Fix sometimes including unused high bits when decoding J2K and JLS

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -41,10 +41,12 @@ Fixes
 * Correctly handle empty values represented as empty strings in json while converting them
   to a dataset (:issue:`2221`).
 * Correctly handle empty LUT data (:issue:`2238`).
+* Fixed data in the "unused" bits above *Bits Stored* being included in the return pixel
+  data for JPEG 2000 and JPEG-LS (:issue:`2260`).
 
 Enhancements
 ------------
-* Python 3.12 and 3.13 now supported; limited support for pre-release Python 3.14
+* Python 3.12, 3.13 and 3.14 are now supported.
 * Added the option to pass a ``bool`` ndarray to :func:`~pydicom.pixels.set_pixel_data`
   to store with *Bits Allocated* of ``1`` using bit-packing (:issue:`2141`).
 * Added a check to :meth:`~pydicom.dataset.Dataset.set_pixel_data` to ensure that the

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -41,8 +41,8 @@ Fixes
 * Correctly handle empty values represented as empty strings in json while converting them
   to a dataset (:issue:`2221`).
 * Correctly handle empty LUT data (:issue:`2238`).
-* Fixed data in the "unused" bits above *Bits Stored* being included in the return pixel
-  data for JPEG 2000 and JPEG-LS (:issue:`2260`).
+* Fixed data in the "unused" bits above *Bits Stored* sometimes being included in the returned
+  pixel data for JPEG 2000 and JPEG-LS (:issue:`2260`).
 
 Enhancements
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Scientific/Engineering :: Physics",

--- a/tests/pixels/pixels_reference.py
+++ b/tests/pixels/pixels_reference.py
@@ -1927,7 +1927,7 @@ def test(ref, arr, **kwargs):
     assert np.array_equal(arr, ref)
 
 
-JLSL_16_12_1_1_10F = PixelReference("emri_small_jpeg_ls_lossless.dcm", "<u2", test)
+JLSL_16_12_1_0_10F = PixelReference("emri_small_jpeg_ls_lossless.dcm", "<u2", test)
 
 
 # JLSN, (8, 8), (1, 45, 10, 1), OB, MONOCHROME2, 0
@@ -2019,7 +2019,7 @@ PIXEL_REFERENCE[JPEGLSLossless] = [
     JLSL_08_07_1_0_1F,
     JLSL_16_15_1_1_1F,
     JLSL_16_16_1_1_1F,
-    JLSL_16_12_1_1_10F,
+    JLSL_16_12_1_0_10F,
 ]
 PIXEL_REFERENCE[JPEGLSNearLossless] = [
     JLSN_08_01_1_0_1F,

--- a/tests/pixels/test_decoder_pylibjpeg.py
+++ b/tests/pixels/test_decoder_pylibjpeg.py
@@ -46,6 +46,7 @@ from .pixels_reference import (
     JLSL_16_12_1_1_10F,
     JPGB_08_08_3_0_120F_YBR_FULL_422,
     RLE_1_1_3F,
+    EXPL_16_1_10F,
 )
 
 
@@ -290,11 +291,16 @@ class TestLibJpegDecoder:
         arr, _ = next(iterator)
         assert [192, 53, 106, 219, 135] == arr[-1, -5:].tolist()
 
+    def test_jls_sign_correction_iter(self):
+        """Test the JLS sign correction works with iter_array(..., indices=[...])"""
+        reference = JLSL_16_12_1_1_10F
+        decoder = get_decoder(JPEGLSLossless)
         iterator = decoder.iter_array(
-            ds, indices=[0, 1, 2], decoding_plugin="pylibjpeg"
+            reference.ds, indices=[0, 1, 2], decoding_plugin="pylibjpeg"
         )
+
         arr, _ = next(iterator)
-        assert [192, 53, 106, 219, 135] == arr[-1, -5:].tolist()
+        assert np.array_equal(arr, EXPL_16_1_10F.ds.pixel_array[0])
 
 
 @pytest.mark.skipif(SKIP_OJ, reason="Test is missing dependencies")

--- a/tests/pixels/test_decoder_pylibjpeg.py
+++ b/tests/pixels/test_decoder_pylibjpeg.py
@@ -290,6 +290,12 @@ class TestLibJpegDecoder:
         arr, _ = next(iterator)
         assert [192, 53, 106, 219, 135] == arr[-1, -5:].tolist()
 
+        iterator = decoder.iter_array(
+            ds, indices=[0, 1, 2], decoding_plugin="pylibjpeg"
+        )
+        arr, _ = next(iterator)
+        assert [192, 53, 106, 219, 135] == arr[-1, -5:].tolist()
+
 
 @pytest.mark.skipif(SKIP_OJ, reason="Test is missing dependencies")
 class TestOpenJpegDecoder:
@@ -473,8 +479,16 @@ class TestOpenJpegDecoder:
 
         iterator = decoder.iter_array(ds, decoding_plugin="pylibjpeg")
         arr, _ = next(iterator)
-        assert arr.dtype.kind == "u"
-        assert arr.dtype.itemsize == 2
+        assert 2096 == arr[0, 0]
+        assert [621, 412, 138, 3903, 3576, 3329, 3189, 3130, 3108, 3101] == (
+            arr[47:57, 279].tolist()
+        )
+        assert [3719, 3975, 141, 383, 633, 910, 1198, 1455, 1638, 1732] == (
+            arr[328:338, 106].tolist()
+        )
+
+        iterator = decoder.iter_array(ds, indices=[0], decoding_plugin="pylibjpeg")
+        arr, _ = next(iterator)
         assert 2096 == arr[0, 0]
         assert [621, 412, 138, 3903, 3576, 3329, 3189, 3130, 3108, 3101] == (
             arr[47:57, 279].tolist()

--- a/tests/pixels/test_decoder_pylibjpeg.py
+++ b/tests/pixels/test_decoder_pylibjpeg.py
@@ -43,6 +43,7 @@ from .pixels_reference import (
     JPGB_08_08_3_0_1F_YBR_FULL,  # has JFIF APP marker
     JLSL_08_07_1_0_1F,
     JLSL_16_15_1_1_1F,
+    JLSL_16_12_1_1_10F,
     JPGB_08_08_3_0_120F_YBR_FULL_422,
     RLE_1_1_3F,
 )
@@ -273,6 +274,22 @@ class TestLibJpegDecoder:
         for _, meta in decoder.iter_array(ds, decoding_plugin="pylibjpeg"):
             assert meta["planar_configuration"] == 0
 
+    def test_jls_shift_correction(self):
+        """Regression test for #2260"""
+        reference = JLSL_16_12_1_1_10F
+        ds = dcmread(reference.path)
+        ds.BitsStored = 8
+        ds.PixelRepresentation = 0
+        decoder = get_decoder(JPEGLSLossless)
+
+        arr, _ = decoder.as_array(ds, raw=True, decoding_plugin="pylibjpeg")
+        # Would be [192 309 362 219 135] if no shift
+        assert [192, 53, 106, 219, 135] == arr[0, -1, -5:].tolist()
+
+        iterator = decoder.iter_array(ds, decoding_plugin="pylibjpeg")
+        arr, _ = next(iterator)
+        assert [192, 53, 106, 219, 135] == arr[-1, -5:].tolist()
+
 
 @pytest.mark.skipif(SKIP_OJ, reason="Test is missing dependencies")
 class TestOpenJpegDecoder:
@@ -432,6 +449,39 @@ class TestOpenJpegDecoder:
         )
         assert len(buffer) == (2 * 512 * 512) // 8
         assert len(meta) == 2
+
+    def test_j2k_shift_correction(self):
+        """Regression test for #2260"""
+        reference = J2KR_16_13_1_1_1F_M2_MISMATCH
+        ds = dcmread(reference.path)
+        ds.PixelRepresentation = 0
+        ds.BitsStored = 12
+
+        decoder = get_decoder(JPEG2000Lossless)
+        arr, _ = decoder.as_array(ds, index=0, decoding_plugin="pylibjpeg")
+        assert arr.dtype.kind == "u"
+        assert arr.dtype.itemsize == 2
+
+        # Without a shift this would be 6192
+        assert 2096 == arr[0, 0]
+        assert [621, 412, 138, 3903, 3576, 3329, 3189, 3130, 3108, 3101] == (
+            arr[47:57, 279].tolist()
+        )
+        assert [3719, 3975, 141, 383, 633, 910, 1198, 1455, 1638, 1732] == (
+            arr[328:338, 106].tolist()
+        )
+
+        iterator = decoder.iter_array(ds, decoding_plugin="pylibjpeg")
+        arr, _ = next(iterator)
+        assert arr.dtype.kind == "u"
+        assert arr.dtype.itemsize == 2
+        assert 2096 == arr[0, 0]
+        assert [621, 412, 138, 3903, 3576, 3329, 3189, 3130, 3108, 3101] == (
+            arr[47:57, 279].tolist()
+        )
+        assert [3719, 3975, 141, 383, 633, 910, 1198, 1455, 1638, 1732] == (
+            arr[328:338, 106].tolist()
+        )
 
 
 @pytest.mark.skipif(SKIP_RLE, reason="Test is missing dependencies")

--- a/tests/pixels/test_decoder_pylibjpeg.py
+++ b/tests/pixels/test_decoder_pylibjpeg.py
@@ -43,7 +43,7 @@ from .pixels_reference import (
     JPGB_08_08_3_0_1F_YBR_FULL,  # has JFIF APP marker
     JLSL_08_07_1_0_1F,
     JLSL_16_15_1_1_1F,
-    JLSL_16_12_1_1_10F,
+    JLSL_16_12_1_0_10F,
     JPGB_08_08_3_0_120F_YBR_FULL_422,
     RLE_1_1_3F,
     EXPL_16_1_10F,
@@ -277,10 +277,10 @@ class TestLibJpegDecoder:
 
     def test_jls_shift_correction(self):
         """Regression test for #2260"""
-        reference = JLSL_16_12_1_1_10F
+        reference = JLSL_16_12_1_0_10F
         ds = dcmread(reference.path)
         ds.BitsStored = 8
-        ds.PixelRepresentation = 0
+        assert reference.ds.PixelRepresentation == 0
         decoder = get_decoder(JPEGLSLossless)
 
         arr, _ = decoder.as_array(ds, raw=True, decoding_plugin="pylibjpeg")
@@ -293,14 +293,15 @@ class TestLibJpegDecoder:
 
     def test_jls_sign_correction_iter(self):
         """Test the JLS sign correction works with iter_array(..., indices=[...])"""
-        reference = JLSL_16_12_1_1_10F
+        reference = JLSL_16_15_1_1_1F
+        assert reference.ds.PixelRepresentation == 1
         decoder = get_decoder(JPEGLSLossless)
         iterator = decoder.iter_array(
-            reference.ds, indices=[0, 1, 2], decoding_plugin="pylibjpeg"
+            reference.ds, indices=[0], decoding_plugin="pylibjpeg"
         )
 
         arr, _ = next(iterator)
-        assert np.array_equal(arr, EXPL_16_1_10F.ds.pixel_array[0])
+        reference.test(arr)
 
 
 @pytest.mark.skipif(SKIP_OJ, reason="Test is missing dependencies")

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -41,7 +41,7 @@ class TestBaseTag:
         """Test __le__ raises TypeError when comparing to non numeric."""
 
         def test_raise():
-            BaseTag(0x00010002) <= "Somethin"
+            BaseTag(0x00010002) <= "Something"
 
         pytest.raises(TypeError, test_raise)
 
@@ -77,7 +77,7 @@ class TestBaseTag:
         """Test __lt__ raises TypeError when comparing to non numeric."""
 
         def test_raise():
-            BaseTag(0x00010002) < "Somethin"
+            BaseTag(0x00010002) < "Something"
 
         pytest.raises(TypeError, test_raise)
 


### PR DESCRIPTION
#### Describe the changes
* Fixes not performing bit shifting with J2K and JLS if no sign correction needed but a bit shift is
* Changes the bit shift amount with J2K and JLS to only use codestream precision when it's less than *Bits Stored* to prevent any data in the unused high bits being returned 
* Related to #2260

I still have to create a separate PR to address how to handle the "unused" high bits on the encoding side.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] [Documentation updated](https://output.circle-artifacts.com/output/job/8d2b4739-81a0-4df4-8b99-445e850a92bc/artifacts/0/doc/_build/html/index.html)
- [x] Unit tests passing and overall coverage the same or better
