### PR TITLE
Apply modality rescale from functional groups

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -49,6 +49,8 @@ Fixes
 * Fixed deepcopy of private blocks in :class:`~pydicom.dataset.Dataset` (:issue:`2294`)
 * Make float data elements with `NaN` value compare as equal - this is semantically better suited
   then the mathematical comparison, where `NaN != NaN` (:issue:`2273`)
+* Apply shared and per-frame *Pixel Value Transformation* functional groups in
+  :func:`~pydicom.pixels.apply_modality_lut` (:issue:`2353`).
 
 Enhancements
 ------------

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -49,8 +49,10 @@ Fixes
 * Fixed deepcopy of private blocks in :class:`~pydicom.dataset.Dataset` (:issue:`2294`)
 * Make float data elements with `NaN` value compare as equal - this is semantically better suited
   then the mathematical comparison, where `NaN != NaN` (:issue:`2273`)
-* Apply shared and per-frame *Pixel Value Transformation* functional groups in
-  :func:`~pydicom.pixels.apply_modality_lut` (:issue:`2353`).
+* Apply shared and per-frame *Pixel Value Transformation* and *Frame VOI LUT*
+  functional groups in :func:`~pydicom.pixels.apply_modality_lut`,
+  :func:`~pydicom.pixels.apply_voi_lut`, and :func:`~pydicom.pixels.apply_windowing`,
+  including support for selecting per-frame parameters by slice number (:issue:`2353`).
 
 Enhancements
 ------------

--- a/src/pydicom/pixels/processing.py
+++ b/src/pydicom/pixels/processing.py
@@ -39,6 +39,26 @@ _CMS_INTENTS = {
 }
 
 
+def _get_rescale_parameters(ds: "Dataset") -> tuple[float, float] | None:
+    """Return the rescale slope and intercept in `ds`, if present."""
+    if "RescaleSlope" in ds and "RescaleIntercept" in ds:
+        return cast(float, ds.RescaleSlope), cast(float, ds.RescaleIntercept)
+
+    return None
+
+
+def _get_functional_group_rescale(
+    group: "Dataset",
+) -> tuple[float, float] | None:
+    """Return rescale parameters from a Pixel Value Transformation macro."""
+    sequence = group.get("PixelValueTransformationSequence")
+    if not sequence:
+        return None
+
+    item = cast(list["Dataset"], sequence)[0]
+    return _get_rescale_parameters(item)
+
+
 def apply_color_lut(
     arr: "np.ndarray", ds: "Dataset | None" = None, palette: str | UID | None = None
 ) -> "np.ndarray":
@@ -348,7 +368,9 @@ def apply_modality_lut(arr: "np.ndarray", ds: "Dataset") -> "np.ndarray":
         operation to.
     ds : dataset.Dataset
         A dataset containing a :dcm:`Modality LUT Module
-        <part03/sect_C.11.html#sect_C.11.1>`.
+        <part03/sect_C.11.html#sect_C.11.1>` or a :dcm:`Pixel Value
+        Transformation Functional Group
+        <part03/sect_C.7.6.16.2.html#sect_C.7.6.16.2.9>`.
 
     Returns
     -------
@@ -357,9 +379,17 @@ def apply_modality_lut(arr: "np.ndarray", ds: "Dataset") -> "np.ndarray":
         (0028,3000) *Modality LUT Sequence* is present then returns an array
         of ``np.uint8`` or ``np.uint16``, depending on the 3rd value of
         (0028,3002) *LUT Descriptor*. If (0028,1052) *Rescale Intercept* and
-        (0028,1053) *Rescale Slope* are present then returns an array of
-        ``np.float64``. If neither are present then `arr` will be returned
-        unchanged.
+        (0028,1053) *Rescale Slope* are present, either at the dataset level
+        or in a shared or per-frame *Pixel Value Transformation Sequence*,
+        then returns an array of ``np.float64``. If none are present then
+        `arr` will be returned unchanged.
+
+    Raises
+    ------
+    ValueError
+        If per-frame rescale parameters are present and the number of frame
+        functional groups does not match (0028,0008) *Number of Frames* or
+        the number of frames in `arr`.
 
     Notes
     -----
@@ -369,10 +399,15 @@ def apply_modality_lut(arr: "np.ndarray", ds: "Dataset") -> "np.ndarray":
     max. pixel value are determined from (0028,0101) *Bits Stored* and
     (0028,0103) *Pixel Representation*.
 
+    For multi-frame pixel data, `arr` should use the pydicom convention of
+    ``(frames, rows, columns)`` or ``(frames, rows, columns, samples)``.
+
     References
     ----------
     * DICOM Standard, Part 3, :dcm:`Annex C.11.1
       <part03/sect_C.11.html#sect_C.11.1>`
