### PR TITLE
charset: don't leak ValueError from dcmread on NUL-bearing SpecificCharacterSet

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -49,6 +49,11 @@ Fixes
 * Fixed deepcopy of private blocks in :class:`~pydicom.dataset.Dataset` (:issue:`2294`)
 * Make float data elements with `NaN` value compare as equal - this is semantically better suited
   then the mathematical comparison, where `NaN != NaN` (:issue:`2273`)
+* Stopped :func:`~pydicom.filereader.dcmread` leaking ``ValueError("embedded null
+  character")`` when *Specific Character Set* (0008,0005) contains an embedded NUL byte;
+  such values now take the same warn-and-fall-back path as unknown encodings (or raise
+  :class:`LookupError` under ``RAISE`` validation), with the original exception message
+  included for clarity (:issue:`2338`)
 
 Enhancements
 ------------

--- a/src/pydicom/charset.py
+++ b/src/pydicom/charset.py
@@ -733,13 +733,26 @@ def _python_encoding_for_corrected_encoding(encoding: str) -> str:
     try:
         codecs.lookup(encoding)
         return encoding
-    except LookupError:
-        _warn_about_invalid_encoding(encoding)
+    except (LookupError, ValueError) as exc:
+        # ``LookupError`` is the normal "unknown encoding" signal.
+        # ``ValueError`` covers names that CPython's encoding-name
+        # normalisation rejects before lookup -- notably
+        # ``ValueError("embedded null character")`` for a NUL-bearing
+        # ``SpecificCharacterSet`` value. Both funnel into the same
+        # warn-and-use-default path so the public ``dcmread`` API does not
+        # surface an undocumented exception. The original exception is
+        # shown in the message so a ``ValueError`` from a third-party codec
+        # registered via ``codecs.register`` stays diagnosable rather than
+        # being silently swallowed.
+        _warn_about_invalid_encoding(encoding, cause=exc)
         return default_encoding
 
 
 def _warn_about_invalid_encoding(
-    encoding: str, patched_encoding: str | None = None
+    encoding: str,
+    patched_encoding: str | None = None,
+    *,
+    cause: Exception | None = None,
 ) -> None:
     """Issue a warning for the given invalid encoding.
     If patched_encoding is given, it is mentioned as the
@@ -747,12 +760,18 @@ def _warn_about_invalid_encoding(
     If no replacement encoding is given, and
     :attr:`~pydicom.config.settings.reading_validation_mode` is set to
     ``RAISE``, `LookupError` is raised.
+    If cause is given, its message is appended for clarity -- e.g. the
+    ``ValueError`` raised by ``codecs.lookup`` for a NUL-bearing name.
     """
     if patched_encoding is None:
+        detail = f" ({cause})" if cause is not None else ""
         if config.settings.reading_validation_mode == config.RAISE:
-            raise LookupError(f"Unknown encoding '{encoding}'")
+            raise LookupError(f"Unknown encoding '{encoding}'{detail}")
 
-        msg = f"Unknown encoding '{encoding}' - using default encoding instead"
+        msg = (
+            f"Unknown encoding '{encoding}' - using default encoding "
+            f"instead{detail}"
+        )
     else:
         msg = (
             f"Incorrect value for Specific Character Set '{encoding}' - "

--- a/src/pydicom/charset.py
+++ b/src/pydicom/charset.py
@@ -768,10 +768,7 @@ def _warn_about_invalid_encoding(
         if config.settings.reading_validation_mode == config.RAISE:
             raise LookupError(f"Unknown encoding '{encoding}'{detail}")
 
-        msg = (
-            f"Unknown encoding '{encoding}' - using default encoding "
-            f"instead{detail}"
-        )
+        msg = f"Unknown encoding '{encoding}' - using default encoding instead{detail}"
     else:
         msg = (
             f"Incorrect value for Specific Character Set '{encoding}' - "

--- a/tests/test_charset.py
+++ b/tests/test_charset.py
@@ -229,6 +229,63 @@ class TestCharset:
         encodings = None
         assert ["iso8859"] == pydicom.charset.convert_encodings(encodings)
 
+    @pytest.mark.parametrize(
+        "encoding",
+        ["\x00ISO_IR 100", "ISO\x00_IR 100", "ISO_IR 100\x00\x00", "X\x00Y"],
+        ids=["leading_null", "middle_null", "trailing_nulls", "minimal_middle"],
+    )
+    def test_convert_encoding_with_embedded_null(
+        self, encoding, allow_reading_invalid_values
+    ):
+        """Encoding names containing a NUL byte must funnel into the
+        same warn-and-fall-back path as unknown encodings rather than
+        leaking ``ValueError("embedded null character")`` from
+        ``codecs.lookup``. Parametrised over leading, middle, and
+        trailing NUL positions because each reaches the malformed-name
+        branch (the trailing case happens to be absorbed earlier by
+        ``valuerep.MultiString`` for the ``CS`` VR when reaching
+        ``convert_encodings`` via ``dcmread``, but the unit-level
+        contract on ``convert_encodings`` must still hold).
+        """
+        with pytest.warns(UserWarning, match="Unknown encoding"):
+            assert ["iso8859"] == pydicom.charset.convert_encodings(encoding)
+
+    @pytest.mark.parametrize(
+        "encoding",
+        ["\x00ISO_IR 100", "ISO\x00_IR 100", "ISO_IR 100\x00\x00", "X\x00Y"],
+        ids=["leading_null", "middle_null", "trailing_nulls", "minimal_middle"],
+    )
+    def test_convert_encoding_with_embedded_null_strict(
+        self, encoding, enforce_valid_values
+    ):
+        """Same NUL-bearing encodings under RAISE-mode validation
+        surface ``LookupError`` via ``_warn_about_invalid_encoding``
+        (the documented strict-mode contract for unknown encodings),
+        not the ``ValueError`` that ``codecs.lookup`` raises
+        internally for NUL-containing strings.
+        """
+        with pytest.raises(LookupError, match="Unknown encoding"):
+            pydicom.charset.convert_encodings(encoding)
+
+    def test_convert_encoding_null_surfaces_original_message(
+        self, allow_reading_invalid_values
+    ):
+        """The warning surfaces the original ``codecs.lookup`` exception
+        message so a malformed name -- or a ``ValueError`` from a
+        third-party codec registered via ``codecs.register`` -- stays
+        diagnosable rather than being silently swallowed by the widened
+        ``except (LookupError, ValueError)``.
+        """
+        with pytest.warns(UserWarning, match="embedded null character"):
+            assert ["iso8859"] == pydicom.charset.convert_encodings("ISO\x00_IR 100")
+
+    def test_convert_encoding_null_surfaces_original_message_strict(
+        self, enforce_valid_values
+    ):
+        """RAISE-mode ``LookupError`` likewise carries the original message."""
+        with pytest.raises(LookupError, match="embedded null character"):
+            pydicom.charset.convert_encodings("ISO\x00_IR 100")
+
     def test_bad_decoded_multi_byte_encoding(self, allow_reading_invalid_values):
         """Test handling bad encoding for single encoding"""
         elem = DataElement(

--- a/tests/test_charset.py
+++ b/tests/test_charset.py
@@ -1,6 +1,8 @@
 # Copyright 2008-2018 pydicom authors. See LICENSE file for details.
 """Unit tests for the pydicom.charset module."""
 
+import platform
+
 import pytest
 
 import pydicom.charset
@@ -9,6 +11,22 @@ from pydicom.data import get_charset_files, get_testdata_file
 from pydicom.dataelem import DataElement
 from pydicom.filebase import DicomBytesIO
 from pydicom.valuerep import PersonName
+
+# ``codecs.lookup`` raises ``ValueError("embedded null character")`` for a
+# NUL-bearing encoding name only on CPython, which rejects the NUL during
+# argument parsing -- before name normalisation (which strips the NUL) is
+# reached. PyPy performs no such pre-rejection: it normalises the name,
+# dropping the NUL, and looks up the stripped name, so the guarded
+# ``ValueError`` never arises and the warn-and-fall-back / RAISE contract
+# asserted below does not apply. The CPython jobs provide the coverage.
+skip_on_pypy_embedded_null = pytest.mark.skipif(
+    platform.python_implementation() == "PyPy",
+    reason=(
+        "codecs.lookup raises ValueError for a NUL-bearing encoding name "
+        "only on CPython; PyPy strips the NUL during name normalisation, "
+        "so the guarded ValueError never occurs"
+    ),
+)
 
 # The file names (without '.dcm' extension) of most of the character test
 # files, together with the respective decoded PatientName tag values.
@@ -229,6 +247,7 @@ class TestCharset:
         encodings = None
         assert ["iso8859"] == pydicom.charset.convert_encodings(encodings)
 
+    @skip_on_pypy_embedded_null
     @pytest.mark.parametrize(
         "encoding",
         ["\x00ISO_IR 100", "ISO\x00_IR 100", "ISO_IR 100\x00\x00", "X\x00Y"],
@@ -250,6 +269,7 @@ class TestCharset:
         with pytest.warns(UserWarning, match="Unknown encoding"):
             assert ["iso8859"] == pydicom.charset.convert_encodings(encoding)
 
+    @skip_on_pypy_embedded_null
     @pytest.mark.parametrize(
         "encoding",
         ["\x00ISO_IR 100", "ISO\x00_IR 100", "ISO_IR 100\x00\x00", "X\x00Y"],
@@ -267,6 +287,7 @@ class TestCharset:
         with pytest.raises(LookupError, match="Unknown encoding"):
             pydicom.charset.convert_encodings(encoding)
 
+    @skip_on_pypy_embedded_null
     def test_convert_encoding_null_surfaces_original_message(
         self, allow_reading_invalid_values
     ):
@@ -279,6 +300,7 @@ class TestCharset:
         with pytest.warns(UserWarning, match="embedded null character"):
             assert ["iso8859"] == pydicom.charset.convert_encodings("ISO\x00_IR 100")
 
+    @skip_on_pypy_embedded_null
     def test_convert_encoding_null_surfaces_original_message_strict(
         self, enforce_valid_values
     ):

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -1270,15 +1270,11 @@ class TestSpecificCharacterSetWithEmbeddedNull:
         preamble = b"\x00" * 128 + b"DICM"
         meta = b""
         meta += explicit(0x0002, 0x0001, b"OB", b"\x00\x01")
-        meta += explicit(
-            0x0002, 0x0002, b"UI", b"1.2.840.10008.5.1.4.1.1.7\x00"
-        )
+        meta += explicit(0x0002, 0x0002, b"UI", b"1.2.840.10008.5.1.4.1.1.7\x00")
         meta += explicit(0x0002, 0x0003, b"UI", b"1.2.3.4\x00")
         meta += explicit(0x0002, 0x0010, b"UI", b"1.2.840.10008.1.2\x00")
         meta += explicit(0x0002, 0x0012, b"UI", b"1.2.3\x00")
-        group_length = explicit(
-            0x0002, 0x0000, b"UL", struct.pack("<I", len(meta))
-        )
+        group_length = explicit(0x0002, 0x0000, b"UL", struct.pack("<I", len(meta)))
         ds_elements = implicit(0x0008, 0x0005, scs_value)
         return preamble + group_length + meta + ds_elements
 

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -6,6 +6,7 @@ import io
 from io import BytesIO
 import logging
 import os
+import platform
 import shutil
 from pathlib import Path
 from struct import unpack
@@ -1224,6 +1225,14 @@ class TestUnknownVR:
         assert "Unknown VR '0x7878' assuming implicit VR encoding" in caplog.text
 
 
+@pytest.mark.skipif(
+    platform.python_implementation() == "PyPy",
+    reason=(
+        "codecs.lookup raises ValueError for a NUL-bearing encoding name "
+        "only on CPython; PyPy strips the NUL during name normalisation, "
+        "so the guarded ValueError never reaches dcmread"
+    ),
+)
 class TestSpecificCharacterSetWithEmbeddedNull:
     """End-to-end contract: ``dcmread(force=True)`` must not leak
     ``ValueError("embedded null character")`` from ``codecs.lookup`` when

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -1224,6 +1224,85 @@ class TestUnknownVR:
         assert "Unknown VR '0x7878' assuming implicit VR encoding" in caplog.text
 
 
+class TestSpecificCharacterSetWithEmbeddedNull:
+    """End-to-end contract: ``dcmread(force=True)`` must not leak
+    ``ValueError("embedded null character")`` from ``codecs.lookup`` when
+    ``SpecificCharacterSet`` (0008,0005) contains a NUL byte.
+
+    The unit-level invariant is also pinned in
+    :class:`tests.test_charset.TestCharset.test_convert_encoding_with_embedded_null`;
+    this class exercises the public ``dcmread`` API directly so a future
+    refactor of the ``dcmread`` -> ``convert_encodings`` call chain cannot
+    regress the public contract without test failure.
+
+    Note: trailing NULs are absorbed by ``valuerep.MultiString``'s NUL
+    stripping before they reach ``convert_encodings``, so the realistic
+    adversarial cases are NULs in leading or middle positions.
+    """
+
+    @staticmethod
+    def _build_file_with_scs(scs_value: bytes) -> bytes:
+        """Build the minimal forced-read DICOM bytestream with the given
+        raw ``SpecificCharacterSet`` value (Implicit VR Little Endian
+        body so the CS value is stored verbatim without VR-level
+        validation)."""
+        import struct
+
+        def explicit(group: int, elem: int, vr: bytes, value: bytes) -> bytes:
+            if vr in (b"OB",):
+                return (
+                    struct.pack("<HH", group, elem)
+                    + vr
+                    + b"\x00\x00"
+                    + struct.pack("<I", len(value))
+                    + value
+                )
+            return (
+                struct.pack("<HH", group, elem)
+                + vr
+                + struct.pack("<H", len(value))
+                + value
+            )
+
+        def implicit(group: int, elem: int, value: bytes) -> bytes:
+            return struct.pack("<HHI", group, elem, len(value)) + value
+
+        preamble = b"\x00" * 128 + b"DICM"
+        meta = b""
+        meta += explicit(0x0002, 0x0001, b"OB", b"\x00\x01")
+        meta += explicit(
+            0x0002, 0x0002, b"UI", b"1.2.840.10008.5.1.4.1.1.7\x00"
+        )
+        meta += explicit(0x0002, 0x0003, b"UI", b"1.2.3.4\x00")
+        meta += explicit(0x0002, 0x0010, b"UI", b"1.2.840.10008.1.2\x00")
+        meta += explicit(0x0002, 0x0012, b"UI", b"1.2.3\x00")
+        group_length = explicit(
+            0x0002, 0x0000, b"UL", struct.pack("<I", len(meta))
+        )
+        ds_elements = implicit(0x0008, 0x0005, scs_value)
+        return preamble + group_length + meta + ds_elements
+
+    @pytest.mark.parametrize(
+        "scs_value",
+        [b"\x00ISO_IR 100", b"ISO\x00_IR 100"],
+        ids=["leading_null", "middle_null"],
+    )
+    def test_dcmread_does_not_leak_value_error(self, scs_value):
+        """Leading- and middle-NUL CS values reach ``codecs.lookup``
+        through ``dcmread`` and previously raised
+        ``ValueError("embedded null character")``. After the fix
+        they fall through to the default encoding with a warning,
+        matching the established behaviour for unknown encodings.
+        """
+        data = self._build_file_with_scs(scs_value)
+        with pytest.warns(UserWarning, match="Unknown encoding"):
+            ds = dcmread(BytesIO(data), force=True)
+        # The file parsed: the dataset is reachable. We do not pin
+        # the exact SCS value (``valuerep`` may strip leading NULs in
+        # the future); only that ``dcmread`` returned without raising.
+        assert ds is not None
+
+
 class TestReadDataElement:
     def setup_method(self):
         ds = Dataset()


### PR DESCRIPTION
Fixes #2338.

`_python_encoding_for_corrected_encoding` catches `LookupError` around `codecs.lookup`, but `codecs.lookup` raises `ValueError("embedded null character")` for a NUL-containing name. A *Specific Character Set* (0008,0005) value with an embedded NUL therefore leaks `ValueError` out of `dcmread`, contrary to the `LookupError`-only contract documented on `convert_encodings`.

Per your preference on the issue (option 1, with the original exception message shown for clarity), this widens the fallback `except LookupError` to `except (LookupError, ValueError)` so malformed names take the same warn-and-fall-back path as unknown encodings, and appends the original exception message to the warning (and to the strict-mode `LookupError`). Surfacing the original message keeps a `ValueError` from a third-party codec registered via `codecs.register` diagnosable rather than silently swallowed -- the concern raised against a bare widen in the issue.

Behaviour:
- default validation: `UserWarning("Unknown encoding '...' - using default encoding instead (embedded null character)")` and a parsed dataset.
- `RAISE` validation: `LookupError("Unknown encoding '...' (embedded null character)")`.

Only leading/middle NULs reach this path; trailing NULs are already absorbed by `valuerep` sanitisation before `convert_encodings` (the residual of #940).

Tests: `test_charset.py` covers leading/middle/trailing NUL positions in both validation modes plus a surfaced-message assertion; `test_filereader.py` exercises `dcmread(force=True)` end-to-end. Release note added under 3.1.0 Fixes.

One open question: the detail is currently appended for both the `ValueError` branch and the ordinary unknown-encoding `LookupError` branch. Would you prefer it scoped to only the `ValueError` case, to leave the existing unknown-encoding message unchanged?