### PR TITLE
[MRG] feat: implement case insensitive matching in tag_for_keyword()

### DIFF
--- a/src/pydicom/datadict.py
+++ b/src/pydicom/datadict.py
@@ -8,6 +8,7 @@ from pydicom.misc import warn_and_log
 from pydicom._private_dict import private_dictionaries
 from pydicom.tag import Tag, BaseTag, TagType
 
+from pydicom.util.collections import CaseInsensitiveDict
 
 # Generate mask dict for checking repeating groups etc.
 # Map a true bitwise mask to the DICOM mask with "x"'s in it.
@@ -455,7 +456,9 @@ def keyword_for_tag(tag: TagType) -> str:
 
 
 # Provide for the 'reverse' lookup. Given the keyword, what is the tag?
-keyword_dict: dict[str, int] = {dictionary_keyword(tag): tag for tag in DicomDictionary}
+keyword_dict: CaseInsensitiveDict = CaseInsensitiveDict(
+    {dictionary_keyword(tag): tag for tag in DicomDictionary}
+)
 
 
 def tag_for_keyword(keyword: str) -> int | None:
@@ -474,7 +477,8 @@ def tag_for_keyword(keyword: str) -> int | None:
         If the element is in the DICOM data dictionary then returns the
         corresponding element's tag, otherwise returns ``None``.
     """
-    return keyword_dict.get(keyword)
+    value = keyword_dict.get(keyword)
+    return value if isinstance(value, int) else None
 
 
 def repeater_has_tag(tag: int) -> bool:

--- a/src/pydicom/util/collections.py
+++ b/src/pydicom/util/collections.py
@@ -1,0 +1,45 @@
+from collections import UserDict
+from typing import Any
+from collections.abc import Mapping, Iterable
+
+
+class CaseInsensitiveDict(UserDict):
+    def __init__(self, data: Mapping[str, Any] | None = None, **kwargs: Any) -> None:
+        super().__init__()
+        if data:
+            self.update(data)
+        if kwargs:
+            self.update(kwargs)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        super().__setitem__(key.lower(), value)
+
+    def __getitem__(self, key: str) -> Any:
+        return super().__getitem__(key.lower())
+
+    def __delitem__(self, key: str) -> None:
+        super().__delitem__(key.lower())
+
+    def __contains__(self, key: object) -> bool:
+        if isinstance(key, str):
+            return super().__contains__(key.lower())
+        return super().__contains__(key)
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        return super().get(key.lower(), default)
+
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        """
+        Update the dictionary with the key/value pairs from other, overwriting existing keys.
+        Accepts mappings, iterables of key-value pairs, and keyword arguments.
+        """
+        if args:
+            other = args[0]
+            if isinstance(other, Mapping):
+                for k, v in other.items():
+                    self[k] = v
+            elif isinstance(other, Iterable):
+                for k, v in other:
+                    self[k] = v
+        for k, v in kwargs.items():
+            self[k] = v

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -18,6 +18,7 @@ from pydicom.datadict import (
     add_private_dict_entries,
     add_private_dict_entry,
     _dictionary_vr_fast,
+    tag_for_keyword,
 )
 from pydicom.datadict import add_dict_entry, add_dict_entries
 from .test_util import save_private_dict
@@ -183,3 +184,8 @@ class TestDict:
         msg = r"Tag \(50F1,0010\) not found in DICOM dictionary"
         with pytest.raises(KeyError, match=msg):
             _dictionary_vr_fast(0x50F10010)
+
+    def test_tag_for_keyword_case_insensitive(self):
+        assert tag_for_keyword("PatientID") == 0x00100020
+        assert tag_for_keyword("patientid") == 0x00100020
+        assert tag_for_keyword("PATIENTID") == 0x00100020


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in progress and change
to [MRG] when you consider them ready for final review.
-->

#### Describe the changes
Make `tag_for_keyword` lookups case insensitive

I would like this feature implemented as I have command line tools that consume dicom tags from the command line and this way users don't have to worry about the exact casing of keywords to match from the dictionary.

I could implement this as a wrapper in my code, but thought it would be beneficial to others as an addition to the core of pydicom as well.

#### Tasks
- [X] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [X] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [X] Unit tests passing and overall coverage the same or better