+    * DICOM Standard, Part 3, :dcm:`Section C.7.6.16.2.9
+      <part03/sect_C.7.6.16.2.html#sect_C.7.6.16.2.9>`
     * DICOM Standard, Part 4, :dcm:`Annex N.2.1.1
       <part04/sect_N.2.html#sect_N.2.1.1>`
     """
@@ -417,9 +452,60 @@ def apply_modality_lut(arr: "np.ndarray", ds: "Dataset") -> "np.ndarray":
         np.clip(clipped_iv, 0, nr_entries - 1, out=clipped_iv)
 
         return lut_data[clipped_iv]
-    elif "RescaleSlope" in ds and "RescaleIntercept" in ds:
-        arr = arr.astype(np.float64) * cast(float, ds.RescaleSlope)
-        arr += cast(float, ds.RescaleIntercept)
+    rescale = _get_rescale_parameters(ds)
+    if rescale is not None:
+        slope, intercept = rescale
+        arr = arr.astype(np.float64) * slope
+        arr += intercept
+        return arr
+
+    shared = cast(list["Dataset"], ds.get("SharedFunctionalGroupsSequence", []))
+    if shared:
+        rescale = _get_functional_group_rescale(shared[0])
+        if rescale is not None:
+            slope, intercept = rescale
+            arr = arr.astype(np.float64) * slope
+            arr += intercept
+            return arr
+
+    per_frame = cast(list["Dataset"], ds.get("PerFrameFunctionalGroupsSequence", []))
+    if not per_frame:
+        return arr
+
+    transforms = [_get_functional_group_rescale(group) for group in per_frame]
+    if not any(transform is not None for transform in transforms):
+        return arr
+
+    nr_frames = len(per_frame)
+    declared_frames = ds.get("NumberOfFrames")
+    if declared_frames is not None and int(declared_frames) != nr_frames:
+        raise ValueError(
+            f"The number of frame functional groups ({nr_frames}) does not "
+            f"match the dataset's Number of Frames ({declared_frames})"
+        )
+
+    if nr_frames > 1:
+        arr_frames = arr.shape[0] if arr.ndim >= 3 else 1
+        if nr_frames != arr_frames:
+            raise ValueError(
+                f"The number of frame functional groups ({nr_frames}) does not "
+                f"match the number of frames in the array ({arr_frames})"
+            )
+
+    arr = arr.astype(np.float64)
+    if nr_frames == 1:
+        slope, intercept = cast(tuple[float, float], transforms[0])
+        arr *= slope
+        arr += intercept
+        return arr
+
+    for idx, transform in enumerate(transforms):
+        if transform is None:
+            continue
+
+        slope, intercept = transform
+        arr[idx] *= slope
+        arr[idx] += intercept
 
     return arr
 

--- a/src/pydicom/pixels/processing.py
+++ b/src/pydicom/pixels/processing.py
@@ -1032,10 +1032,7 @@ def apply_windowing(
         return _apply_windowing(arr, ds, voi, index, rescale)
 
     if not uses_per_frame:
-        if base_voi is None:
-            return arr
-
-        return _apply_windowing(arr, ds, base_voi, index, base_rescale)
+        return _apply_windowing(arr, ds, cast("Dataset", base_voi), index, base_rescale)
 
     nr_frames = len(per_frame)
     declared_frames = ds.get("NumberOfFrames")
@@ -1054,10 +1051,7 @@ def apply_windowing(
             )
 
     if nr_frames == 1:
-        voi = base_voi or frame_voi[0]
-        if voi is None:
-            return arr
-
+        voi = cast("Dataset", base_voi or frame_voi[0])
         return _apply_windowing(arr, ds, voi, index, base_rescale or frame_rescale[0])
 
     out = arr.astype("float64")

--- a/src/pydicom/pixels/processing.py
+++ b/src/pydicom/pixels/processing.py
@@ -41,8 +41,10 @@ _CMS_INTENTS = {
 
 def _get_rescale_parameters(ds: "Dataset") -> tuple[float, float] | None:
     """Return the rescale slope and intercept in `ds`, if present."""
-    if "RescaleSlope" in ds and "RescaleIntercept" in ds:
-        return cast(float, ds.RescaleSlope), cast(float, ds.RescaleIntercept)
+    slope = ds.get("RescaleSlope", None)
+    intercept = ds.get("RescaleIntercept", None)
+    if slope is not None and intercept is not None:
+        return cast(float, slope), cast(float, intercept)
 
     return None
 
@@ -57,6 +59,23 @@ def _get_functional_group_rescale(
 
     item = cast(list["Dataset"], sequence)[0]
     return _get_rescale_parameters(item)
+
+
+def _get_functional_group_voi(group: "Dataset") -> "Dataset | None":
+    """Return the Frame VOI LUT macro item in `group`, if present."""
+    sequence = group.get("FrameVOILUTSequence")
+    if not sequence:
+        return None
+
+    return cast(list["Dataset"], sequence)[0]
+
+
+def _has_windowing(ds: "Dataset") -> bool:
+    """Return ``True`` if `ds` contains valid windowing parameters."""
+    return None not in [
+        ds.get("WindowCenter", None),
+        ds.get("WindowWidth", None),
+    ]
 
 
 def apply_color_lut(
@@ -358,7 +377,9 @@ def apply_icc_profile(
     return arr
 
 
-def apply_modality_lut(arr: "np.ndarray", ds: "Dataset") -> "np.ndarray":
+def apply_modality_lut(
+    arr: "np.ndarray", ds: "Dataset", slice_number: int | None = None
+) -> "np.ndarray":
     """Apply a modality lookup table or rescale operation to `arr`.
 
     Parameters
