### PR TITLE
Remove black from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,15 +23,11 @@ repos:
       - id: typos
         exclude: _.*_dict.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.14.14
     hooks:
       - id: ruff-check
         files: src
         args: [--fix, --show-fixes, --exit-non-zero-on-fix]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.12.0
-    hooks:
-      - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.19.1
     hooks:


### PR DESCRIPTION
- avoids conflicts between black and ruff
- ruff does almost the same as black and is much faster

See [my comment](https://github.com/pydicom/pydicom/pull/2289#discussion_r2755783840).
