### PR TITLE
docs: clarify generate_uid entropy_srcs is deterministic but unsalted

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -14,6 +14,10 @@ Changes
   per-frame metadata to help account for inter-frame variations in frame properties
   when decoding.
 * Apply PEP 735 to build environment. It modifies how build dependencies are installed.
+* Clarified the :func:`~pydicom.uid.generate_uid` ``entropy_srcs`` docstring: the
+  hash is deterministic but unsalted, so it provides no protection against
+  brute-force recovery of low-entropy inputs and should not be relied upon as an
+  irreversible de-identification mechanism (:issue:`2341`).
 
 Fixes
 -----

--- a/src/pydicom/uid.py
+++ b/src/pydicom/uid.py
@@ -573,11 +573,15 @@ def generate_uid(
         generated using the :func:`uuid.uuid4` algorithm.
     entropy_srcs : list of str, optional
         If `prefix` is used then the `prefix` will be appended with a
-        SHA512 hash of the supplied :class:`list` which means the result is
-        deterministic and should make the original data unrecoverable. If
-        `entropy_srcs` isn't used then a random number from
-        :func:`secrets.randbelow` will be appended to the `prefix`. If `prefix`
-        is ``None`` then `entropy_srcs` has no effect.
+        SHA512 hash of the supplied :class:`list`. The result is deterministic
+        (the same input always produces the same UID), which is useful for
+        stable remapping. SHA512 is a one-way hash, but it is applied here
+        without a salt, so it provides no protection against brute-force or
+        dictionary attacks on low-entropy inputs and should not be relied upon
+        as an irreversible de-identification mechanism. If `entropy_srcs`
+        isn't used then a random number from :func:`secrets.randbelow` will be
+        appended to the `prefix`. If `prefix` is ``None`` then `entropy_srcs`
+        has no effect.
 
     Returns
     -------


### PR DESCRIPTION
## Summary

Documentation-only fix for the `generate_uid` `entropy_srcs` parameter (#2341).

The current wording says the SHA512-hashed result *"is deterministic and should make the original data unrecoverable"*, which has two problems:

1. **It implies determinism and irrecoverability are linked.** They're independent — and a deterministic, unsalted mapping is precisely what enables a brute-force/dictionary attack.
2. **"should make the original data unrecoverable" overstates the guarantee.** The hash is unsalted and unkeyed, so low-entropy or enumerable inputs (patient IDs, dates, accession numbers, known source UIDs) are recoverable by hashing candidate inputs against the public algorithm.

## Change

- Reworded the `entropy_srcs` parameter docstring to decouple determinism from irreversibility and to state plainly that the unsalted hash offers no protection against brute-force recovery and should not be relied on as an irreversible de-identification mechanism.
- Added a release note under *Changes* in `doc/release_notes/v3.1.0.rst`.

Closes #2341

🤖 Generated with [Claude Code](https://claude.com/claude-code)