### PR TITLE
fix: bound SQ nesting depth in dcmread to raise InvalidDicomError instead of RecursionError

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -49,6 +49,9 @@ Fixes
 * Fixed deepcopy of private blocks in :class:`~pydicom.dataset.Dataset` (:issue:`2294`)
 * Make float data elements with `NaN` value compare as equal - this is semantically better suited
   then the mathematical comparison, where `NaN != NaN` (:issue:`2273`)
+* Bound sequence nesting depth in :func:`~pydicom.filereader.dcmread` so adversarially-deep
+  ``SQ`` chains raise :class:`~pydicom.errors.InvalidDicomError` instead of ``RecursionError``
+  (:issue:`2330`).
 
 Enhancements
 ------------
@@ -82,3 +85,6 @@ Enhancements
   :func:`~pydicom.pixels.convert_color_space` where applicable (:issue:`2228`)
 * Take the color space information from an Adobe APP14 marker into account when decoding
   pixel data for JPEG transfer syntaxes.
+* Added :attr:`pydicom.config.Settings.max_sequence_depth` (default ``100``) to bound the
+  maximum sequence nesting depth allowed during reading. Exceeding the bound raises
+  :class:`~pydicom.errors.InvalidDicomError` instead of ``RecursionError`` (:issue:`2330`).

--- a/src/pydicom/config.py
+++ b/src/pydicom/config.py
@@ -254,6 +254,17 @@ class Settings:
         # Chunk size to use when reading from buffered DataElement values
         self._buffered_read_size = 8192
 
+        # Maximum allowed nesting depth for sequences during read. Exceeding
+        # this depth raises ``InvalidDicomError`` instead of the
+        # ``RecursionError`` that would otherwise come from exhausting Python's
+        # interpreter stack on adversarially-nested input. The default value
+        # (100) gives a comfortable margin below Python's default
+        # ``sys.recursionlimit`` of 1000 (pydicom's reader uses ~4 frames per
+        # nesting level plus generator/setup overhead, so the practical Python
+        # limit is around depth 240). Real-world DICOM Structured Reports
+        # rarely exceed 10-20 levels of nesting.
+        self._max_sequence_depth: int = 100
+
     @property
     def buffered_read_size(self) -> int:
         """Get or set the chunk size when reading from buffered
@@ -305,6 +316,35 @@ class Settings:
     @writing_validation_mode.setter
     def writing_validation_mode(self, value: int) -> None:
         self._writing_validation_mode = value
+
+    @property
+    def max_sequence_depth(self) -> int:
+        """Maximum allowed nesting depth for sequences during ``dcmread``.
+
+        Reading deeply-nested DICOM sequences recurses through the parser
+        in proportion to the nesting depth. On adversarial or truncated
+        input the recursion can exhaust Python's interpreter stack and
+        raise an unhelpful ``RecursionError``. When the parser is about
+        to descend past this depth, an :class:`~pydicom.errors.InvalidDicomError`
+        is raised instead, so consumers can distinguish "malformed input"
+        from "library bug".
+
+        Default: ``100``. Increase if you legitimately need to parse files
+        with more nesting (and have raised :func:`sys.setrecursionlimit`
+        accordingly). Note that pydicom's reader uses approximately 4 Python
+        stack frames per nesting level plus a small fixed overhead, so the
+        practical ceiling under the default ``sys.recursionlimit`` of 1000 is
+        around depth 240.
+
+        .. versionadded:: 3.1
+        """
+        return self._max_sequence_depth
+
+    @max_sequence_depth.setter
+    def max_sequence_depth(self, depth: int) -> None:
+        if depth <= 0:
+            raise ValueError("max_sequence_depth must be greater than 0")
+        self._max_sequence_depth = depth
 
     @property
     def infer_sq_for_un_vr(self) -> bool:

--- a/src/pydicom/filereader.py
+++ b/src/pydicom/filereader.py
@@ -56,6 +56,7 @@ def data_element_generator(
     defer_size: int | str | float | None = None,
     encoding: str | MutableSequence[str] = default_encoding,
     specific_tags: list[BaseTag | int] | None = None,
+    _depth: int = 0,
 ) -> Iterator[RawDataElement | DataElement]:
     """Create a generator to efficiently return the raw data elements.
 
