### PR TITLE
Update pre-commit typos version to v1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.44.0
+    rev: v1
     hooks:
       - id: typos
         exclude: _.*_dict.py

--- a/_typos.toml
+++ b/_typos.toml
@@ -7,6 +7,7 @@ parm = "parm"
 universite = "universite"
 womens = "womens"
 observ = "observ"
+writeable = "writeable"
 
 [default]
 extend-ignore-re = [


### PR DESCRIPTION
- add "writeable" to typos dictionary (alternative spelling of writable, used in numpy)

The auto-update replaced all "writeable", breaking the code.

#### Tasks
- [x] Fix or feature added
