### PR TITLE
Report looked-up VR and hint at update_raw_element on length mismatch

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -49,6 +49,9 @@ Fixes
 * Fixed deepcopy of private blocks in :class:`~pydicom.dataset.Dataset` (:issue:`2294`)
 * Make float data elements with `NaN` value compare as equal - this is semantically better suited
   then the mathematical comparison, where `NaN != NaN` (:issue:`2273`)
+* When parsing fails because a value's length doesn't match the VR determined from a data
+  dictionary lookup, report that VR in the error message (previously ``None``) and suggest
+  :meth:`~pydicom.dataset.Dataset.update_raw_element` (:issue:`2170`)
 
 Enhancements
 ------------

--- a/src/pydicom/hooks.py
+++ b/src/pydicom/hooks.py
@@ -251,8 +251,15 @@ def raw_element_value(
         # Failed conversion, either raise or convert to a UN VR
         msg = (
             f"{exc} This occurred while trying to parse {raw.tag} according "
-            f"to VR '{raw.VR}'."
+            f"to VR '{vr}'."
         )
+        if raw.VR in (None, VR.UN) and vr != VR.UN:
+            msg += (
+                " The VR was determined from a data dictionary lookup and "
+                "may not match the actual value; Dataset.update_raw_element() "
+                "can be used to set the correct VR before the element is "
+                "converted."
+            )
         if not config.convert_wrong_length_to_UN:
             raise BytesLengthException(
                 f"{msg} To replace this error with a warning set "

--- a/tests/test_dataelem.py
+++ b/tests/test_dataelem.py
@@ -735,6 +735,51 @@ class TestRawDataElement:
             assert "UN" == raw_elem.VR
             assert value == raw_elem.value
 
+    @pytest.mark.parametrize("accept_wrong_length", [False], indirect=True)
+    def test_wrong_bytes_length_guessed_vr_hint(self, accept_wrong_length):
+        """Regression test for #2170: hint at the dictionary-determined VR."""
+        ds = Dataset()
+        ds.set_original_encoding(True, True)
+        ds._dict[Tag(0x01F10010)] = RawDataElement(
+            Tag(0x01F10010), None, 8, b"ELSCINT1", 0, True, True
+        )
+        ds._dict[Tag(0x01F11026)] = RawDataElement(
+            Tag(0x01F11026), None, 6, b"0.264 ", 0, True, True
+        )
+        msg = (
+            r"to parse \(01F1,1026\) according to VR 'FD'. The VR was "
+            r"determined from a data dictionary lookup and may not match the "
+            r"actual value; Dataset.update_raw_element\(\) can be used to set "
+            r"the correct VR before the element is converted."
+        )
+        with pytest.raises(BytesLengthException, match=msg):
+            convert_raw_data_element(ds._dict[Tag(0x01F11026)], ds=ds)
+
+    @pytest.mark.parametrize("accept_wrong_length", [True], indirect=True)
+    def test_wrong_bytes_length_guessed_vr_hint_warns(self, accept_wrong_length):
+        """The dictionary lookup hint is also present when converting to UN."""
+        ds = Dataset()
+        ds.set_original_encoding(True, True)
+        ds._dict[Tag(0x01F10010)] = RawDataElement(
+            Tag(0x01F10010), None, 8, b"ELSCINT1", 0, True, True
+        )
+        ds._dict[Tag(0x01F11026)] = RawDataElement(
+            Tag(0x01F11026), None, 6, b"0.264 ", 0, True, True
+        )
+        msg = (
+            r"to parse \(01F1,1026\) according to VR 'FD'. The VR was "
+            r"determined from a data dictionary lookup .* Setting VR to 'UN'."
+        )
+        with pytest.warns(UserWarning, match=msg):
+            raw_elem = convert_raw_data_element(ds._dict[Tag(0x01F11026)], ds=ds)
+            assert "UN" == raw_elem.VR
+            assert b"0.264 " == raw_elem.value
+
+        # The suggested fix resolves the element correctly
+        ds.update_raw_element(0x01F11026, vr="DS")
+        assert ds[0x01F11026].VR == "DS"
+        assert ds[0x01F11026].value == 0.264
+
     def test_read_known_private_tag_implicit(self):
         fp = DicomBytesIO()
         ds = Dataset()


### PR DESCRIPTION
#### Describe the changes

For #2170: when a value fails length validation against a VR that pydicom determined from a data dictionary lookup (implicit VR private tags being the canonical case - the issue's ELSCINT1 (01F1,1026) has dictionary VR FD but the data is really DS), the `BytesLengthException` message now:

* reports the VR that was actually used to parse - previously it showed the VR read from the file, which is `None` for implicit VR (see the traceback in the issue)
* when that VR came from a dictionary lookup rather than the dataset, says so and points at `Dataset.update_raw_element()` (the value-preserving fix, and the workaround recommended in the issue), alongside the existing `convert_wrong_length_to_UN` hint (which converts to **UN** instead)

Before:
```
...This occurred while trying to parse (01F1,1026) according to VR 'None'. To replace this error with a warning set pydicom.config.convert_wrong_length_to_UN = True.
```
After:
```
...This occurred while trying to parse (01F1,1026) according to VR 'FD'. The VR was determined from a data dictionary lookup and may not match the actual value; Dataset.update_raw_element() can be used to set the correct VR before the element is converted. To replace this error with a warning set pydicom.config.convert_wrong_length_to_UN = True.
```

Everything is confined to the `except BytesLengthException` branch, so nothing changes on the success path. I checked that no exception notes get attached on this path (the read-side conversion doesn't run inside a `with dataset` block), so the message is the only context the user gets here.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [x] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