@@ -306,7 +307,12 @@ def data_element_generator(
                     )
 
                 seq = read_sequence(
-                    fp, is_implicit_VR, is_little_endian, length, encoding
+                    fp,
+                    is_implicit_VR,
+                    is_little_endian,
+                    length,
+                    encoding,
+                    _depth=_depth,
                 )
                 if has_tag_set and tag not in tag_set:
                     continue
@@ -418,6 +424,7 @@ def read_dataset(
     parent_encoding: str | MutableSequence[str] = default_encoding,
     specific_tags: list[BaseTag | int] | None = None,
     at_top_level: bool = True,
+    _depth: int = 0,
 ) -> Dataset:
     """Return a :class:`~pydicom.dataset.Dataset` instance containing the next
     dataset in the file.
@@ -447,6 +454,11 @@ def read_dataset(
     at_top_level: bool
         If dataset is top level (not within a sequence).
         Used to turn off explicit VR heuristic within sequences
+    _depth : int
+        Internal: current sequence nesting depth. Bounded by
+        :attr:`pydicom.config.Settings.max_sequence_depth` to convert a
+        ``RecursionError`` on adversarial input into a clean
+        :class:`~pydicom.errors.InvalidDicomError`.
 
     Returns
     -------
@@ -474,6 +486,7 @@ def read_dataset(
         defer_size,
         parent_encoding,
         specific_tags,
+        _depth=_depth,
     )
     try:
         if bytelength is None:
@@ -516,6 +529,7 @@ def read_sequence(
     bytelength: int,
     encoding: str | MutableSequence[str],
     offset: int = 0,
+    _depth: int = 0,
 ) -> Sequence:
     """Read and return a :class:`~pydicom.sequence.Sequence` -- i.e. a
     :class:`list` of :class:`Datasets<pydicom.dataset.Dataset>`.
