### PR TITLE
Fix decoder behavior and tests

### DIFF
--- a/src/pydicom/pixels/decoders/base.py
+++ b/src/pydicom/pixels/decoders/base.py
@@ -516,6 +516,20 @@ class DecodeRunner(RunnerBase):
                 )
                 return
 
+        # If no RGB indicators (component IDs or APP markers) were found then
+        #   default JPEG Baseline multi-sample images to YCbCr 4:2:2 and others
+        #   to YCbCr full range. This covers the common case where the dataset's
+        #   Photometric Interpretation was incorrectly set to RGB while the
+        #   codestream is actually YCbCr.
+        if self.transfer_syntax == JPEGBaseline8Bit and "YBR" not in pi:
+            self.set_frame_option(index, "photometric_interpretation", PI.YBR_FULL_422)
+            warn_and_log(
+                f"The (0028,0004) 'Photometric Interpretation' value is '{pi}' "
+                f"however the JPEG Baseline codestream for frame {index} has no RGB "
+                f"indicators; defaulting to 'YBR_FULL_422' per JPEG conventions"
+            )
+            return
+
     def decode(self, index: int) -> bytes | bytearray:
         """Decode the frame of pixel data at `index`.
 

--- a/src/pydicom/pixels/decoders/pillow.py
+++ b/src/pydicom/pixels/decoders/pillow.py
@@ -84,6 +84,20 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytes:
                 else:
                     # Use Image.draft() to signal no color transformation
                     image.draft("YCbCr", image.size)  # type: ignore[no-untyped-call]
+                    # Ensure per-frame PI matches the returned samples
+                    # JPEG Baseline typically implies YCbCr 4:2:2
+                    if tsyntax == uid.JPEGBaseline8Bit:
+                        runner.set_frame_option(
+                            runner.index,
+                            "photometric_interpretation",
+                            PI.YBR_FULL_422,
+                        )
+                    else:
+                        runner.set_frame_option(
+                            runner.index,
+                            "photometric_interpretation",
+                            PI.YBR_FULL,
+                        )
             elif image.info["adobe_transform"] == 1:  # 0: RGB, 1: YCbCr
                 # If the Adobe APP14 marker is present then Pillow uses the value to
                 #   determine the color space and defaults to returning RGB
@@ -93,6 +107,19 @@ def _decode_frame(src: bytes, runner: DecodeRunner) -> bytes:
                     )
                 elif "YBR" in cs:
                     image.draft("YCbCr", image.size)  # type: ignore[no-untyped-call]
+                    # Match frame PI to returned YCbCr samples
+                    if tsyntax == uid.JPEGBaseline8Bit:
+                        runner.set_frame_option(
+                            runner.index,
+                            "photometric_interpretation",
+                            PI.YBR_FULL_422,
+                        )
+                    else:
+                        runner.set_frame_option(
+                            runner.index,
+                            "photometric_interpretation",
+                            PI.YBR_FULL,
+                        )
 
         return cast(bytes, image.tobytes())
 


### PR DESCRIPTION
This pull request improves the handling of JPEG Baseline images in cases where the DICOM dataset's Photometric Interpretation (PI) is incorrectly set to RGB but the JPEG codestream is actually YCbCr, which is a common real-world issue. The changes ensure that, when no explicit RGB indicators or APP markers are found, the decoder defaults to the appropriate YCbCr interpretation and updates the per-frame PI accordingly. Additionally, a new test is added to verify this behavior.

**JPEG Baseline color space handling improvements:**

* In `_conform_jpg_colorspace` (`base.py`), added logic to default the per-frame photometric interpretation to `YBR_FULL_422` for JPEG Baseline images with no RGB indicators, and to log a warning when this occurs. This addresses cases where the DICOM PI is incorrectly set to RGB but the codestream is YCbCr.
* In `_decode_frame` (`pillow.py`), updated the decoder to set the per-frame photometric interpretation to `YBR_FULL_422` for JPEG Baseline images and `YBR_FULL` for others when no color transformation is indicated, ensuring consistency with the actual returned samples. [[1]](diffhunk://#diff-a6e099fedfaeb88af344c220185c7185e893fb4a1c09b9f760e6fe30035ee224R87-R100) [[2]](diffhunk://#diff-a6e099fedfaeb88af344c220185c7185e893fb4a1c09b9f760e6fe30035ee224R110-R122)

**Testing enhancements:**

* Added a new test (`test_decoder_pillow.py`) to verify that when no APP markers are present and the dataset PI is RGB, the decoder defaults to `YBR_FULL_422` for raw decode and correctly converts to RGB for non-raw decode. This test simulates a common real-world scenario and validates both metadata and pixel data conversion.
