### PR TITLE
fix: raise InvalidDicomError on truncated sequence item header

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -49,6 +49,11 @@ Fixes
 * Fixed deepcopy of private blocks in :class:`~pydicom.dataset.Dataset` (:issue:`2294`)
 * Make float data elements with `NaN` value compare as equal - this is semantically better suited
   then the mathematical comparison, where `NaN != NaN` (:issue:`2273`)
+* Translate a truncated sequence item header in
+  :func:`~pydicom.filereader.read_sequence_item` to
+  :class:`~pydicom.errors.InvalidDicomError` instead of the legacy bare
+  ``OSError``. Also narrows the surrounding ``except BaseException`` so
+  ``KeyboardInterrupt`` and ``SystemExit`` are no longer swallowed.
 
 Enhancements
 ------------

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -53,7 +53,8 @@ Fixes
   :func:`~pydicom.filereader.read_sequence_item` to
   :class:`~pydicom.errors.InvalidDicomError` instead of the legacy bare
   ``OSError``. Also narrows the surrounding ``except BaseException`` so
-  ``KeyboardInterrupt`` and ``SystemExit`` are no longer swallowed.
+  ``KeyboardInterrupt`` and ``SystemExit`` are no longer swallowed
+  (:issue:`2332`).
 
 Enhancements
 ------------

--- a/src/pydicom/filereader.py
+++ b/src/pydicom/filereader.py
@@ -3,7 +3,7 @@
 
 # Need zlib and io.BytesIO for deflate-compressed file
 import os
-from struct import Struct, unpack
+from struct import Struct, error as struct_error, unpack
 from typing import BinaryIO, Any, cast
 from collections.abc import Callable, MutableSequence, Iterator
 import zlib
@@ -561,8 +561,17 @@ def read_sequence_item(
     try:
         bytes_read = fp.read(8)
         group, element, length = unpack(tag_length_format, bytes_read)
-    except BaseException:
-        raise OSError(f"No tag to read at file position {fp.tell() + offset:X}")
+    except (EOFError, OSError, struct_error) as exc:
+        # A truncated stream or a short read leaves us unable to recover
+        # the next sequence item header. Translate to InvalidDicomError
+        # (the documented dcmread failure mode) so callers can rely on a
+        # single exception type for malformed-DICOM input, and chain the
+        # underlying cause for diagnosability. The previous `except
+        # BaseException` was too broad -- it would have swallowed
+        # KeyboardInterrupt / SystemExit and re-raised them as OSError.
+        raise InvalidDicomError(
+            f"No tag to read at file position {fp.tell() + offset:X}"
+        ) from exc
 
     tag = (group, element)
     if tag == SequenceDelimiterTag:  # No more items, time to stop reading

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -996,6 +996,28 @@ class TestReader:
             "Expected sequence item with tag (FFFE,E000) at file position 0x22"
         ) in caplog.text
 
+    def test_sequence_item_truncated_raises_invaliddicom(self):
+        """SQ with undefined length but no item header before EOF must raise
+        ``InvalidDicomError``, not the legacy bare ``OSError``.
+
+        The previous implementation caught ``BaseException`` (so
+        ``KeyboardInterrupt`` / ``SystemExit`` were also swallowed) and re-raised
+        as ``OSError`` -- an exception type ``dcmread``'s docstring does not
+        promise to raise. Callers had no single type to ``except`` to handle
+        malformed-DICOM input.
+        """
+        # Implicit VR LE: CS "ISO_IR 100", then an undefined-length SQ at
+        # (0008,0006) with NO item header, NO sequence delimiter, EOF.
+        # read_sequence_item's `fp.read(8)` returns < 8 bytes and `unpack`
+        # raises struct.error -> we should land on InvalidDicomError.
+        truncated_sq = (
+            b"\x08\x00\x05\x00CS\x0a\x00ISO_IR 100"
+            b"\x08\x00\x06\x00SQ\x00\x00\xff\xff\xff\xff"
+        )
+
+        with pytest.raises(InvalidDicomError, match="No tag to read at file position"):
+            read_dataset(BytesIO(truncated_sq), False, True)
+
     def test_registered_private_transfer_syntax(self, enable_debugging, caplog):
         """Test reading a dataset with a registered private transfer syntax"""
         uid = UID("1.2.3.4")

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -8,7 +8,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from struct import unpack
+from struct import error as struct_error, unpack
 import sys
 import tempfile
 import time
@@ -1015,8 +1015,15 @@ class TestReader:
             b"\x08\x00\x06\x00SQ\x00\x00\xff\xff\xff\xff"
         )
 
-        with pytest.raises(InvalidDicomError, match="No tag to read at file position"):
+        with pytest.raises(
+            InvalidDicomError, match="No tag to read at file position"
+        ) as excinfo:
             read_dataset(BytesIO(truncated_sq), False, True)
+
+        # The PR sells `raise ... from exc` as a diagnosability benefit; pin
+        # the chain so a future refactor that drops the `from` clause fails
+        # CI instead of silently losing the underlying cause.
+        assert isinstance(excinfo.value.__cause__, struct_error)
 
     def test_registered_private_transfer_syntax(self, enable_debugging, caplog):
         """Test reading a dataset with a registered private transfer syntax"""


### PR DESCRIPTION
Fixes #2332.

## Summary

`read_sequence_item` (`src/pydicom/filereader.py:560-565`) previously caught `BaseException` and re-raised the failure as a bare `OSError`. Two problems:

1. **Contract violation.** `dcmread`'s docstring (`src/pydicom/filereader.py:1054-1059`) documents only `InvalidDicomError` and `TypeError` as raisable. Callers wrapping `dcmread` in `except InvalidDicomError` missed truncated-sequence cases entirely.
2. **Too broad.** `except BaseException` swallows `KeyboardInterrupt` and `SystemExit` and re-raises them as `OSError`, breaking signal handling for long-running consumers.

This PR narrows the catch to `(EOFError, OSError, struct.error)`, raises `InvalidDicomError` with the same human-readable message, and chains the underlying cause via `raise ... from exc` so the original `struct.error` (or other low-level failure) stays available via `__cause__` for debugging.

## Files changed

- `src/pydicom/filereader.py` -- import `struct.error as struct_error`, narrow the catch + change exception type.
- `tests/test_filereader.py` -- new `test_sequence_item_truncated_raises_invaliddicom` constructs the minimal repro (CS element + undefined-length SQ header with no item header before EOF) and asserts `InvalidDicomError` is raised with the same message.
- `doc/release_notes/v3.1.0.rst` -- Fixes entry.

## Test plan

- [x] New test passes locally on Python 3.13.
- [x] `pytest tests/test_filereader.py::TestReader` -- 63 passing (was 62; 1 new).
- [x] The 4 fuzz inputs that originally raised bare `OSError` now raise `InvalidDicomError` with the same message.
- [x] Branch is up to date with `upstream/main`.

## Discovery

Surfaced during a black-box fuzzing campaign that produced 915 mutated DICOM inputs from real clinical seeds. 869 loaded cleanly, 42 raised `InvalidDicomError` as documented, and 4 raised the bare-`OSError` path that this PR fixes. The inconsistency between the documented and actual failure modes is what flagged the bug.

## Notes

This change is independent of #2331 (SQ depth guard) and can be merged in either order. Both touch `read_sequence_item` but in non-overlapping ways.