@@ -532,7 +546,7 @@ def read_sequence(
         while (not bytelength) or (fp_tell() - fpStart < bytelength):
             file_tell = fp_tell()
             dataset = read_sequence_item(
-                fp, is_implicit_VR, is_little_endian, encoding, offset
+                fp, is_implicit_VR, is_little_endian, encoding, offset, _depth
             )
             if dataset is None:  # None is returned if hit Sequence Delimiter
                 break
@@ -551,6 +565,7 @@ def read_sequence_item(
     is_little_endian: bool,
     encoding: str | MutableSequence[str],
     offset: int = 0,
+    _depth: int = 0,
 ) -> Dataset | None:
     """Read and return a single :class:`~pydicom.sequence.Sequence` item, i.e.
     a :class:`~pydicom.dataset.Dataset`.
@@ -589,6 +604,17 @@ def read_sequence_item(
                 "Found Item tag (start of item)"
             )
 
+    # Bound nesting depth before recursing into the contained dataset --
+    # otherwise an adversarially-deep SQ chain exhausts Python's stack and
+    # surfaces as RecursionError instead of a meaningful parse failure.
+    max_depth = config.settings.max_sequence_depth
+    if _depth + 1 > max_depth:
+        raise InvalidDicomError(
+            f"Sequence nesting depth ({_depth + 1}) exceeds the configured "
+            f"maximum ({max_depth}). Increase "
+            f"`pydicom.config.settings.max_sequence_depth` to read this file."
+        )
+
     if length == 0xFFFFFFFF:
         ds = read_dataset(
             fp,
@@ -597,6 +623,7 @@ def read_sequence_item(
             bytelength=None,
             parent_encoding=encoding,
             at_top_level=False,
+            _depth=_depth + 1,
         )
         ds.is_undefined_length_sequence_item = True
     else:
@@ -607,6 +634,7 @@ def read_sequence_item(
             length,
             parent_encoding=encoding,
             at_top_level=False,
+            _depth=_depth + 1,
         )
         ds.is_undefined_length_sequence_item = False
 

--- a/src/pydicom/filereader.py
+++ b/src/pydicom/filereader.py
@@ -423,7 +423,6 @@ def read_dataset(
     defer_size: str | int | float | None = None,
     parent_encoding: str | MutableSequence[str] = default_encoding,
     specific_tags: list[BaseTag | int] | None = None,
-    at_top_level: bool = True,
     _depth: int = 0,
 ) -> Dataset:
     """Return a :class:`~pydicom.dataset.Dataset` instance containing the next
@@ -451,13 +450,13 @@ def read_dataset(
         Character Set* isn't specified.
     specific_tags : list of BaseTag, optional
         See :func:`dcmread` for parameter info.
-    at_top_level: bool
-        If dataset is top level (not within a sequence).
-        Used to turn off explicit VR heuristic within sequences
     _depth : int
-        Internal: current sequence nesting depth. Bounded by
-        :attr:`pydicom.config.Settings.max_sequence_depth` to convert a
-        ``RecursionError`` on adversarial input into a clean
+        Internal: current sequence nesting depth. ``0`` at the top level;
+        incremented by :func:`read_sequence_item` before recursing. Used both
+        to disable the explicit-VR heuristic inside sequences (only top-level
+        datasets get the heuristic) and to bound nesting via
+        :attr:`pydicom.config.Settings.max_sequence_depth`, converting
+        ``RecursionError`` on adversarial input into
         :class:`~pydicom.errors.InvalidDicomError`.
 
     Returns
@@ -475,7 +474,7 @@ def read_dataset(
     fp_tell = fp.tell
     fp_start = fp.tell()
     is_implicit_VR = _is_implicit_vr(
-        fp, is_implicit_VR, is_little_endian, stop_when, is_sequence=not at_top_level
+        fp, is_implicit_VR, is_little_endian, stop_when, is_sequence=(_depth > 0)
     )
     fp.seek(fp_start)
     de_gen = data_element_generator(
@@ -622,7 +621,6 @@ def read_sequence_item(
             is_little_endian,
             bytelength=None,
             parent_encoding=encoding,
-            at_top_level=False,
             _depth=_depth + 1,
         )
         ds.is_undefined_length_sequence_item = True
@@ -633,7 +631,6 @@ def read_sequence_item(
             is_little_endian,
             length,
             parent_encoding=encoding,
-            at_top_level=False,
             _depth=_depth + 1,
         )
         ds.is_undefined_length_sequence_item = False

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -1722,6 +1722,146 @@ class TestReadTruncatedFile:
             mr.pixel_array
 
 
+class TestMaxSequenceDepth:
+    """Bound parser nesting depth so adversarial input raises a
+    meaningful ``InvalidDicomError`` instead of ``RecursionError``.
+    """
+
+    @staticmethod
+    def _nested_sq_file(tmp_path, depth: int) -> str:
+        """Build a minimal Explicit-VR-LE DICOM file with ``depth`` levels
+        of nested ContentSequence (0040,A730).
+
+        Uses raw bytes to avoid pydicom's own writer recursing on us.
+        """
+        import struct
+
+        preamble = b"\x00" * 128 + b"DICM"
+
+        # File Meta Information
+        sop_class = b"1.2.840.10008.5.1.4.1.1.88.11\x00"
+        sop_instance = b"1.2.3.4.5.6.7\x00"
+        tsuid = b"1.2.840.10008.1.2.1\x00"
+        impl_class = b"1.2.3\x00"
+        fmi_body = (
+            struct.pack("<HH", 0x0002, 0x0001) + b"OB\x00\x00"
+            + struct.pack("<I", 2) + b"\x00\x01"
+            + struct.pack("<HH", 0x0002, 0x0002) + b"UI"
+            + struct.pack("<H", len(sop_class)) + sop_class
+            + struct.pack("<HH", 0x0002, 0x0003) + b"UI"
+            + struct.pack("<H", len(sop_instance)) + sop_instance
+            + struct.pack("<HH", 0x0002, 0x0010) + b"UI"
+            + struct.pack("<H", len(tsuid)) + tsuid
+            + struct.pack("<HH", 0x0002, 0x0012) + b"UI"
+            + struct.pack("<H", len(impl_class)) + impl_class
+        )
+        fmi = (
+            struct.pack("<HH", 0x0002, 0x0000) + b"UL"
+            + struct.pack("<H", 4) + struct.pack("<I", len(fmi_body))
+            + fmi_body
+        )
+
+        # Minimal identifying tags before the nested SQ
+        dataset_prefix = (
+            struct.pack("<HH", 0x0008, 0x0016) + b"UI"
+            + struct.pack("<H", len(sop_class)) + sop_class
+            + struct.pack("<HH", 0x0008, 0x0018) + b"UI"
+            + struct.pack("<H", len(sop_instance)) + sop_instance
+        )
+
+        # depth nested ContentSequence (0040,A730) blocks
+        sq_header = (
+            struct.pack("<HH", 0x0040, 0xA730) + b"SQ\x00\x00"
+            + struct.pack("<I", 0xFFFFFFFF)
+        )
+        item_header = (
+            struct.pack("<HH", 0xFFFE, 0xE000) + struct.pack("<I", 0xFFFFFFFF)
+        )
+        item_delim = struct.pack("<HH", 0xFFFE, 0xE00D) + struct.pack("<I", 0)
+        seq_delim = struct.pack("<HH", 0xFFFE, 0xE0DD) + struct.pack("<I", 0)
+        value_type = b"CONTAINER\x00"
+        inner_elem = (
+            struct.pack("<HH", 0x0040, 0xA040) + b"CS"
+            + struct.pack("<H", len(value_type)) + value_type
+        )
+        open_block = sq_header + item_header + inner_elem
+        close_block = item_delim + seq_delim
+        nested_sq = (open_block * depth) + (close_block * depth)
+
+        path = tmp_path / f"nested_{depth}.dcm"
+        path.write_bytes(preamble + fmi + dataset_prefix + nested_sq)
+        return str(path)
+
+    def test_default_setting_value(self):
+        """Default is conservatively bounded under Python's recursion limit."""
+        assert pydicom.config.settings.max_sequence_depth == 100
+
+    def test_setter_rejects_non_positive(self):
+        with pytest.raises(ValueError, match="must be greater than 0"):
+            pydicom.config.settings.max_sequence_depth = 0
+        with pytest.raises(ValueError, match="must be greater than 0"):
+            pydicom.config.settings.max_sequence_depth = -1
+
+    def test_setter_round_trip(self):
+        original = pydicom.config.settings.max_sequence_depth
+        try:
+            pydicom.config.settings.max_sequence_depth = 500
+            assert pydicom.config.settings.max_sequence_depth == 500
+        finally:
+            pydicom.config.settings.max_sequence_depth = original
+
+    def test_shallow_file_parses_normally(self, tmp_path):
+        """A file at depth = max - 1 parses without error."""
+        path = self._nested_sq_file(tmp_path, depth=20)
+        ds = dcmread(path, force=True)
+        # Walk into the sequence to confirm the structure exists.
+        assert (0x0040, 0xA730) in ds
+
+    def test_depth_at_limit_parses(self, tmp_path):
+        """A file at exactly the limit parses (boundary is exclusive)."""
+        original = pydicom.config.settings.max_sequence_depth
+        try:
+            pydicom.config.settings.max_sequence_depth = 50
+            path = self._nested_sq_file(tmp_path, depth=50)
+            ds = dcmread(path, force=True)
+            assert (0x0040, 0xA730) in ds
+        finally:
+            pydicom.config.settings.max_sequence_depth = original
+
+    def test_depth_one_past_limit_raises(self, tmp_path):
+        """A file one level past the limit raises InvalidDicomError."""
+        original = pydicom.config.settings.max_sequence_depth
+        try:
+            pydicom.config.settings.max_sequence_depth = 50
+            path = self._nested_sq_file(tmp_path, depth=51)
+            with pytest.raises(InvalidDicomError, match="nesting depth"):
+                dcmread(path, force=True)
+        finally:
+            pydicom.config.settings.max_sequence_depth = original
+
+    def test_adversarial_depth_does_not_recursionerror(self, tmp_path):
+        """The whole point: deep input raises InvalidDicomError, NOT
+        ``RecursionError``. Uses default max=100 against a depth=300 file."""
+        path = self._nested_sq_file(tmp_path, depth=300)
+        with pytest.raises(InvalidDicomError, match="nesting depth"):
+            dcmread(path, force=True)
+
+    def test_error_message_includes_actual_and_limit(self, tmp_path):
+        """Error message must surface both numbers so the user can act."""
+        original = pydicom.config.settings.max_sequence_depth
+        try:
+            pydicom.config.settings.max_sequence_depth = 50
+            path = self._nested_sq_file(tmp_path, depth=51)
+            with pytest.raises(InvalidDicomError) as excinfo:
+                dcmread(path, force=True)
+            msg = str(excinfo.value)
+            assert "51" in msg
+            assert "50" in msg
+            assert "max_sequence_depth" in msg
+        finally:
+            pydicom.config.settings.max_sequence_depth = original
+
+
 class TestFileLike:
     """Test that can read DICOM files with file-like object rather than
     filename

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -1744,45 +1744,62 @@ class TestMaxSequenceDepth:
         tsuid = b"1.2.840.10008.1.2.1\x00"
         impl_class = b"1.2.3\x00"
         fmi_body = (
-            struct.pack("<HH", 0x0002, 0x0001) + b"OB\x00\x00"
-            + struct.pack("<I", 2) + b"\x00\x01"
-            + struct.pack("<HH", 0x0002, 0x0002) + b"UI"
-            + struct.pack("<H", len(sop_class)) + sop_class
-            + struct.pack("<HH", 0x0002, 0x0003) + b"UI"
-            + struct.pack("<H", len(sop_instance)) + sop_instance
-            + struct.pack("<HH", 0x0002, 0x0010) + b"UI"
-            + struct.pack("<H", len(tsuid)) + tsuid
-            + struct.pack("<HH", 0x0002, 0x0012) + b"UI"
-            + struct.pack("<H", len(impl_class)) + impl_class
+            struct.pack("<HH", 0x0002, 0x0001)
+            + b"OB\x00\x00"
+            + struct.pack("<I", 2)
+            + b"\x00\x01"
+            + struct.pack("<HH", 0x0002, 0x0002)
+            + b"UI"
+            + struct.pack("<H", len(sop_class))
+            + sop_class
+            + struct.pack("<HH", 0x0002, 0x0003)
+            + b"UI"
+            + struct.pack("<H", len(sop_instance))
+            + sop_instance
+            + struct.pack("<HH", 0x0002, 0x0010)
+            + b"UI"
+            + struct.pack("<H", len(tsuid))
+            + tsuid
+            + struct.pack("<HH", 0x0002, 0x0012)
+            + b"UI"
+            + struct.pack("<H", len(impl_class))
+            + impl_class
         )
         fmi = (
-            struct.pack("<HH", 0x0002, 0x0000) + b"UL"
-            + struct.pack("<H", 4) + struct.pack("<I", len(fmi_body))
+            struct.pack("<HH", 0x0002, 0x0000)
+            + b"UL"
+            + struct.pack("<H", 4)
+            + struct.pack("<I", len(fmi_body))
             + fmi_body
         )
 
         # Minimal identifying tags before the nested SQ
         dataset_prefix = (
-            struct.pack("<HH", 0x0008, 0x0016) + b"UI"
-            + struct.pack("<H", len(sop_class)) + sop_class
-            + struct.pack("<HH", 0x0008, 0x0018) + b"UI"
-            + struct.pack("<H", len(sop_instance)) + sop_instance
+            struct.pack("<HH", 0x0008, 0x0016)
+            + b"UI"
+            + struct.pack("<H", len(sop_class))
+            + sop_class
+            + struct.pack("<HH", 0x0008, 0x0018)
+            + b"UI"
+            + struct.pack("<H", len(sop_instance))
+            + sop_instance
         )
 
         # depth nested ContentSequence (0040,A730) blocks
         sq_header = (
-            struct.pack("<HH", 0x0040, 0xA730) + b"SQ\x00\x00"
+            struct.pack("<HH", 0x0040, 0xA730)
+            + b"SQ\x00\x00"
             + struct.pack("<I", 0xFFFFFFFF)
         )
-        item_header = (
-            struct.pack("<HH", 0xFFFE, 0xE000) + struct.pack("<I", 0xFFFFFFFF)
-        )
+        item_header = struct.pack("<HH", 0xFFFE, 0xE000) + struct.pack("<I", 0xFFFFFFFF)
         item_delim = struct.pack("<HH", 0xFFFE, 0xE00D) + struct.pack("<I", 0)
         seq_delim = struct.pack("<HH", 0xFFFE, 0xE0DD) + struct.pack("<I", 0)
         value_type = b"CONTAINER\x00"
         inner_elem = (
-            struct.pack("<HH", 0x0040, 0xA040) + b"CS"
-            + struct.pack("<H", len(value_type)) + value_type
+            struct.pack("<HH", 0x0040, 0xA040)
+            + b"CS"
+            + struct.pack("<H", len(value_type))
+            + value_type
         )
         open_block = sq_header + item_header + inner_elem
         close_block = item_delim + seq_delim


### PR DESCRIPTION
Closes #2330.

## Summary

`pydicom.dcmread` raises an opaque `RecursionError` when parsing a structurally-valid DICOM file with a sequence nested past ~depth 249 (at Python's default `sys.recursionlimit` of 1000). This PR converts that failure mode into a meaningful `pydicom.errors.InvalidDicomError` and adds a configurable bound.

## Changes

- **`pydicom.config.settings.max_sequence_depth`** -- new setting, default `100`. Exposed via the existing `Settings` singleton so consumers can raise it if they legitimately need to parse deeper structures.
- **Private `_depth` counter** threaded through `read_dataset`, `data_element_generator`, `read_sequence`, and `read_sequence_item` in `src/pydicom/filereader.py`. Public APIs are unchanged.
- **Pre-recursion check** in `read_sequence_item`: when `_depth + 1` would exceed `max_sequence_depth`, raise `InvalidDicomError` with a message including the actual depth, the configured limit, and a hint pointing at the config setting.

The default of `100` sits comfortably below Python's default `sys.recursionlimit` of 1000 -- pydicom's reader uses ~4 frames per SQ level plus a small fixed overhead, so the practical Python ceiling is ~depth 240. Real-world DICOM Structured Reports rarely nest beyond 10-20 levels, so 100 gives a 5-10x safety margin while protecting against pathological input.

## Test plan

- [x] 8 new tests in `tests/test_filereader.py::TestMaxSequenceDepth`:
  - Default value
  - Setter validation (rejects 0 / negative)
  - Setter round-trip
  - Shallow file (depth 20) parses normally
  - File exactly at the limit parses
  - File one past the limit raises `InvalidDicomError`
  - Depth-300 adversarial file raises `InvalidDicomError` (not `RecursionError`)
  - Error message includes both the actual depth and the configured limit
- [x] Full `test_filereader.py` + `test_sequence.py` regression: 156/156 pass (3 unrelated skips)

## Compatibility

- No public API changes; `_depth` parameter is private and prefixed with `_` to signal that.
- Default behaviour changes only for files that nest sequences past 100 levels deep -- previously these raised `RecursionError`, now they raise `InvalidDicomError`. Consumers that need the old behaviour can `pydicom.config.settings.max_sequence_depth = 240` (or higher with `sys.setrecursionlimit` adjusted).
- Versioning notes in the docstring use `.. versionadded:: 3.1` -- happy to retarget if a different milestone fits better.

## Discovery

Found via a black-box fuzzing campaign against fo-dicom + pydicom. The same shape of malformed input also crashes fo-dicom 5.2.6 with a native `StackOverflowException`; that side is being addressed in [fo-dicom/fo-dicom#2114](https://github.com/fo-dicom/fo-dicom/pull/2114) (same CWE-674 family).