@@ -371,6 +392,10 @@ def apply_modality_lut(arr: "np.ndarray", ds: "Dataset") -> "np.ndarray":
         <part03/sect_C.11.html#sect_C.11.1>` or a :dcm:`Pixel Value
         Transformation Functional Group
         <part03/sect_C.7.6.16.2.html#sect_C.7.6.16.2.9>`.
+    slice_number : int, optional
+        The zero-based frame number whose per-frame transformation should be
+        applied to `arr`. If not supplied then all per-frame transformations
+        are applied in frame order.
 
     Returns
     -------
@@ -484,6 +509,22 @@ def apply_modality_lut(arr: "np.ndarray", ds: "Dataset") -> "np.ndarray":
             f"match the dataset's Number of Frames ({declared_frames})"
         )
 
+    if slice_number is not None:
+        if slice_number < 0 or slice_number >= nr_frames:
+            raise IndexError(
+                f"The slice number ({slice_number}) is outside the available "
+                f"frame range (0 to {nr_frames - 1})"
+            )
+
+        transform = transforms[slice_number]
+        if transform is None:
+            return arr
+
+        slope, intercept = transform
+        arr = arr.astype(np.float64) * slope
+        arr += intercept
+        return arr
+
     if nr_frames > 1:
         arr_frames = arr.shape[0] if arr.ndim >= 3 else 1
         if nr_frames != arr_frames:
