### PR TITLE
src directory doesn't need to be specified anymore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ force-exclude = ".venv|/_.*_dict.py$"  # to not do files pre-commit asks for
 
 
 [tool.ruff]
-src = ["src"]
 line-length = 214
 include = ["src/*.py", "tests/*.py", "doc/*.py"]
 


### PR DESCRIPTION
#### Describe the changes

Addresses a [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=pydicom%2Fpydicom&ref=HEAD&refType=branch) issue.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
