### PR TITLE
Silence typos error

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -10,7 +10,8 @@ observ = "observ"
 
 [default]
 extend-ignore-re = [
-    "np\\.\\w"
+    "np\\.\\w",
+    "`eval`uable"
 ]
 
 [files]


### PR DESCRIPTION
- let it ignore `eval`uable

For some reason, this popped up now with the same version of "typos".

#### Tasks
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
