### PR TITLE
Account for changed zlib algorithm in tests

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -30,7 +30,7 @@ jobs:
             test-numpy: true
             test-extras: true
             upload-coverage: false
-          - os: ubuntu
+          - os: windows
             python-version: "3.14"
             test-numpy: true
             test-extras: true

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -25,7 +25,7 @@ jobs:
             test-numpy: true
             test-extras: true
             upload-coverage: true
-          - os: windows
+          - os: ubuntu
             python-version: "3.14"
             test-numpy: true
             test-extras: true

--- a/tests/pixels/test_utils.py
+++ b/tests/pixels/test_utils.py
@@ -2,6 +2,7 @@
 """Tests for the pixels.utils module."""
 
 import importlib
+import sys
 from io import BytesIO
 import logging
 import os
@@ -2014,7 +2015,11 @@ class TestCompressDeflated:
 
         assert ds.SamplesPerPixel == 1
         assert ds.file_meta.TransferSyntaxUID == DeflatedImageFrameCompression
-        assert len(ds.PixelData) == 22288
+        assert (
+            len(ds.PixelData) == 22288
+            if sys.version_info < (3, 14) or sys.platform != "win32"
+            else 22640
+        )
         assert "PlanarConfiguration" not in ds
         assert ds["PixelData"].is_undefined_length
         assert ds["PixelData"].VR == "OB"
@@ -2025,8 +2030,14 @@ class TestCompressDeflated:
     @pytest.mark.parametrize(
         "path,length",
         [
-            (EXPL_1_1_3F.path, 2920),
-            (EXPL_1_1_3F_NONALIGNED.path, 3386),
+            (
+                EXPL_1_1_3F.path,
+                2920 if sys.version_info < (3, 14) or sys.platform != "win32" else 2558,
+            ),
+            (
+                EXPL_1_1_3F_NONALIGNED.path,
+                3386 if sys.version_info < (3, 14) or sys.platform != "win32" else 3052,
+            ),
         ],
     )
     def test_compress_bytes_1bit(self, path, length):


### PR DESCRIPTION
- in Python 3.14, zlib under Windows switched to use zlib-ng

Should fix the failing tests from the previous PR.
From the [Python documentation for 3.14](https://docs.python.org/3.14/whatsnew/3.14.html#zlib):
> On Windows, [zlib-ng](https://github.com/zlib-ng/zlib-ng) is now used as the implementation of the [zlib](https://docs.python.org/3.14/library/zlib.html#module-zlib) module in the default binaries. There are no known incompatibilities between zlib-ng and the previously-used zlib implementation. This should result in better performance at all compression levels.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working - n/a
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
