### PR TITLE
Avoid warning when running pre-commit locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.44.0
     hooks:
       - id: typos
         exclude: _.*_dict.py


### PR DESCRIPTION
#### Describe the changes

Avoids this warning:
> [WARNING] The 'rev' field of repo 'https://github.com/crate-ci/typos' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported. See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.


#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [ ] Unit tests passing and overall coverage the same or better
