### PR TITLE
Handle comparison of elements with NaN value

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -46,6 +46,8 @@ Fixes
 * Correctly handle meta data tags incorrectly written in implicit transfer syntax (:issue:`2290`)
 * Made debugging of :func:`~pydicom.filereader.read_dataset` a bit more robust (:pr:`2292`).
 * Fixed deepcopy of private blocks in :class:`~pydicom.dataset.Dataset` (:issue:`2294`)
+* Make float data elements with `NaN` value compare as equal - this is semantically better suited
+  then the mathematical comparison, where `NaN != NaN` (:issue:`2273`)
 
 Enhancements
 ------------

--- a/src/pydicom/dataelem.py
+++ b/src/pydicom/dataelem.py
@@ -8,6 +8,7 @@ A DataElement has a tag,
 """
 
 import base64
+import math
 from collections.abc import Callable, MutableSequence
 import copy
 from io import BufferedIOBase
@@ -691,6 +692,8 @@ class DataElement:  # noqa: PLW1641
                 )
 
             if not self.is_buffered and not other.is_buffered:
+                if isinstance(self.value, float) and math.isnan(self.value):
+                    return other.value is not None and math.isnan(other.value)
                 return self.value == other.value
 
             try:

--- a/src/pydicom/valuerep.py
+++ b/src/pydicom/valuerep.py
@@ -2,6 +2,7 @@
 """Special classes for DICOM value representations (VR)"""
 
 import datetime
+import math
 from decimal import Decimal
 from enum import Enum, unique
 import re
@@ -1091,6 +1092,8 @@ class DSfloat(float):
         """Override to allow string equality comparisons."""
         if isinstance(other, str):
             return str(self) == other
+        if isinstance(other, float) and math.isnan(other):
+            return math.isnan(self)
 
         return super().__eq__(other)
 

--- a/tests/test_dataelem.py
+++ b/tests/test_dataelem.py
@@ -129,6 +129,21 @@ class TestDataElement:
         assert math.pi == data_element.value
         assert "3.14159265358979" == str(data_element.value)
 
+    def test_comparison_with_nan(self):
+        nan_value = float("nan")
+        data_element1 = DataElement((1, 2), "FL", nan_value)
+        data_element2 = DataElement((1, 2), "FL", nan_value)
+        assert data_element1 == data_element2
+
+        data_element2 = DataElement((1, 2), "FL", 1.3)
+        assert data_element1 != data_element2
+        data_element2 = DataElement((1, 2), "FL", None)
+        assert data_element1 != data_element2
+
+        data_element1 = DataElement((1, 2), "FL", (nan_value, 1.3, 3.6))
+        data_element2 = DataElement((1, 2), "FL", (nan_value, 1.3, 3.6))
+        assert data_element1 == data_element2
+
     def test_backslash(self):
         """DataElement: String with '\\' sets multi-valued data_element."""
         data_element = DataElement((1, 2), "DS", r"42.1\42.2\42.3")

--- a/tests/test_valuerep.py
+++ b/tests/test_valuerep.py
@@ -18,6 +18,7 @@ from pydicom.data import get_testdata_file
 from pydicom.dataset import Dataset
 from pydicom._dicom_dict import DicomDictionary, RepeatersDictionary
 from pydicom.filereader import read_dataset
+from pydicom.multival import MultiValue
 from pydicom.tag import Tag
 from pydicom.valuerep import (
     DS,
@@ -683,6 +684,17 @@ class TestDSfloat:
         """Test hash(DSfloat)"""
         assert hash(DSfloat(1.2345)) == hash(1.2345)
         assert hash(DSfloat("1.2345")) == hash(1.2345)
+
+    def test_comparison_with_nan(self):
+        nan_value = DSfloat("nan")
+        assert nan_value == DSfloat("nan")
+        assert nan_value == math.nan
+        assert nan_value != 1234.5
+        assert nan_value != "1234.5"
+
+        values_with_nan1 = MultiValue(DSfloat, [10.5, nan_value])
+        values_with_nan2 = MultiValue(DSfloat, [10.5, nan_value])
+        assert values_with_nan1 == values_with_nan2
 
 
 class TestDSdecimal:


### PR DESCRIPTION
- two elements with value NaN shall compare as equal
- fixes #2273

As discussed in the issue, two data elements with value `NaN` shall be compared as equal. This makes semantically more sense than the mathematical case, where `NaN != NaN`.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Unit tests passing and overall coverage the same or better