@@ -590,7 +631,11 @@ apply_rescale = apply_modality_lut
 
 
 def apply_voi_lut(
-    arr: "np.ndarray", ds: "Dataset", index: int = 0, prefer_lut: bool = True
+    arr: "np.ndarray",
+    ds: "Dataset",
+    index: int = 0,
+    prefer_lut: bool = True,
+    slice_number: int | None = None,
 ) -> "np.ndarray":
     """Apply a VOI lookup table or windowing operation to `arr`.
 
@@ -618,6 +663,10 @@ def apply_voi_lut(
         When the VOI LUT Module contains both *Window Width*/*Window Center*
         and *VOI LUT Sequence*, if ``True`` (default) then apply the VOI LUT,
         otherwise apply the windowing operation.
+    slice_number : int, optional
+        The zero-based frame number whose per-frame Frame VOI LUT parameters
+        should be applied to `arr`. If not supplied then all per-frame
+        parameters are applied in frame order.
 
     Returns
     -------
@@ -652,22 +701,32 @@ def apply_voi_lut(
             ds.VOILUTSequence[0].get("LUTDescriptor", None),
             ds.VOILUTSequence[0].get("LUTData", None),
         ]
-    valid_windowing = None not in [
-        ds.get("WindowCenter", None),
-        ds.get("WindowWidth", None),
-    ]
+    valid_windowing = _has_windowing(ds)
+    if not valid_windowing:
+        shared = cast(list["Dataset"], ds.get("SharedFunctionalGroupsSequence", []))
+        shared_voi = _get_functional_group_voi(shared[0]) if shared else None
+        valid_windowing = shared_voi is not None and _has_windowing(shared_voi)
+
+    if not valid_windowing:
+        per_frame = cast(
+            list["Dataset"], ds.get("PerFrameFunctionalGroupsSequence", [])
+        )
+        valid_windowing = any(
+            voi is not None and _has_windowing(voi)
+            for voi in (_get_functional_group_voi(group) for group in per_frame)
+        )
 
     if valid_voi and valid_windowing:
         if prefer_lut:
             return apply_voi(arr, ds, index)
 
-        return apply_windowing(arr, ds, index)
+        return apply_windowing(arr, ds, index, slice_number)
 
     if valid_voi:
         return apply_voi(arr, ds, index)
 
     if valid_windowing:
-        return apply_windowing(arr, ds, index)
+        return apply_windowing(arr, ds, index, slice_number)
 
     return arr
 
@@ -773,53 +832,14 @@ def apply_voi(arr: "np.ndarray", ds: "Dataset", index: int = 0) -> "np.ndarray":
     return cast("np.ndarray", lut_data[clipped_iv])
 
 
-def apply_windowing(arr: "np.ndarray", ds: "Dataset", index: int = 0) -> "np.ndarray":
-    """Apply a windowing operation to `arr`.
-
-    .. versionadded:: 2.1
-
-    Parameters
-    ----------
-    arr : numpy.ndarray
-        The :class:`~numpy.ndarray` to apply the windowing operation to.
-    ds : dataset.Dataset
-        A dataset containing a :dcm:`VOI LUT Module<part03/sect_C.11.2.html>`.
-        If (0028,1050) *Window Center* and (0028,1051) *Window Width* are
-        present then returns an array of ``np.float64``, otherwise `arr` will
-        be returned unchanged.
-    index : int, optional
-        When the VOI LUT Module contains multiple alternative views, this is
-        the index of the view to return (default ``0``).
-
-    Returns
-    -------
-    numpy.ndarray
-        An array with applied windowing operation.
-
-    Notes
-    -----
-    When the dataset requires a modality LUT or rescale operation as part of
-    the Modality LUT module then that must be applied before any windowing
-    operation.
-
-    See Also
-    --------
-    :func:`~pydicom.pixels.processing.apply_modality_lut`
-    :func:`~pydicom.pixels.processing.apply_voi`
-    :func:`~pydicom.pixels.processing.apply_voi_lut`
-
-    References
-    ----------
-    * DICOM Standard, Part 3, :dcm:`Annex C.11.2
-      <part03/sect_C.11.html#sect_C.11.2>`
-    * DICOM Standard, Part 3, :dcm:`Annex C.8.11.3.1.5
-      <part03/sect_C.8.11.3.html#sect_C.8.11.3.1.5>`
-    * DICOM Standard, Part 4, :dcm:`Annex N.2.1.1
-      <part04/sect_N.2.html#sect_N.2.1.1>`
-    """
-    if "WindowWidth" not in ds and "WindowCenter" not in ds:
-        return arr
-
+def _apply_windowing(
+    arr: "np.ndarray",
+    ds: "Dataset",
+    voi: "Dataset",
+    index: int,
+    rescale: tuple[float, float] | None,
+) -> "np.ndarray":
+    """Apply windowing using `voi` and image metadata from `ds`."""
     if ds.PhotometricInterpretation not in ["MONOCHROME1", "MONOCHROME2"]:
         raise ValueError(
             "When performing a windowing operation only 'MONOCHROME1' and "
@@ -828,18 +848,18 @@ def apply_windowing(arr: "np.ndarray", ds: "Dataset", index: int = 0) -> "np.nda
         )
 
     # May be LINEAR (default), LINEAR_EXACT, SIGMOID or not present, VM 1
-    voi_func = cast(str, getattr(ds, "VOILUTFunction", "LINEAR")).upper()
+    voi_func = cast(str, getattr(voi, "VOILUTFunction", "LINEAR")).upper()
     # VR DS, VM 1-n
-    elem = ds["WindowCenter"]
+    elem = voi["WindowCenter"]
     center = cast(list[float], elem.value)[index] if elem.VM > 1 else elem.value
     center = cast(float, center)
-    elem = ds["WindowWidth"]
+    elem = voi["WindowWidth"]
     width = cast(list[float], elem.value)[index] if elem.VM > 1 else elem.value
     width = cast(float, width)
 
     # The output range depends on whether or not a modality LUT or rescale
-    #   operation has been applied
-    ds.BitsStored = cast(int, ds.BitsStored)
+    # operation has been applied
+    bits_stored = cast(int, ds.BitsStored)
     y_min: float
     y_max: float
     if ds.get("ModalityLUTSequence"):
@@ -851,20 +871,16 @@ def apply_windowing(arr: "np.ndarray", ds: "Dataset", index: int = 0) -> "np.nda
     elif ds.PixelRepresentation == 0:
         # Unsigned
         y_min = 0
-        y_max = 2**ds.BitsStored - 1
+        y_max = 2**bits_stored - 1
     else:
         # Signed
-        y_min = -(2 ** (ds.BitsStored - 1))
-        y_max = 2 ** (ds.BitsStored - 1) - 1
+        y_min = -(2 ** (bits_stored - 1))
+        y_max = 2 ** (bits_stored - 1) - 1
 
-    slope = ds.get("RescaleSlope", None)
-    intercept = ds.get("RescaleIntercept", None)
-    if slope is not None and intercept is not None:
-        ds.RescaleSlope = cast(float, ds.RescaleSlope)
-        ds.RescaleIntercept = cast(float, ds.RescaleIntercept)
-        # Otherwise its the actual data range
-        y_min = y_min * ds.RescaleSlope + ds.RescaleIntercept
-        y_max = y_max * ds.RescaleSlope + ds.RescaleIntercept
+    if rescale is not None:
+        slope, intercept = rescale
+        y_min = y_min * slope + intercept
+        y_max = y_max * slope + intercept
 
     y_range = y_max - y_min
     arr = arr.astype("float64")
@@ -906,6 +922,154 @@ def apply_windowing(arr: "np.ndarray", ds: "Dataset", index: int = 0) -> "np.nda
         raise ValueError(f"Unsupported (0028,1056) VOI LUT Function value '{voi_func}'")
 
     return arr
+
+
+def apply_windowing(
+    arr: "np.ndarray",
+    ds: "Dataset",
+    index: int = 0,
+    slice_number: int | None = None,
+) -> "np.ndarray":
+    """Apply a windowing operation to `arr`.
+
+    .. versionadded:: 2.1
+
+    Parameters
+    ----------
+    arr : numpy.ndarray
+        The :class:`~numpy.ndarray` to apply the windowing operation to.
+    ds : dataset.Dataset
+        A dataset containing a :dcm:`VOI LUT Module<part03/sect_C.11.2.html>`.
+        If (0028,1050) *Window Center* and (0028,1051) *Window Width* are
+        present then returns an array of ``np.float64``, otherwise `arr` will
+        be returned unchanged.
+    index : int, optional
+        When the VOI LUT Module contains multiple alternative views, this is
+        the index of the view to return (default ``0``).
+    slice_number : int, optional
+        The zero-based frame number whose per-frame Frame VOI LUT parameters
+        should be applied to `arr`. If not supplied then all per-frame
+        parameters are applied in frame order.
+
+    Returns
+    -------
+    numpy.ndarray
+        An array with applied windowing operation.
+
+    Notes
+    -----
+    When the dataset requires a modality LUT or rescale operation as part of
+    the Modality LUT module then that must be applied before any windowing
+    operation.
+
+    See Also
+    --------
+    :func:`~pydicom.pixels.processing.apply_modality_lut`
+    :func:`~pydicom.pixels.processing.apply_voi`
+    :func:`~pydicom.pixels.processing.apply_voi_lut`
+
+    References
+    ----------
+    * DICOM Standard, Part 3, :dcm:`Annex C.11.2
+      <part03/sect_C.11.html#sect_C.11.2>`
+    * DICOM Standard, Part 3, :dcm:`Annex C.8.11.3.1.5
+      <part03/sect_C.8.11.3.html#sect_C.8.11.3.1.5>`
+    * DICOM Standard, Part 4, :dcm:`Annex N.2.1.1
+      <part04/sect_N.2.html#sect_N.2.1.1>`
+    """
+    top_voi = ds if _has_windowing(ds) else None
+    top_rescale = _get_rescale_parameters(ds)
+
+    shared = cast(list["Dataset"], ds.get("SharedFunctionalGroupsSequence", []))
+    shared_group = shared[0] if shared else None
+    shared_voi = (
+        _get_functional_group_voi(shared_group) if shared_group is not None else None
+    )
+    if shared_voi is not None and not _has_windowing(shared_voi):
+        shared_voi = None
+    shared_rescale = (
+        _get_functional_group_rescale(shared_group)
+        if shared_group is not None
+        else None
+    )
+
+    per_frame = cast(list["Dataset"], ds.get("PerFrameFunctionalGroupsSequence", []))
+    frame_voi = [_get_functional_group_voi(group) for group in per_frame]
+    frame_voi = [
+        voi if voi is not None and _has_windowing(voi) else None for voi in frame_voi
+    ]
+    frame_rescale = [_get_functional_group_rescale(group) for group in per_frame]
+
+    base_voi = top_voi or shared_voi
+    base_rescale = top_rescale or shared_rescale
+    if base_voi is None and not any(voi is not None for voi in frame_voi):
+        return arr
+
+    uses_per_frame = bool(per_frame) and (
+        (base_voi is None and any(voi is not None for voi in frame_voi))
+        or (base_rescale is None and any(value is not None for value in frame_rescale))
+    )
+
+    if slice_number is not None and per_frame:
+        nr_frames = len(per_frame)
+        declared_frames = ds.get("NumberOfFrames")
+        if declared_frames is not None and int(declared_frames) != nr_frames:
+            raise ValueError(
+                f"The number of frame functional groups ({nr_frames}) does not "
+                f"match the dataset's Number of Frames ({declared_frames})"
+            )
+        if slice_number < 0 or slice_number >= nr_frames:
+            raise IndexError(
+                f"The slice number ({slice_number}) is outside the available "
+                f"frame range (0 to {nr_frames - 1})"
+            )
+
+        voi = base_voi or frame_voi[slice_number]
+        if voi is None:
+            return arr
+
+        rescale = base_rescale or frame_rescale[slice_number]
+        return _apply_windowing(arr, ds, voi, index, rescale)
+
+    if not uses_per_frame:
+        if base_voi is None:
+            return arr
+
+        return _apply_windowing(arr, ds, base_voi, index, base_rescale)
+
+    nr_frames = len(per_frame)
+    declared_frames = ds.get("NumberOfFrames")
+    if declared_frames is not None and int(declared_frames) != nr_frames:
+        raise ValueError(
+            f"The number of frame functional groups ({nr_frames}) does not "
+            f"match the dataset's Number of Frames ({declared_frames})"
+        )
+
+    if nr_frames > 1:
+        arr_frames = arr.shape[0] if arr.ndim >= 3 else 1
+        if nr_frames != arr_frames:
+            raise ValueError(
+                f"The number of frame functional groups ({nr_frames}) does not "
+                f"match the number of frames in the array ({arr_frames})"
+            )
+
+    if nr_frames == 1:
+        voi = base_voi or frame_voi[0]
+        if voi is None:
+            return arr
+
+        return _apply_windowing(arr, ds, voi, index, base_rescale or frame_rescale[0])
+
+    out = arr.astype("float64")
+    for frame_number in range(nr_frames):
+        voi = base_voi or frame_voi[frame_number]
+        if voi is None:
+            continue
+
+        rescale = base_rescale or frame_rescale[frame_number]
+        out[frame_number] = _apply_windowing(arr[frame_number], ds, voi, index, rescale)
+
+    return out
 
 
 def convert_color_space(

--- a/tests/pixels/test_processing.py
+++ b/tests/pixels/test_processing.py
@@ -438,6 +438,25 @@ class TestModalityLUT:
         assert np.array_equal(original, arr)
         assert np.array_equal([[[2]], [[4]]], out)
 
+    def test_per_frame_functional_group_slice_number(self):
+        """Test selecting one per-frame transformation."""
+        ds = Dataset()
+        ds.NumberOfFrames = 2
+        ds.PerFrameFunctionalGroupsSequence = [
+            self._get_functional_group(3, -1),
+            self._get_functional_group(7, -3),
+        ]
+        arr = np.asarray([[1]], dtype=np.int16)
+
+        out = apply_modality_lut(arr, ds, slice_number=1)
+
+        assert np.float64 == out.dtype
+        assert np.array_equal([[4]], out)
+
+        msg = r"The slice number \(2\) is outside the available frame range"
+        with pytest.raises(IndexError, match=msg):
+            apply_modality_lut(arr, ds, slice_number=2)
+
     def test_missing_per_frame_functional_group(self):
         """Test a missing per-frame transform leaves that frame unchanged."""
         ds = Dataset()
@@ -1188,6 +1207,17 @@ class TestExpandSegmentedLUT:
 class TestApplyWindowing:
     """Tests for apply_windowing()."""
 
+    @staticmethod
+    def _get_functional_group(center, width):
+        """Return a functional group containing Frame VOI LUT parameters."""
+        voi = Dataset()
+        voi.WindowCenter = center
+        voi.WindowWidth = width
+
+        group = Dataset()
+        group.FrameVOILUTSequence = [voi]
+        return group
+
     def test_window_single_view(self):
         """Test windowing with a single view."""
         # 12-bit unsigned
@@ -1476,6 +1506,41 @@ class TestApplyWindowing:
         assert 3046.6 == pytest.approx(out[0, 326, 130], abs=0.1)
         assert 4095.0 == pytest.approx(out[1, 326, 130], abs=0.1)
 
+    def test_window_per_frame_functional_groups(self):
+        """Test windowing using per-frame Frame VOI LUT parameters."""
+        ds = Dataset()
+        ds.NumberOfFrames = 2
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        ds.PixelRepresentation = 0
+        ds.BitsStored = 8
+        ds.PerFrameFunctionalGroupsSequence = [
+            self._get_functional_group(0, 1),
+            self._get_functional_group(255, 1),
+        ]
+        arr = np.asarray([[[0]], [[0]]], dtype=np.uint8)
+
+        out = apply_windowing(arr, ds)
+
+        assert np.float64 == out.dtype
+        assert np.array_equal([[[255]], [[0]]], out)
+
+        out = apply_windowing(arr[0], ds, slice_number=1)
+        assert np.array_equal([[0]], out)
+
+    def test_window_shared_functional_group(self):
+        """Test windowing using shared Frame VOI LUT parameters."""
+        ds = Dataset()
+        ds.NumberOfFrames = 2
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        ds.PixelRepresentation = 0
+        ds.BitsStored = 8
+        ds.SharedFunctionalGroupsSequence = [self._get_functional_group(0, 1)]
+        arr = np.asarray([[[0]], [[0]]], dtype=np.uint8)
+
+        out = apply_windowing(arr, ds)
+
+        assert np.array_equal([[[255]], [[255]]], out)
+
     def test_window_rescale(self):
         """Test windowing after a rescale operation."""
         ds = dcmread(WIN_12_1F)
@@ -1590,6 +1655,15 @@ class TestApplyWindowing:
         ds.ModalityLUTSequence = []
         out = apply_windowing(arr, ds)
         assert [-128, -127, -1, 0, 1, 126, 127] == out.tolist()
+
+        transform = Dataset()
+        transform.RescaleSlope = 2
+        transform.RescaleIntercept = -1
+        group = Dataset()
+        group.PixelValueTransformationSequence = [transform]
+        ds.PerFrameFunctionalGroupsSequence = [group]
+        out = apply_windowing(arr, ds)
+        assert arr is out
 
     def test_rescale_empty(self):
         """Test RescaleSlope and RescaleIntercept being empty."""
@@ -1889,6 +1963,27 @@ class TestApplyVOILUT:
         ds.WindowWidth = 1
         ds.WindowCenter = 0
         assert [255, 255, 255, 255, 255] == apply_voi_lut(arr, ds).tolist()
+
+    def test_per_frame_windowing(self):
+        """Test Frame VOI LUT parameters are used for each frame."""
+        ds = Dataset()
+        ds.NumberOfFrames = 2
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        ds.PixelRepresentation = 0
+        ds.BitsStored = 8
+        ds.PerFrameFunctionalGroupsSequence = []
+        for center in (0, 255):
+            voi = Dataset()
+            voi.WindowCenter = center
+            voi.WindowWidth = 1
+            group = Dataset()
+            group.FrameVOILUTSequence = [voi]
+            ds.PerFrameFunctionalGroupsSequence.append(group)
+
+        arr = np.asarray([[[0]], [[0]]], dtype=np.uint8)
+        out = apply_voi_lut(arr, ds)
+
+        assert np.array_equal([[[255]], [[0]]], out)
 
     def test_only_voi(self):
         """Test only LUT operation elements present."""

--- a/tests/pixels/test_processing.py
+++ b/tests/pixels/test_processing.py
@@ -373,6 +373,19 @@ class TestConvertColorSpace:
 class TestModalityLUT:
     """Tests for apply_modality_lut()."""
 
+    @staticmethod
+    def _get_functional_group(slope, intercept):
+        """Return a functional group with a pixel value transformation."""
+        transform = Dataset()
+        transform.RescaleSlope = slope
+        transform.RescaleIntercept = intercept
+        transform.RescaleType = "US"
+
+        group = Dataset()
+        group.PixelValueTransformationSequence = [transform]
+
+        return group
+
     def test_slope_intercept(self):
         """Test the rescale slope/intercept transform."""
         ds = dcmread(MOD_16)
@@ -389,6 +402,100 @@ class TestModalityLUT:
         ds.RescaleIntercept = -2048
         out = apply_modality_lut(arr, ds)
         assert np.array_equal(arr * 2.5 - 2048, out)
+
+    def test_shared_functional_group(self):
+        """Test rescale using a shared functional group."""
+        ds = Dataset()
+        ds.NumberOfFrames = 2
+        ds.SharedFunctionalGroupsSequence = [self._get_functional_group(2, -1)]
+        arr = np.asarray([[[1, 2]], [[3, 4]]], dtype=np.int16)
+        original = arr.copy()
+
+        out = apply_modality_lut(arr, ds)
+
+        assert out.flags.writeable
+        assert np.float64 == out.dtype
+        assert np.array_equal(original, arr)
+        assert np.array_equal(arr * 2 - 1, out)
+
+    def test_per_frame_functional_groups(self):
+        """Test rescale using per-frame functional groups."""
+        ds = Dataset()
+        ds.NumberOfFrames = 2
+        # Shared functional groups may contain unrelated macros
+        ds.SharedFunctionalGroupsSequence = [Dataset()]
+        ds.PerFrameFunctionalGroupsSequence = [
+            self._get_functional_group(3, -1),
+            self._get_functional_group(7, -3),
+        ]
+        arr = np.asarray([[[1]], [[1]]], dtype=np.int16)
+        original = arr.copy()
+
+        out = apply_modality_lut(arr, ds)
+
+        assert out.flags.writeable
+        assert np.float64 == out.dtype
+        assert np.array_equal(original, arr)
+        assert np.array_equal([[[2]], [[4]]], out)
+
+    def test_missing_per_frame_functional_group(self):
+        """Test a missing per-frame transform leaves that frame unchanged."""
+        ds = Dataset()
+        ds.NumberOfFrames = 2
+        ds.PerFrameFunctionalGroupsSequence = [
+            Dataset(),
+            self._get_functional_group(2, -1),
+        ]
+        arr = np.asarray([[[1, 2]], [[3, 4]]], dtype=np.int16)
+
+        out = apply_modality_lut(arr, ds)
+
+        assert np.float64 == out.dtype
+        assert np.array_equal([[[1, 2]], [[5, 7]]], out)
+
+    def test_single_frame_functional_group(self):
+        """Test a per-frame transform for a single-frame array."""
+        ds = Dataset()
+        ds.NumberOfFrames = 1
+        ds.PerFrameFunctionalGroupsSequence = [self._get_functional_group(2, -1)]
+        arr = np.asarray([[1, 2], [3, 4]], dtype=np.int16)
+
+        out = apply_modality_lut(arr, ds)
+
+        assert np.array_equal([[1, 3], [5, 7]], out)
+
+    def test_per_frame_functional_group_mismatch(self):
+        """Test mismatched frame count raises an exception."""
+        ds = Dataset()
+        ds.NumberOfFrames = 2
+        ds.PerFrameFunctionalGroupsSequence = [
+            self._get_functional_group(3, -1),
+            self._get_functional_group(7, -3),
+        ]
+        # The issue's original reproducer uses this shape, which is one frame
+        # under pydicom's frame-first ndarray convention, not two frames
+        arr = np.atleast_3d([1, 1])
+
+        msg = (
+            r"The number of frame functional groups \(2\) does not match the "
+            r"number of frames in the array \(1\)"
+        )
+        with pytest.raises(ValueError, match=msg):
+            apply_modality_lut(arr, ds)
+
+    def test_per_frame_functional_group_dataset_mismatch(self):
+        """Test mismatched Number of Frames raises an exception."""
+        ds = Dataset()
+        ds.NumberOfFrames = 2
+        ds.PerFrameFunctionalGroupsSequence = [self._get_functional_group(2, -1)]
+        arr = np.ones((2, 2, 2), dtype=np.int16)
+
+        msg = (
+            r"The number of frame functional groups \(1\) does not match the "
+            r"dataset's Number of Frames \(2\)"
+        )
+        with pytest.raises(ValueError, match=msg):
+            apply_modality_lut(arr, ds)
 
     def test_lut_sequence(self):
         """Test the LUT Sequence transform."""
@@ -444,6 +551,10 @@ class TestModalityLUT:
         assert arr is out
 
         ds.ModalityLUTSequence = []
+        out = apply_modality_lut(arr, ds)
+        assert arr is out
+
+        ds.PerFrameFunctionalGroupsSequence = [Dataset()]
         out = apply_modality_lut(arr, ds)
         assert arr is out
 

--- a/tests/pixels/test_processing.py
+++ b/tests/pixels/test_processing.py
@@ -1527,6 +1527,96 @@ class TestApplyWindowing:
         out = apply_windowing(arr[0], ds, slice_number=1)
         assert np.array_equal([[0]], out)
 
+    def test_window_per_frame_slice_errors(self):
+        """Test invalid per-frame metadata and slice numbers."""
+        ds = Dataset()
+        ds.NumberOfFrames = 3
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        ds.PixelRepresentation = 0
+        ds.BitsStored = 8
+        ds.PerFrameFunctionalGroupsSequence = [
+            self._get_functional_group(0, 1),
+            self._get_functional_group(255, 1),
+        ]
+        arr = np.asarray([[0]], dtype=np.uint8)
+
+        msg = (
+            r"The number of frame functional groups \(2\) does not match the "
+            r"dataset's Number of Frames \(3\)"
+        )
+        with pytest.raises(ValueError, match=msg):
+            apply_windowing(arr, ds, slice_number=0)
+
+        ds.NumberOfFrames = 2
+        msg = r"The slice number \(-1\) is outside the available frame range"
+        with pytest.raises(IndexError, match=msg):
+            apply_windowing(arr, ds, slice_number=-1)
+
+        ds.PerFrameFunctionalGroupsSequence[0] = Dataset()
+        out = apply_windowing(arr, ds, slice_number=0)
+        assert arr is out
+
+    def test_window_per_frame_mismatch(self):
+        """Test mismatched per-frame metadata and array frame counts."""
+        ds = Dataset()
+        ds.NumberOfFrames = 3
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        ds.PixelRepresentation = 0
+        ds.BitsStored = 8
+        ds.PerFrameFunctionalGroupsSequence = [
+            self._get_functional_group(0, 1),
+            self._get_functional_group(255, 1),
+        ]
+        arr = np.asarray([[[0]], [[0]]], dtype=np.uint8)
+
+        msg = (
+            r"The number of frame functional groups \(2\) does not match the "
+            r"dataset's Number of Frames \(3\)"
+        )
+        with pytest.raises(ValueError, match=msg):
+            apply_windowing(arr, ds)
+
+        ds.NumberOfFrames = 2
+        msg = (
+            r"The number of frame functional groups \(2\) does not match the "
+            r"number of frames in the array \(1\)"
+        )
+        with pytest.raises(ValueError, match=msg):
+            apply_windowing(arr[0], ds)
+
+    def test_window_single_frame_functional_group(self):
+        """Test per-frame windowing with a single-frame array."""
+        ds = Dataset()
+        ds.NumberOfFrames = 1
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        ds.PixelRepresentation = 0
+        ds.BitsStored = 8
+        ds.PerFrameFunctionalGroupsSequence = [self._get_functional_group(0, 1)]
+        arr = np.asarray([[0]], dtype=np.uint8)
+
+        out = apply_windowing(arr, ds)
+
+        assert np.float64 == out.dtype
+        assert np.array_equal([[255]], out)
+
+    def test_window_missing_per_frame_functional_group(self):
+        """Test a missing per-frame VOI leaves that frame unchanged."""
+        ds = Dataset()
+        ds.NumberOfFrames = 2
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        ds.PixelRepresentation = 0
+        ds.BitsStored = 8
+        ds.PerFrameFunctionalGroupsSequence = [
+            Dataset(),
+            self._get_functional_group(255, 1),
+        ]
+        arr = np.asarray([[[1]], [[1]]], dtype=np.uint8)
+
+        out = apply_windowing(arr, ds)
+
+        assert np.float64 == out.dtype
+        assert np.array_equal([[[1]], [[0]]], out)
+
     def test_window_shared_functional_group(self):
         """Test windowing using shared Frame VOI LUT parameters."""
         ds = Dataset()
@@ -1655,6 +1745,12 @@ class TestApplyWindowing:
         ds.ModalityLUTSequence = []
         out = apply_windowing(arr, ds)
         assert [-128, -127, -1, 0, 1, 126, 127] == out.tolist()
+
+        group = Dataset()
+        group.FrameVOILUTSequence = [Dataset()]
+        ds.SharedFunctionalGroupsSequence = [group]
+        out = apply_windowing(arr, ds)
+        assert arr is out
 
         transform = Dataset()
         transform.RescaleSlope = 2


### PR DESCRIPTION
#### Describe the changes

Closes #2353.

`apply_modality_lut()` / `apply_rescale()` now reads the Pixel Value Transformation Sequence from `SharedFunctionalGroupsSequence` or `PerFrameFunctionalGroupsSequence` for multi-frame datasets.

The change:

* applies distinct slope/intercept values in frame order
* leaves frames without a transformation unchanged
* validates per-frame metadata against `NumberOfFrames` and the ndarray frame count
* preserves the existing top-level Modality LUT and rescale behavior

The regression coverage uses a canonical two-frame array with shape `(2, 1, 1)`. The issue’s `np.atleast_3d([1, 1])` example has shape `(1, 2, 1)`, which represents one frame under pydicom’s frame-first convention.

#### Tasks

* [x] Unit tests added that reproduce the issue or prove feature is working
* [x] Fix or feature added
* [x] Code typed and mypy shows no errors
* [x] Documentation updated (function docs and release note)
* [x] Unit tests passing and overall coverage the same or better

#### Testing

* `python -m pytest -q tests/pixels/test_processing.py` — 105 passed, 11 skipped
* `ruff check src/pydicom/pixels/processing.py`
* `ruff format --check src/pydicom/pixels/processing.py tests/pixels/test_processing.py`
* `mypy src/pydicom/pixels/processing.py`
* Real Enhanced CT validation: two frames rescaled to `float64` range `-1024..172`, with the input array unchanged
