### PR TITLE
Set VR for meta tags incorrectly written in implicit syntax

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -43,6 +43,7 @@ Fixes
 * Correctly handle empty LUT data (:issue:`2238`).
 * Fixed data in the "unused" bits above *Bits Stored* sometimes being included in the returned
   pixel data for JPEG 2000 and JPEG-LS (:issue:`2260`).
+* Correctly handle meta data tags incorrectly written in implicit transfer syntax (:issue:`2290`)
 
 Enhancements
 ------------


### PR DESCRIPTION
- the tags are already handled, setting the VR makes it possible to write them back correctly
- closes #2290

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
