### PR TITLE
Include element tag in BytesLengthException from ambiguous VR correction

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -77,6 +77,8 @@ Enhancements
 * Added enhanced exception notes (Python >= 3.11) giving a pseudo-code path to the DICOM object
   where an error occurred.  Activated using `with dataset:` context; already used internally in key
   locations (:issue:`2168`)
+* Include the element tag in the :class:`~pydicom.errors.BytesLengthException` raised when
+  ambiguous VR correction fails during writing due to an invalid value length (:issue:`2168`)
 * Added support for adding unknown public transfer syntaxes to :func:`~pydicom.uid.register_transfer_syntax`
 * When decoding JPEG pixel data use Pillow's color transformations rather than
   :func:`~pydicom.pixels.convert_color_space` where applicable (:issue:`2228`)

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -17,6 +17,7 @@ from pydicom.dataelem import (
     RawDataElement,
 )
 from pydicom.dataset import Dataset, validate_file_meta, FileMetaDataset
+from pydicom.errors import BytesLengthException
 from pydicom.filebase import DicomFile, DicomBytesIO, DicomIO, WriteableBuffer
 from pydicom.fileutil import (
     path_from_pathlike,
@@ -276,6 +277,10 @@ def correct_ambiguous_vr_element(
             _correct_ambiguous_vr_element(elem, ancestors, is_little_endian)
         except AttributeError as e:
             raise AttributeError(
+                f"Failed to resolve ambiguous VR for tag {elem.tag}: {e}"
+            )
+        except BytesLengthException as e:
+            raise BytesLengthException(
                 f"Failed to resolve ambiguous VR for tag {elem.tag}: {e}"
             )
 

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -16,7 +16,7 @@ from tempfile import TemporaryFile
 from typing import cast
 import zlib
 
-from pydicom.errors import InvalidDicomError
+from pydicom.errors import BytesLengthException, InvalidDicomError
 
 try:
     import resource
@@ -1359,6 +1359,18 @@ class TestCorrectAmbiguousVRElement:
         ds = dcmread(fp, force=True)
         assert ds.ModalityLUTSequence[0]["LUTDescriptor"].VR == "US"
         assert ds.ModalityLUTSequence[0]["LUTData"].VR == "OW"
+
+    def test_invalid_value_length(self):
+        """Regression test for #2168: the error message includes the tag."""
+        ds = Dataset()
+        ds.PixelRepresentation = 0
+        ds.SmallestImagePixelValue = b"\x00\x01\x02"
+        msg = (
+            r"Failed to resolve ambiguous VR for tag \(0028,0106\): Expected "
+            r"total bytes to be an even multiple of bytes per value"
+        )
+        with pytest.raises(BytesLengthException, match=msg):
+            correct_ambiguous_vr_element(ds[0x00280106], ds, True)
 
 
 class TestWriteAmbiguousVR:


### PR DESCRIPTION
#### Describe the changes

One slice of #2168 (the "quick win" of adding tag context to error messages): when ambiguous VR correction fails during writing because the value length doesn't match the resolved VR, the `BytesLengthException` now includes the offending element's tag, mirroring the existing `AttributeError` handling in `correct_ambiguous_vr_element`.

Before (the StackOverflow case quoted in the issue):
```
BytesLengthException: Expected total bytes to be an even multiple of bytes per value. Instead received b'0x0' with length 3 and struct format 'H' which corresponds to bytes per value of 2.
```
After:
```
BytesLengthException: Failed to resolve ambiguous VR for tag (0028,0106): Expected total bytes to be an even multiple of bytes per value. Instead received b'\x00\x01\x02' with length 3 and struct format 'H' which corresponds to bytes per value of 2.
```

The exception type is unchanged and nothing is added to the success path, so there's no performance impact on the write loop. The exception notes from #2255 also annotate this path when writing via `save_as()` on Python 3.11+; this change additionally covers Python 3.10 and any code that only surfaces `str(e)`, since notes don't appear in the message itself.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better

