### PR TITLE
fix: handle embedded NUL in SpecificCharacterSet encoding (Fixes #2338)

### DIFF
--- a/src/pydicom/charset.py
+++ b/src/pydicom/charset.py
@@ -730,6 +730,13 @@ def _python_encoding_for_corrected_encoding(encoding: str) -> str:
             return default_encoding
 
     # fallback: assume that it is already a python encoding
+    # Pre-check for embedded NUL characters: codecs.lookup raises ValueError
+    # (not LookupError) on NUL-containing strings, which would leak out of
+    # dcmread's public contract.  See #2338.
+    if "\x00" in encoding:
+        _warn_about_invalid_encoding(encoding)
+        return default_encoding
+
     try:
         codecs.lookup(encoding)
         return encoding

--- a/tests/test_charset.py
+++ b/tests/test_charset.py
@@ -489,6 +489,35 @@ class TestCharset:
         with pytest.raises(LookupError, match="Unknown encoding 'ISO 2022 IR 146'"):
             pydicom.charset.decode_element(elem, ["ISO 2022 IR 100", "ISO 2022 IR 146"])
 
+    def test_embedded_null_in_encoding(self, allow_reading_invalid_values):
+        """Test that embedded NUL in SpecificCharacterSet does not raise
+        ValueError. Regression test for #2338."""
+        # leading NUL
+        elem = DataElement(0x00100010, "PN", b"Buc^J\xe9r\xf4me")
+        with pytest.warns(
+            UserWarning,
+            match=r"Unknown encoding .*ISO_IR 100.* using default encoding",
+        ):
+            pydicom.charset.decode_element(elem, ["\x00ISO_IR 100"])
+
+        # middle NUL
+        elem = DataElement(0x00100010, "PN", b"Buc^J\xe9r\xf4me")
+        with pytest.warns(
+            UserWarning,
+            match=r"Unknown encoding .*ISO.*IR 100.* using default encoding",
+        ):
+            pydicom.charset.decode_element(elem, ["ISO\x00_IR 100"])
+
+    def test_embedded_null_in_encoding_strict(self, enforce_valid_values):
+        """Test that embedded NUL in SpecificCharacterSet raises LookupError
+        (not ValueError) when reading_validation_mode is RAISE. #2338."""
+        elem = DataElement(0x00100010, "PN", b"Buc^J\xe9r\xf4me")
+        with pytest.raises(
+            LookupError,
+            match=r"Unknown encoding .*ISO_IR 100",
+        ):
+            pydicom.charset.decode_element(elem, ["\x00ISO_IR 100"])
+
     def test_japanese_multi_byte_personname(self):
         """Test japanese person name which has multi byte strings are
         correctly encoded."""


### PR DESCRIPTION
Fixes #2338

## Problem

`pydicom.dcmread(force=True)` raises `ValueError("embedded null character")` when `SpecificCharacterSet` (0008,0005) contains a NUL byte in a leading or middle position. The exception comes from `codecs.lookup` inside `_python_encoding_for_corrected_encoding` (`src/pydicom/charset.py`).

The existing `except LookupError` handler never fires because CPython's encoding-name normalisation raises `ValueError` (not `LookupError`) on NUL-containing strings. This violates `dcmread`'s documented exception contract.

## Solution

Add a pre-check for `"\x00" in encoding` before calling `codecs.lookup()` in `_python_encoding_for_corrected_encoding`. If a NUL is found, fall through to the same warn-and-fallback path used for truly unknown encodings. This is the narrowest fix that preserves the documented `convert_encodings` contract without changing any other value-decoding behaviour.

This follows the approach recommended in the issue (option 2) and is consistent with the pattern established in PR #2331 (RecursionError bound), PR #2333 (OSError on truncated SQ), and PR #2337 (NotImplementedError on unknown VR).

## Verification

```
$ python -m pytest tests/test_charset.py -v
59 passed in 0.30s

$ python -m pytest tests/test_charset.py tests/test_filereader.py -v
197 passed, 3 skipped in 8.92s
```

End-to-end test with the issue's reproduction script:
```
$ python -c "
import io, struct, pydicom, warnings
# ... (middle-NUL SpecificCharacterSet)
with warnings.catch_warnings():
    warnings.simplefilter('ignore')
    result = pydicom.dcmread(io.BytesIO(...), force=True)
    print(f'Success! SpecificCharacterSet: {result.SpecificCharacterSet!r}')
"
Success! SpecificCharacterSet: 'ISO\x00_IR 100'
No ValueError raised - fix works correctly.
```

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
