### PR TITLE
fix-fileset-uid-property-annotation with Python 3.14

### DIFF
--- a/src/pydicom/fileset.py
+++ b/src/pydicom/fileset.py
@@ -2029,12 +2029,12 @@ class FileSet:
         return "\n".join(s)
 
     @property
-    def UID(self) -> UID:
+    def UID(self) -> sop.UID:
         """Return the File-set's UID."""
-        return cast(UID, self._uid)
+        return cast(sop.UID, self._uid)
 
     @UID.setter
-    def UID(self, uid: UID) -> None:
+    def UID(self, uid: sop.UID) -> None:
         """Set the File-set UID.
 
         Parameters

--- a/src/pydicom/pixels/common.py
+++ b/src/pydicom/pixels/common.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 
 from pydicom.misc import warn_and_log
 from pydicom.pixels.utils import as_pixel_options
+import pydicom.uid as sop
 from pydicom.uid import UID
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -194,7 +195,7 @@ class CoderBase:
             raise ValueError(f"Unable to remove '{label}', no such plugin'")
 
     @property
-    def UID(self) -> UID:
+    def UID(self) -> sop.UID:
         """Return the corresponding *Transfer Syntax UID* as :class:`~pydicom.uid.UID`."""  # noqa: E501
         return self._uid
 


### PR DESCRIPTION
Python 3.14 may resolve the UID annotation of a property named UID to the property object itself. This causes Sphinx autodoc to include the property object's memory address in the generated documentation, resulting in architecture-dependent documentation and FTBR failures.

Use an explicitly qualified UID type for the affected UID properties in FileSet and CoderBase to avoid the name collision.


#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better

Closes: #2357