### PR TITLE
Make debugging filereader.read_dataset more robust

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -44,6 +44,7 @@ Fixes
 * Fixed data in the "unused" bits above *Bits Stored* sometimes being included in the returned
   pixel data for JPEG 2000 and JPEG-LS (:issue:`2260`).
 * Correctly handle meta data tags incorrectly written in implicit transfer syntax (:issue:`2290`)
+* Made debugging of :func:`~pydicom.filereader.read_dataset` a bit more robust (:pr:`2292`).
 
 Enhancements
 ------------

--- a/src/pydicom/filereader.py
+++ b/src/pydicom/filereader.py
@@ -492,18 +492,18 @@ def read_dataset(
     except NotImplementedError as details:
         logger.error(details)
 
-    ds = Dataset(raw_data_elements, parent_encoding=parent_encoding)
-
     encoding: str | MutableSequence[str]
     if 0x00080005 in raw_data_elements:
-        elem = cast(RawDataElement, raw_data_elements[BaseTag(0x00080005)])
-        char_set = cast(
-            str | MutableSequence[str] | None, convert_raw_data_element(elem).value
-        )
+        raw_elem = cast(RawDataElement, raw_data_elements[BaseTag(0x00080005)])
+        elem = convert_raw_data_element(raw_elem)
+        char_set = cast(str | MutableSequence[str] | None, elem.value)
+        # avoid converting the raw data element again
+        raw_data_elements[BaseTag(0x00080005)] = elem
         encoding = convert_encodings(char_set)  # -> List[str]
     else:
         encoding = parent_encoding  # -> str | MutableSequence[str]
 
+    ds = Dataset(raw_data_elements, parent_encoding=parent_encoding)
     ds.set_original_encoding(is_implicit_VR, is_little_endian, encoding)
     return ds
 


### PR DESCRIPTION
- moved creation of dataset after the conversion of SpecificCharacterSet
- avoids problems if breaking after dataset creation

Minor change to avoid problem during debugging - I didn't add a test as I have no idea how to test this.
Ran into this during debugging. Because dataset display in the debugger explicitly converts raw data elements into data elements (via `__repr__`), setting a breakpoint at that location broke the following code that assumed the element to be a raw data element and created an exception.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working n/a
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
