### PR TITLE
Reduce peak memory usage in `apply_windowing`

### DIFF
--- a/src/pydicom/pixels/processing.py
+++ b/src/pydicom/pixels/processing.py
@@ -799,14 +799,13 @@ def apply_windowing(arr: "np.ndarray", ds: "Dataset", index: int = 0) -> "np.nda
                 "for a 'LINEAR_EXACT' windowing operation"
             )
 
-        below = arr <= (center - width / 2)
-        above = arr > (center + width / 2)
-        between = np.logical_and(~below, ~above)
+        arr -= center
+        arr /= width
+        arr += 0.5
+        arr *= y_range
+        arr += y_min
 
-        arr[below] = y_min
-        arr[above] = y_max
-        if between.any():
-            arr[between] = ((arr[between] - center) / width + 0.5) * y_range + y_min
+        np.clip(arr, y_min, y_max, out=arr)
     elif voi_func == "SIGMOID":
         # PS3.3 C.11.2.1.3.1
         if width <= 0:
@@ -815,7 +814,12 @@ def apply_windowing(arr: "np.ndarray", ds: "Dataset", index: int = 0) -> "np.nda
                 "for a 'SIGMOID' windowing operation"
             )
 
-        arr = y_range / (1 + np.exp(-4 * (arr - center) / width)) + y_min
+        arr -= center
+        arr *= -4.0 / width
+        np.exp(arr, out=arr)
+        arr += 1.0
+        np.divide(y_range, arr, out=arr)
+        arr += y_min
     else:
         raise ValueError(f"Unsupported (0028,1056) VOI LUT Function value '{voi_func}'")
 


### PR DESCRIPTION
I noticed memory spikes when VOILUT attribute was present in dicom. After some research, I found that `apply_windowing` allocates three boolean arrays the size of the input during the LINEAR windowing operation, causing unnecessary peak memory spikes on large datasets.

Replaced the mask-based approach with in-place arithmetic and `np.clip(..., out=arr)`, which produces the same result without the extra allocations, reducing memory overhead by ~27%. This will work because the linear transform is monotonic, therefore values below the window will always transform to something ≤ y_min, values above will always transform to something ≥ y_max. So applying `np.clip` after the transformation produces exactly the same result as clamping them before.

The same in-place approach was applied to the SIGMOID branch - the original expression `y_range / (1 + np.exp(-4 * (arr - center) / width)) + y_min` was decomposed into sequence of in-place operations to avoid numpy creating temporary arrays.

Benchmarked on a 512x512x100 uint16 array - peak overhead dropped.

From:
```
arr size:  50.0 MB
peak:      325.0 MB
overhead:  275.0 MB
```
To:
```
arr size:  50.0 MB
peak:      250.0 MB
overhead:  200.0 MB
```

Testing script:
```
import tracemalloc
import numpy as np
import pydicom
from pydicom.dataset import Dataset, FileMetaDataset
from pydicom.uid import ExplicitVRLittleEndian
from pydicom.pixels.processing import apply_windowing

# mock dicom
ds = Dataset()
ds.file_meta = FileMetaDataset()
ds.file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
ds.PhotometricInterpretation = "MONOCHROME2"
ds.BitsStored = 16
ds.PixelRepresentation = 0
ds.WindowCenter = 40.0
ds.WindowWidth = 400.0

# simulation of CT series
arr = np.random.randint(0, 4096, (512, 512, 100), dtype=np.uint16)

# warmup, cause of numpy buffers / cache
apply_windowing(arr.copy(), ds)

tracemalloc.start()
apply_windowing(arr.copy(), ds)
current, peak = tracemalloc.get_traced_memory()
tracemalloc.stop()

print(f"arr size:  {arr.nbytes / 1024 / 1024:.1f} MB")
print(f"peak:      {peak / 1024 / 1024:.1f} MB")
print(f"overhead:  {(peak - arr.nbytes) / 1024 / 1024:.1f} MB")
```