### PR TITLE
docs: clarify generate_uid entropy_srcs is not irreversible de-identification (#2341)

### DIFF
--- a/src/pydicom/uid.py
+++ b/src/pydicom/uid.py
@@ -572,12 +572,16 @@ def generate_uid(
         a prefix of ``'2.25.'`` will be used with the integer form of a UUID
         generated using the :func:`uuid.uuid4` algorithm.
     entropy_srcs : list of str, optional
-        If `prefix` is used then the `prefix` will be appended with a
-        SHA512 hash of the supplied :class:`list` which means the result is
-        deterministic and should make the original data unrecoverable. If
-        `entropy_srcs` isn't used then a random number from
-        :func:`secrets.randbelow` will be appended to the `prefix`. If `prefix`
-        is ``None`` then `entropy_srcs` has no effect.
+        If `prefix` is used then it is appended with a SHA512 hash of the
+        supplied :class:`list`. The result is *deterministic* -- the same
+        input always produces the same UID, which is useful for stable
+        remapping. Separately, SHA512 is a one-way hash, but note that it is
+        used here *unsalted*, so it offers no protection against brute-force
+        or dictionary recovery of low-entropy inputs and should not be relied
+        on as an irreversible de-identification mechanism. If `entropy_srcs`
+        isn't used then a random number from :func:`secrets.randbelow` will be
+        appended to the `prefix`. If `prefix` is ``None`` then `entropy_srcs`
+        has no effect.
 
     Returns
     -------


### PR DESCRIPTION
## Summary

Documentation-only fix for the `generate_uid` `entropy_srcs` parameter (#2341).

The current wording says the SHA512-hashed result *"is deterministic and should make the original data unrecoverable"*, which has two problems:

1. It links determinism and irreversibility as if one implies the other. They're independent — and a deterministic, unsalted mapping is exactly what makes a dictionary attack possible.
2. *"should make the original data unrecoverable"* overstates the guarantee. The hash is **unsalted and unkeyed**, so for low-entropy or enumerable inputs (patient IDs, dates, accession numbers, known source UIDs) the mapping is reversible by brute force — the algorithm is public:

   ```python
   for candidate in plausible_inputs:
       if generate_uid(entropy_srcs=[candidate]) == observed_uid:
           ...  # original recovered
   ```

This matters because users doing de-identification may rely on the "unrecoverable" wording for PHI.

## Change

Reword the `entropy_srcs` description to (a) present determinism and one-wayness as separate properties and (b) state plainly that the unsalted hash is not a safe de-identification mechanism for low-entropy inputs. No code change.

Fixes #2341

---
*AI-assisted, human-reviewed — I'm an AI engineer; I find, fix, and verify with AI, then review before opening under my name.*
