### PR TITLE
Raise InvalidDicomError for unknown VR via dcmread (#2336)

### DIFF
--- a/doc/reference/errors.rst
+++ b/doc/reference/errors.rst
@@ -9,3 +9,4 @@ Exceptions (:mod:`pydicom.errors`)
    :toctree: generated/
 
    InvalidDicomError
+   UnknownVRError

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -59,6 +59,13 @@ Fixes
   to opt in to a permissive parse where the offending element's VR is replaced
   with ``UN`` and a warning is logged, mirroring
   :data:`~pydicom.config.convert_wrong_length_to_UN` (:issue:`2336`).
+  The unknown VR is now signalled by the new
+  :class:`~pydicom.errors.UnknownVRError`, which subclasses
+  ``NotImplementedError`` so existing handlers are unaffected. Keying the
+  translation on that type keeps it from capturing an unrelated
+  ``NotImplementedError`` raised by a callback registered through
+  :mod:`pydicom.hooks`, which would otherwise report an extension's failure
+  as malformed input.
 
 Enhancements
 ------------

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -49,6 +49,16 @@ Fixes
 * Fixed deepcopy of private blocks in :class:`~pydicom.dataset.Dataset` (:issue:`2294`)
 * Make float data elements with `NaN` value compare as equal - this is semantically better suited
   then the mathematical comparison, where `NaN != NaN` (:issue:`2273`)
+* Translate an unknown VR encountered through :func:`~pydicom.filereader.dcmread`
+  to :class:`~pydicom.errors.InvalidDicomError` -- the documented public-API
+  failure mode -- instead of the legacy ``NotImplementedError``. Internal
+  callers (``read_partial``, ``read_dataset``, ``read_file_meta_info``, the
+  implicit-VR retry inside ``_read_file_meta_info``, ``util.fixer``) continue
+  to see ``NotImplementedError`` unchanged. Added the new
+  :data:`~pydicom.config.convert_unknown_vr_to_UN` setting (default ``False``)
+  to opt in to a permissive parse where the offending element's VR is replaced
+  with ``UN`` and a warning is logged, mirroring
+  :data:`~pydicom.config.convert_wrong_length_to_UN` (:issue:`2336`).
 
 Enhancements
 ------------

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -65,7 +65,8 @@ Fixes
   translation on that type keeps it from capturing an unrelated
   ``NotImplementedError`` raised by a callback registered through
   :mod:`pydicom.hooks`, which would otherwise report an extension's failure
-  as malformed input.
+  as malformed input. The error message now names the DICOM Standard edition
+  this release implements, since an unrecognised VR may simply postdate it.
 
 Enhancements
 ------------

--- a/src/pydicom/config.py
+++ b/src/pydicom/config.py
@@ -363,6 +363,20 @@ convert_wrong_length_to_UN = False
 Default ``False``.
 """
 
+convert_unknown_vr_to_UN = False
+"""Convert a field VR to "UN" and return its raw bytes if the encoded VR is
+not recognised. Default ``False``.
+
+When ``False``, an unknown VR encountered during value conversion raises
+:class:`NotImplementedError` from the lower-level converter, which
+:func:`~pydicom.filereader.dcmread` then surfaces as
+:class:`~pydicom.errors.InvalidDicomError` per its documented exception
+contract. When ``True``, a warning is logged instead and the offending
+element's VR is silently switched to ``UN`` so the rest of the file can
+be parsed -- useful when an in-flight study with a single bad tag would
+otherwise be unreadable. Mirrors :data:`convert_wrong_length_to_UN`.
+"""
+
 datetime_conversion = False
 """Set to ``True`` to convert the value(s) of elements with a VR of DA, DT and
 TM to :class:`datetime.date`, :class:`datetime.datetime` and

--- a/src/pydicom/errors.py
+++ b/src/pydicom/errors.py
@@ -24,3 +24,25 @@ class BytesLengthException(Exception):
     """Exception that is raised for an unexpected number of bytes."""
 
     pass
+
+
+class UnknownVRError(NotImplementedError):
+    """Exception that is raised when an element's encoded VR is not recognised.
+
+    .. versionadded:: 3.1
+
+    Subclasses :class:`NotImplementedError`, so code that already catches that
+    is unaffected -- including :func:`~pydicom.filereader.read_dataset`, the
+    implicit-VR retry inside :func:`~pydicom.filereader.read_file_meta_info`
+    and :func:`~pydicom.util.fixer.fix_mismatch`.
+
+    Its purpose is to let :func:`~pydicom.filereader.dcmread` translate *this*
+    failure to :class:`InvalidDicomError` without also capturing unrelated
+    ``NotImplementedError`` raised by callbacks registered through
+    :mod:`pydicom.hooks`.
+
+    To parse the offending element as **UN** rather than raise, set
+    :attr:`~pydicom.config.convert_unknown_vr_to_UN` to ``True``.
+    """
+
+    pass

--- a/src/pydicom/filereader.py
+++ b/src/pydicom/filereader.py
@@ -19,7 +19,7 @@ from pydicom.dataelem import (
     empty_value_for_VR,
 )
 from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
-from pydicom.errors import InvalidDicomError
+from pydicom.errors import InvalidDicomError, UnknownVRError
 from pydicom.filebase import ReadableBuffer, DicomBytesIO
 from pydicom.fileutil import (
     read_undefined_length_value,
@@ -1088,20 +1088,26 @@ def dcmread(
                 force=force,
                 specific_tags=specific_tags,
             )
-        except NotImplementedError as exc:
+        except UnknownVRError as exc:
             # An unknown VR ('ZZ' / 'XX' / etc.) at any nesting depth
-            # bubbles up here as NotImplementedError from
-            # ``raw_element_value`` (see issue #2336). Per dcmread's
-            # documented ``Raises`` contract, malformed DICOM input must
-            # surface as ``InvalidDicomError``; translate at the public
-            # API boundary and chain the original cause for
+            # bubbles up here from ``raw_element_value`` (see issue #2336).
+            # Per dcmread's documented ``Raises`` contract, malformed DICOM
+            # input must surface as ``InvalidDicomError``; translate at the
+            # public API boundary and chain the original cause for
             # diagnosability. Internal callers (``read_partial``,
             # ``read_dataset``, ``read_file_meta_info``, the #503
             # implicit-VR retry inside ``_read_file_meta_info``,
-            # ``util.fixer``) continue to see ``NotImplementedError``
-            # unchanged. To recover and parse the unknown element as
-            # ``UN`` instead of failing here, set
-            # ``pydicom.config.convert_unknown_vr_to_UN = True``.
+            # ``util.fixer``) catch ``NotImplementedError``, which
+            # ``UnknownVRError`` subclasses, so they are unchanged.
+            #
+            # Catching the subclass rather than ``NotImplementedError`` keeps
+            # this narrow: a callback registered on the ``raw_element_value``
+            # hook may raise ``NotImplementedError`` for its own reasons, and
+            # an extension failing is not the file being malformed.
+            #
+            # To recover and parse the unknown element as ``UN`` instead of
+            # failing here, set ``pydicom.config.convert_unknown_vr_to_UN``
+            # to ``True``.
             raise InvalidDicomError(str(exc)) from exc
     finally:
         if not caller_owns_file:

--- a/src/pydicom/filereader.py
+++ b/src/pydicom/filereader.py
@@ -1080,13 +1080,29 @@ def dcmread(
     if stop_before_pixels:
         stop_when = _at_pixel_data
     try:
-        dataset = read_partial(
-            fp,
-            stop_when,
-            defer_size=size_in_bytes(defer_size),
-            force=force,
-            specific_tags=specific_tags,
-        )
+        try:
+            dataset = read_partial(
+                fp,
+                stop_when,
+                defer_size=size_in_bytes(defer_size),
+                force=force,
+                specific_tags=specific_tags,
+            )
+        except NotImplementedError as exc:
+            # An unknown VR ('ZZ' / 'XX' / etc.) at any nesting depth
+            # bubbles up here as NotImplementedError from
+            # ``raw_element_value`` (see issue #2336). Per dcmread's
+            # documented ``Raises`` contract, malformed DICOM input must
+            # surface as ``InvalidDicomError``; translate at the public
+            # API boundary and chain the original cause for
+            # diagnosability. Internal callers (``read_partial``,
+            # ``read_dataset``, ``read_file_meta_info``, the #503
+            # implicit-VR retry inside ``_read_file_meta_info``,
+            # ``util.fixer``) continue to see ``NotImplementedError``
+            # unchanged. To recover and parse the unknown element as
+            # ``UN`` instead of failing here, set
+            # ``pydicom.config.convert_unknown_vr_to_UN = True``.
+            raise InvalidDicomError(str(exc)) from exc
     finally:
         if not caller_owns_file:
             fp.close()

--- a/src/pydicom/hooks.py
+++ b/src/pydicom/hooks.py
@@ -246,7 +246,25 @@ def raw_element_value(
     try:
         value = convert_value(vr, raw, encoding)
     except NotImplementedError as exc:
-        raise NotImplementedError(f"{exc} in tag {raw.tag}")
+        # An unknown VR ('ZZ', 'XX', etc.) reaches us as NotImplementedError
+        # from convert_value. Mirror convert_wrong_length_to_UN: either keep
+        # the original exception (so the dcmread boundary can translate it
+        # to InvalidDicomError per the documented contract), or fall back
+        # to a UN-VR parse and continue. We do NOT translate here because
+        # internal callers (read_partial, read_dataset, the #503
+        # implicit-VR retry inside _read_file_meta_info, util.fixer) rely
+        # on catching NotImplementedError specifically.
+        msg = f"{exc} in tag {raw.tag}"
+        if not config.convert_unknown_vr_to_UN:
+            raise NotImplementedError(
+                f"{msg}. To replace this error with a warning and parse the "
+                "element as 'UN', set "
+                "pydicom.config.convert_unknown_vr_to_UN = True."
+            ) from exc
+
+        warn_and_log(f"{msg}. Setting VR to 'UN'.")
+        data["VR"] = VR.UN
+        value = raw.value
     except BytesLengthException as exc:
         # Failed conversion, either raise or convert to a UN VR
         msg = (

--- a/src/pydicom/hooks.py
+++ b/src/pydicom/hooks.py
@@ -5,7 +5,7 @@ from collections.abc import MutableSequence, Callable
 
 from pydicom import config
 from pydicom.datadict import dictionary_VR, private_dictionary_VR
-from pydicom.errors import BytesLengthException
+from pydicom.errors import BytesLengthException, UnknownVRError
 from pydicom.misc import warn_and_log
 from pydicom.multival import MultiValue
 from pydicom.tag import BaseTag, _LUT_DESCRIPTOR_TAGS
@@ -245,18 +245,21 @@ def raw_element_value(
     vr = data["VR"]
     try:
         value = convert_value(vr, raw, encoding)
-    except NotImplementedError as exc:
-        # An unknown VR ('ZZ', 'XX', etc.) reaches us as NotImplementedError
-        # from convert_value. Mirror convert_wrong_length_to_UN: either keep
-        # the original exception (so the dcmread boundary can translate it
-        # to InvalidDicomError per the documented contract), or fall back
-        # to a UN-VR parse and continue. We do NOT translate here because
-        # internal callers (read_partial, read_dataset, the #503
-        # implicit-VR retry inside _read_file_meta_info, util.fixer) rely
-        # on catching NotImplementedError specifically.
+    except UnknownVRError as exc:
+        # An unknown VR ('ZZ', 'XX', etc.) reaches us as UnknownVRError from
+        # convert_value. Mirror convert_wrong_length_to_UN: either raise, or
+        # fall back to a UN-VR parse and continue.
+        #
+        # Re-raise the same type (it subclasses NotImplementedError, so
+        # read_dataset, the #503 implicit-VR retry inside
+        # _read_file_meta_info and util.fixer keep catching it unchanged).
+        # Carrying the distinct type all the way up is what lets the dcmread
+        # boundary translate *this* failure to InvalidDicomError without also
+        # swallowing an unrelated NotImplementedError raised by a callback
+        # registered on this hook.
         msg = f"{exc} in tag {raw.tag}"
         if not config.convert_unknown_vr_to_UN:
-            raise NotImplementedError(
+            raise UnknownVRError(
                 f"{msg}. To replace this error with a warning and parse the "
                 "element as 'UN', set "
                 "pydicom.config.convert_unknown_vr_to_UN = True."

--- a/src/pydicom/values.py
+++ b/src/pydicom/values.py
@@ -14,7 +14,7 @@ from pydicom import config
 from pydicom.charset import default_encoding, decode_bytes
 from pydicom.config import logger, have_numpy
 from pydicom.dataelem import empty_value_for_VR, RawDataElement
-from pydicom.errors import BytesLengthException
+from pydicom.errors import BytesLengthException, UnknownVRError
 from pydicom.filereader import read_sequence
 from pydicom.multival import MultiValue
 from pydicom.sequence import Sequence
@@ -751,7 +751,14 @@ def convert_value(
         # If the VR characters are outside that range then print hex values
         if ord(VR[0]) not in char_range or ord(VR[1]) not in char_range:
             VR = " ".join([f"0x{ord(ch):02x}" for ch in VR])
-        raise NotImplementedError(f"Unknown Value Representation '{VR}'")
+        # UnknownVRError subclasses NotImplementedError, so existing handlers
+        # are unaffected. Raising it at the single point the unknown VR is
+        # actually detected means every route into this function carries the
+        # distinct type -- including callers that bypass the
+        # ``raw_element_value`` hook, such as the legacy
+        # ``config.data_element_callback`` installed by
+        # :func:`~pydicom.util.fixer.fix_mismatch`.
+        raise UnknownVRError(f"Unknown Value Representation '{VR}'")
 
     if raw_data_element.length == 0:
         return empty_value_for_VR(VR)

--- a/src/pydicom/values.py
+++ b/src/pydicom/values.py
@@ -15,6 +15,7 @@ from pydicom.charset import default_encoding, decode_bytes
 from pydicom.config import logger, have_numpy
 from pydicom.dataelem import empty_value_for_VR, RawDataElement
 from pydicom.errors import BytesLengthException, UnknownVRError
+from pydicom._version import __version__, __dicom_version__
 from pydicom.filereader import read_sequence
 from pydicom.multival import MultiValue
 from pydicom.sequence import Sequence
@@ -758,7 +759,16 @@ def convert_value(
         # ``raw_element_value`` hook, such as the legacy
         # ``config.data_element_callback`` installed by
         # :func:`~pydicom.util.fixer.fix_mismatch`.
-        raise UnknownVRError(f"Unknown Value Representation '{VR}'")
+        #
+        # The DICOM Standard edition is named because "unknown" only means
+        # unknown to this release: a VR added to the Standard later than the
+        # edition this release implements is valid DICOM that pydicom cannot
+        # convert yet, and the remedy (upgrade pydicom) differs from the
+        # remedy for a corrupt file.
+        raise UnknownVRError(
+            f"Unknown Value Representation '{VR}' (pydicom {__version__} "
+            f"implements DICOM Standard {__dicom_version__})"
+        )
 
     if raw_data_element.length == 0:
         return empty_value_for_VR(VR)

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -27,6 +27,7 @@ from pydicom.filereader import (
     read_file_meta_info,
 )
 from pydicom.dataelem import DataElement, convert_raw_data_element
+from pydicom._version import __dicom_version__
 from pydicom.errors import InvalidDicomError, UnknownVRError
 from pydicom.filebase import DicomBytesIO
 from pydicom.hooks import hooks
@@ -1191,7 +1192,12 @@ class TestUnknownVR:
             False,
             True,
         )
-        msg = r"Unknown Value Representation '{}' in tag \(0008,0006\)"
+        # The parenthetical names the DICOM Standard edition this release
+        # implements, because an unrecognised VR may simply postdate it.
+        msg = (
+            r"Unknown Value Representation '{}' \(pydicom .+ implements "
+            r"DICOM Standard .+\) in tag \(0008,0006\)"
+        )
         msg = msg.format(str_output)
         with pytest.raises(NotImplementedError, match=msg):
             print(ds)
@@ -1259,6 +1265,10 @@ class TestUnknownVR:
 
         assert "Unknown Value Representation 'ZZ'" in str(excinfo.value)
         assert "(0002,0000)" in str(excinfo.value)
+        # The message names the DICOM Standard edition this release implements,
+        # since an unrecognised VR may simply postdate it -- the reader then
+        # knows whether "upgrade pydicom" is the remedy.
+        assert __dicom_version__ in str(excinfo.value)
         # The chain is preserved for diagnosability.
         assert isinstance(excinfo.value.__cause__, NotImplementedError)
 

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -27,8 +27,9 @@ from pydicom.filereader import (
     read_file_meta_info,
 )
 from pydicom.dataelem import DataElement, convert_raw_data_element
-from pydicom.errors import InvalidDicomError
+from pydicom.errors import InvalidDicomError, UnknownVRError
 from pydicom.filebase import DicomBytesIO
+from pydicom.hooks import hooks
 from pydicom.multival import MultiValue
 from pydicom.sequence import Sequence
 from pydicom.tag import Tag, TupleTag
@@ -1301,6 +1302,83 @@ class TestUnknownVR:
         from pydicom.filereader import read_partial
 
         with pytest.raises(NotImplementedError, match="'ZZ'"):
+            read_partial(
+                BytesIO(self._UNKNOWN_VR_FMI_BYTES),
+                stop_when=None,
+                defer_size=None,
+                force=True,
+            )
+
+    def test_dcmread_does_not_translate_callback_notimplementederror(self):
+        """A ``NotImplementedError`` raised by a registered callback reaches
+        the caller unchanged.
+
+        :mod:`pydicom.hooks` is a documented extension point, and a callback
+        failing is not the same event as the file being malformed -- reporting
+        it as :class:`~pydicom.errors.InvalidDicomError` would send someone
+        debugging their own plugin off to inspect a valid file instead.
+
+        The translation is therefore keyed on
+        :class:`~pydicom.errors.UnknownVRError` rather than on
+        ``NotImplementedError``. Reading a *valid* dataset keeps the two
+        causes cleanly separated: nothing about this input is malformed, so
+        the callback's own failure is the only exception in play.
+        """
+
+        class _CallbackFailure(NotImplementedError):
+            """Stands in for an extension signalling its own failure."""
+
+        def _raising_callback(raw, data, *, encoding=None, ds=None, **kwargs):
+            raise _CallbackFailure("callback-sentinel")
+
+        original = hooks.raw_element_value
+        hooks.register_callback("raw_element_value", _raising_callback)
+        try:
+            with pytest.raises(_CallbackFailure, match="callback-sentinel"):
+                dcmread(mr_name)
+        finally:
+            hooks.register_callback("raw_element_value", original)
+
+    def test_dcmread_translates_unknown_vr_via_legacy_element_callback(self):
+        """The translation also covers callers that bypass the hook.
+
+        :func:`~pydicom.util.fixer.fix_mismatch` installs the legacy
+        ``config.data_element_callback``, which runs *before* the
+        ``raw_element_value`` hook in
+        :func:`~pydicom.dataelem.convert_raw_data_element` and calls
+        ``convert_value`` itself, catching only ``ValueError``. An unknown VR
+        therefore escapes that callback without ever reaching the hook.
+
+        Raising :class:`~pydicom.errors.UnknownVRError` from ``convert_value``
+        -- the single point the unknown VR is actually detected -- is what
+        keeps this path covered. Pinned because it would otherwise silently
+        revert to leaking ``NotImplementedError``, which is the exact defect
+        #2336 reports.
+        """
+        from pydicom.util.fixer import fix_mismatch
+
+        fix_mismatch()
+        try:
+            with pytest.raises(InvalidDicomError, match="'ZZ'"):
+                dcmread(BytesIO(self._UNKNOWN_VR_FMI_BYTES), force=True)
+        finally:
+            config.reset_data_element_callback()
+
+    def test_unknown_vr_error_is_a_notimplementederror(self):
+        """:class:`~pydicom.errors.UnknownVRError` stays catchable as
+        ``NotImplementedError``.
+
+        The subclassing is what keeps ``read_dataset``, the #503 implicit-VR
+        retry and ``util.fixer`` working untouched, and keeps downstream code
+        written against pydicom < 3.1 working. Pinned explicitly because
+        breaking it would be silent -- those call sites swallow the exception
+        rather than propagate it.
+        """
+        assert issubclass(UnknownVRError, NotImplementedError)
+
+        from pydicom.filereader import read_partial
+
+        with pytest.raises(UnknownVRError):
             read_partial(
                 BytesIO(self._UNKNOWN_VR_FMI_BYTES),
                 stop_when=None,

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -1223,6 +1223,91 @@ class TestUnknownVR:
 
         assert "Unknown VR '0x7878' assuming implicit VR encoding" in caplog.text
 
+    # ----- Regression: dcmread exception contract for unknown VR (#2336) -----
+
+    # 144-byte File-Meta-Information-only fixture: 128-byte zero preamble +
+    # ``DICM`` + (0002,0000) FileMetaInformationGroupLength encoded with the
+    # invented VR 'ZZ'. Lifts to NotImplementedError from convert_value, which
+    # the public dcmread API must surface as InvalidDicomError per its
+    # documented ``Raises`` contract. Inline rather than a fixture so each
+    # test is self-contained for the maintainer reading the diff.
+    _UNKNOWN_VR_FMI_BYTES = bytes.fromhex(
+        "00" * 128
+        + "4449434d"  # 'DICM'
+        + "02000000"  # tag (0002,0000)
+        + "5a5a"      # VR 'ZZ'
+        + "0400"      # length 4
+        + "00000000"  # value
+    )
+
+    def test_dcmread_raises_invaliddicom_on_unknown_vr(self):
+        """Unknown VR via ``dcmread(force=True)`` must raise
+        :class:`InvalidDicomError`, not :class:`NotImplementedError`.
+
+        ``dcmread``'s docstring promises ``InvalidDicomError`` for malformed
+        DICOM input. Prior to #2336, unknown VRs leaked
+        ``NotImplementedError`` through the public API, leaving callers
+        with no single exception type to handle malformed input.
+
+        Same shape as the contract narrowing in PR #2331 (``RecursionError``
+        on deep SQ nesting) and PR #2333 (bare ``OSError`` on truncated SQ
+        item header).
+        """
+        with pytest.raises(InvalidDicomError) as excinfo:
+            dcmread(BytesIO(self._UNKNOWN_VR_FMI_BYTES), force=True)
+
+        assert "Unknown Value Representation 'ZZ'" in str(excinfo.value)
+        assert "(0002,0000)" in str(excinfo.value)
+        # The chain is preserved for diagnosability.
+        assert isinstance(excinfo.value.__cause__, NotImplementedError)
+
+    def test_dcmread_unknown_vr_recovers_when_config_set(self):
+        """``config.convert_unknown_vr_to_UN = True`` parses the file with a
+        warning instead of raising.
+
+        Mirrors :data:`config.convert_wrong_length_to_UN` -- callers handling
+        in-flight studies with a single bad tag can opt in to a permissive
+        parse instead of losing the whole file. Default stays strict (the
+        previous test pins that).
+        """
+        original = config.convert_unknown_vr_to_UN
+        config.convert_unknown_vr_to_UN = True
+        try:
+            with pytest.warns(UserWarning, match="Setting VR to 'UN'"):
+                ds = dcmread(BytesIO(self._UNKNOWN_VR_FMI_BYTES), force=True)
+        finally:
+            config.convert_unknown_vr_to_UN = original
+
+        # The file parsed; the offending element is reachable on the file
+        # meta dataset (its VR may have been resolved from the dictionary
+        # after the UN fall-back, since (0002,0000) is a known tag -- the
+        # invariant we pin is "the file parsed", not "VR stays UN").
+        assert 0x00020000 in ds.file_meta
+
+    def test_read_partial_still_raises_notimplemented_on_unknown_vr(self):
+        """Internal callers below the public ``dcmread`` boundary continue
+        to see :class:`NotImplementedError` unchanged.
+
+        The translation in :func:`dcmread` is scoped to the public-API
+        boundary so internal callers (``read_partial``, ``read_dataset``,
+        ``read_file_meta_info``, the #503 implicit-VR retry inside
+        ``_read_file_meta_info``, ``util.fixer``) can keep relying on
+        catching ``NotImplementedError`` specifically.
+
+        Defends against a future regression where someone moves the
+        translation lower in the call stack and accidentally narrows the
+        exception type for those internal callers.
+        """
+        from pydicom.filereader import read_partial
+
+        with pytest.raises(NotImplementedError, match="'ZZ'"):
+            read_partial(
+                BytesIO(self._UNKNOWN_VR_FMI_BYTES),
+                stop_when=None,
+                defer_size=None,
+                force=True,
+            )
+
 
 class TestReadDataElement:
     def setup_method(self):

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -1235,8 +1235,8 @@ class TestUnknownVR:
         "00" * 128
         + "4449434d"  # 'DICM'
         + "02000000"  # tag (0002,0000)
-        + "5a5a"      # VR 'ZZ'
-        + "0400"      # length 4
+        + "5a5a"  # VR 'ZZ'
+        + "0400"  # length 4
         + "00000000"  # value
     )
 


### PR DESCRIPTION
Fixes #2336.

## Summary

[\`dcmread\`'s documented \`Raises\` contract](https://pydicom.github.io/pydicom/dev/reference/generated/pydicom.filereader.dcmread.html) is `InvalidDicomError` for malformed DICOM input. Unknown Value Representations (`ZZ`, `XX`, etc.) currently leak `NotImplementedError` through the public API. Callers handling malformed input have no single exception type to catch.

Same class of bug as #2330 (`RecursionError` on deep SQ, PR #2331) and #2332 (bare `OSError` on truncated SQ items, PR #2333).

## Two-prong fix (mirrors existing precedent)

1. **Permissive mode**. New `config.convert_unknown_vr_to_UN` (default `False`), mirroring `config.convert_wrong_length_to_UN`. When `True`, `raw_element_value` in [`hooks.py`](https://github.com/pydicom/pydicom/blob/main/src/pydicom/hooks.py) logs a warning, sets the element's VR to `UN`, and returns -- so a single malformed VR no longer prevents parsing the rest of the file.

2. **Contract narrowing**. Wrap the `read_partial` call inside `dcmread` ([`filereader.py`](https://github.com/pydicom/pydicom/blob/main/src/pydicom/filereader.py)) with `except NotImplementedError`, re-raising as `InvalidDicomError(...) from exc`. Applies when the flag is `False` (default) and only translates at the public-API boundary. Internal callers (`read_partial`, `read_dataset`, `read_file_meta_info`, the #503 implicit-VR retry inside `_read_file_meta_info`, `util.fixer`) continue to see `NotImplementedError` unchanged.

## Repro (from #2336)

```python
from io import BytesIO
import pydicom

raw = bytes.fromhex(
    "00" * 128
    + "4449434d"          # 'DICM'
    + "02000000"          # tag (0002,0000)
    + "5a5a"              # VR 'ZZ'
    + "0400"              # length 4
    + "00000000"          # value
)
pydicom.dcmread(BytesIO(raw), force=True)
```

Before: `NotImplementedError: Unknown Value Representation 'ZZ' in tag (0002,0000)`
After (default): `InvalidDicomError: Unknown Value Representation 'ZZ' in tag (0002,0000). To replace this error with a warning and parse the element as 'UN', set pydicom.config.convert_unknown_vr_to_UN = True.`
After (`config.convert_unknown_vr_to_UN = True`): parses with a `UserWarning`.

## Tests

Three new tests in `TestUnknownVR` in [`tests/test_filereader.py`](tests/test_filereader.py):

- `test_dcmread_raises_invaliddicom_on_unknown_vr` -- the contract is `InvalidDicomError`, original `NotImplementedError` chained via `__cause__`.
- `test_dcmread_unknown_vr_recovers_when_config_set` -- permissive mode parses with `UserWarning`, file_meta is materialised.
- `test_read_partial_still_raises_notimplemented_on_unknown_vr` -- internal callers (and the #503 implicit-VR retry inside `_read_file_meta_info`) continue to see `NotImplementedError`.

Existing `TestUnknownVR.test_fail_decode_msg` still passes -- that test exercises lazy attribute materialisation (`Dataset.__getitem__ -> _convert_value`), which the [issue body](https://github.com/pydicom/pydicom/issues/2336) explicitly leaves out of scope for separate follow-up.

## Release notes

Added a bullet under "Fixes" in `doc/release_notes/v3.1.0.rst`.