### PR TITLE
Disable failing test under PyPy

### DIFF
--- a/tests/test_fileset.py
+++ b/tests/test_fileset.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 from pathlib import Path
 import shutil
@@ -2576,6 +2577,8 @@ class TestFileSet_Copy:
     def teardown_method(self):
         FileSet.__len__ = self.orig
 
+    @pytest.mark.skipif(platform.python_implementation() == "PyPy",
+                        reason="pyfakefs does not work with generate_uid() in PyPy")
     def test_constrained_to_fileset_root(self, fileset_fs):
         """Ensure files cannot be copied outside the FileSet root"""
         with pytest.raises(


### PR DESCRIPTION
- _urandom (used in generate_uid) does not work with pyfakefs in PyPy

This may be fixed in `pyfakefs` in a later version.
