### PR TITLE
Handle 10-16 bit Modality LUT entries (#2317)

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -49,6 +49,9 @@ Fixes
 * Fixed deepcopy of private blocks in :class:`~pydicom.dataset.Dataset` (:issue:`2294`)
 * Make float data elements with `NaN` value compare as equal - this is semantically better suited
   then the mathematical comparison, where `NaN != NaN` (:issue:`2273`)
+* Fixed :func:`~pydicom.pixels.apply_modality_lut` raising for a *Modality LUT* with 10 to 16
+  bits per entry (such as 12-bit), now handled as 16-bit to match
+  :func:`~pydicom.pixels.apply_voi` (:issue:`2317`).
 
 Enhancements
 ------------

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -51,7 +51,8 @@ Fixes
   then the mathematical comparison, where `NaN != NaN` (:issue:`2273`)
 * Fixed :func:`~pydicom.pixels.apply_modality_lut` raising for a *Modality LUT* with 10 to 16
   bits per entry (such as 12-bit), now handled as 16-bit to match
-  :func:`~pydicom.pixels.apply_voi` (:issue:`2317`).
+  :func:`~pydicom.pixels.apply_voi`; a value other than 16 (invalid for the *Modality LUT*)
+  now warns instead (:issue:`2317`).
 
 Enhancements
 ------------

--- a/src/pydicom/pixels/processing.py
+++ b/src/pydicom/pixels/processing.py
@@ -385,6 +385,12 @@ def apply_modality_lut(arr: "np.ndarray", ds: "Dataset") -> "np.ndarray":
         # The third LUT Descriptor value (bits per entry) may be 8 or 10-16;
         # map 10-16 to 16-bit as apply_voi() does
         if nominal_depth in list(range(10, 17)):
+            if nominal_depth != 16:
+                # For the Modality LUT the third value shall be 16 (PS3.3 C.11.1.1)
+                warn_and_log(
+                    f"Invalid value '{nominal_depth}' for the third value of the "
+                    "Modality LUT Descriptor - assuming 16"
+                )
             dtype = "uint16"
         elif nominal_depth == 8:
             dtype = "uint8"

--- a/src/pydicom/pixels/processing.py
+++ b/src/pydicom/pixels/processing.py
@@ -382,7 +382,16 @@ def apply_modality_lut(arr: "np.ndarray", ds: "Dataset") -> "np.ndarray":
         first_map = cast(list[int], item.LUTDescriptor)[1]
         nominal_depth = cast(list[int], item.LUTDescriptor)[2]
 
-        dtype = f"uint{nominal_depth}"
+        # The third LUT Descriptor value (bits per entry) may be 8 or 10-16;
+        # map 10-16 to 16-bit as apply_voi() does
+        if nominal_depth in list(range(10, 17)):
+            dtype = "uint16"
+        elif nominal_depth == 8:
+            dtype = "uint8"
+        else:
+            raise NotImplementedError(
+                f"'{nominal_depth}' bits per LUT entry is not supported"
+            )
 
         # Ambiguous VR, US or OW
         unc_data: Iterable[int]

--- a/tests/pixels/test_processing.py
+++ b/tests/pixels/test_processing.py
@@ -416,6 +416,29 @@ class TestModalityLUT:
         assert 52428 == out[228, 385]
         assert 58974 == out[291, 385]
 
+    def test_lut_sequence_12_bit(self):
+        """Test a 12-bit LUT entry depth is handled as 16-bit (#2317)."""
+        # The third LUT Descriptor value (bits per entry) of 10-16 should be
+        # read as 16-bit; previously a value such as 12 raised because of the
+        # invalid "uint12" dtype
+        ds = dcmread(MOD_16_SEQ)
+        seq = ds.ModalityLUTSequence[0]
+        seq.LUTDescriptor = [4096, -2048, 12]
+
+        out = apply_modality_lut(ds.pixel_array, ds)
+        assert out.dtype == np.uint16
+        # LUTData is unchanged so the mapping matches the 16-bit case
+        assert [32759, 32759, 49147, 49147, 32759] == list(out[0, 50:55])
+
+    def test_lut_sequence_unsupported_depth_raises(self):
+        """Test an unsupported LUT entry bit depth raises (#2317)."""
+        ds = dcmread(MOD_16_SEQ)
+        seq = ds.ModalityLUTSequence[0]
+        seq.LUTDescriptor = [4096, -2048, 4]
+        msg = r"'4' bits per LUT entry is not supported"
+        with pytest.raises(NotImplementedError, match=msg):
+            apply_modality_lut(ds.pixel_array, ds)
+
     def test_lut_sequence_zero_entries(self):
         """Test that 0 entries is interpreted correctly."""
         # LUTDescriptor[0] of 0 -> 65536, but only 4096 entries so any

--- a/tests/pixels/test_processing.py
+++ b/tests/pixels/test_processing.py
@@ -446,6 +446,20 @@ class TestModalityLUT:
         with pytest.raises(NotImplementedError, match=msg):
             apply_modality_lut(ds.pixel_array, ds)
 
+    def test_lut_sequence_8_bit(self):
+        """Test an 8-bit LUT entry depth is handled as 8-bit (#2317)."""
+        ds = dcmread(MOD_16_SEQ)
+        seq = ds.ModalityLUTSequence[0]
+        seq.LUTDescriptor = [4, 0, 8]
+        seq.LUTData = [0, 85, 170, 255]
+
+        # IVs below `first_map` (0) map to the first entry, IVs at or beyond
+        # the number of entries (4) map to the last entry
+        arr = np.asarray([-1, 0, 1, 2, 3, 9])
+        out = apply_modality_lut(arr, ds)
+        assert out.dtype == np.uint8
+        assert [0, 0, 85, 170, 255, 255] == list(out)
+
     def test_lut_sequence_zero_entries(self):
         """Test that 0 entries is interpreted correctly."""
         # LUTDescriptor[0] of 0 -> 65536, but only 4096 entries so any

--- a/tests/pixels/test_processing.py
+++ b/tests/pixels/test_processing.py
@@ -425,7 +425,14 @@ class TestModalityLUT:
         seq = ds.ModalityLUTSequence[0]
         seq.LUTDescriptor = [4096, -2048, 12]
 
-        out = apply_modality_lut(ds.pixel_array, ds)
+        # For the Modality LUT the third value shall be 16, so a non-16 value
+        # is invalid and warns while still being assumed to be 16-bit
+        msg = (
+            r"Invalid value '12' for the third value of the Modality LUT "
+            r"Descriptor - assuming 16"
+        )
+        with pytest.warns(UserWarning, match=msg):
+            out = apply_modality_lut(ds.pixel_array, ds)
         assert out.dtype == np.uint16
         # LUTData is unchanged so the mapping matches the 16-bit case
         assert [32759, 32759, 49147, 49147, 32759] == list(out[0, 50:55])


### PR DESCRIPTION
Closes #2317.

`apply_modality_lut` built the LUT dtype as `f"uint{nominal_depth}"`, which raised (`uint12 not understood`) for any bits-per-entry other than 8 or 16. This maps 10 to 16 bits to 16-bit, matching what `apply_voi` already does, and raises `NotImplementedError` for anything else.

Added regression tests (12-bit handled, unsupported depth raises) and a release note. Verified against a synthetic 12-bit Modality LUT.
