### PR TITLE
Byte swap big endian Pixel Data before encoding

### DIFF
--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -49,6 +49,8 @@ Fixes
 * Fixed deepcopy of private blocks in :class:`~pydicom.dataset.Dataset` (:issue:`2294`)
 * Make float data elements with `NaN` value compare as equal - this is semantically better suited
   then the mathematical comparison, where `NaN != NaN` (:issue:`2273`)
+* Fixed :meth:`~pydicom.dataset.Dataset.compress` silently producing byte swapped pixel
+  data when the source dataset uses *Explicit VR Big Endian* (:issue:`2340`).
 
 Enhancements
 ------------

--- a/src/pydicom/pixels/encoders/base.py
+++ b/src/pydicom/pixels/encoders/base.py
@@ -23,6 +23,7 @@ from pydicom.pixels.common import (
 from pydicom.pixels.utils import get_packed_frame
 from pydicom.uid import (
     UID,
+    ExplicitVRBigEndian,
     JPEGBaseline8Bit,
     JPEGExtended12Bit,
     JPEGLossless,
@@ -318,7 +319,7 @@ class EncodeRunner(RunnerBase):
 
         if isinstance(src, Dataset):
             self._set_options_ds(src)
-            self._src = src.PixelData
+            self._src = self._pixel_data_as_little_endian(src)
             self._src_type = "Dataset"
         elif isinstance(src, (bytes | bytearray | memoryview)):
             self._src = src
@@ -342,6 +343,45 @@ class EncodeRunner(RunnerBase):
                 "'src' must be bytes, numpy.ndarray or pydicom.dataset.Dataset, "
                 f"not '{src.__class__.__name__}'"
             )
+
+    def _pixel_data_as_little_endian(self, ds: "Dataset") -> Buffer:
+        """Return `ds`'s *Pixel Data* as little-endian ordered bytes.
+
+        Encoders require little-endian input, so *Pixel Data* read from an
+        *Explicit VR Big Endian* dataset has to be byte swapped first. Without
+        this the encoder reads every sample byte-reversed and encodes corrupt
+        pixel data without raising - a 16-bit value of 1 becomes 256.
+
+        Parameters
+        ----------
+        ds : pydicom.dataset.Dataset
+            The dataset supplying the pixel data.
+
+        Returns
+        -------
+        bytes | bytearray | memoryview
+            The pixel data, byte swapped if the dataset is big-endian encoded.
+        """
+        src = ds.PixelData
+        file_meta = getattr(ds, "file_meta", None)
+        if getattr(file_meta, "TransferSyntaxUID", None) != ExplicitVRBigEndian:
+            return src
+
+        # Bits allocated of 1 is bit-packed and 8 is a single byte, neither swaps
+        nr_bytes = self.bits_allocated // 8
+        if nr_bytes < 2 or len(src) % nr_bytes:
+            return src
+
+        # Swap symmetric byte positions within each sample
+        buffer = bytearray(src)
+        for left in range(nr_bytes // 2):
+            right = nr_bytes - 1 - left
+            buffer[left::nr_bytes], buffer[right::nr_bytes] = (
+                buffer[right::nr_bytes],
+                buffer[left::nr_bytes],
+            )
+
+        return bytes(buffer)
 
     @property
     def src(self) -> "Buffer | np.ndarray":

--- a/src/pydicom/pixels/encoders/base.py
+++ b/src/pydicom/pixels/encoders/base.py
@@ -362,7 +362,7 @@ class EncodeRunner(RunnerBase):
         bytes | bytearray | memoryview
             The pixel data, byte swapped if the dataset is big-endian encoded.
         """
-        src = ds.PixelData
+        src = cast(Buffer, ds.PixelData)
         file_meta = getattr(ds, "file_meta", None)
         if getattr(file_meta, "TransferSyntaxUID", None) != ExplicitVRBigEndian:
             return src

--- a/tests/pixels/test_encoder_base.py
+++ b/tests/pixels/test_encoder_base.py
@@ -14,13 +14,14 @@ except ImportError:
 
 from pydicom import config, examples
 from pydicom.data import get_testdata_file
-from pydicom.dataset import Dataset
+from pydicom.dataset import Dataset, FileMetaDataset
 from pydicom.pixels.encoders import RLELosslessEncoder
 from pydicom.pixels.common import PhotometricInterpretation as PI
 from pydicom.pixels.encoders.base import Encoder, EncodeRunner
 from pydicom.pixels.utils import get_expected_length, unpack_bits
 from pydicom.uid import (
     UID,
+    ExplicitVRBigEndian,
     RLELossless,
     JPEGLSLossless,
     JPEG2000MC,
@@ -92,6 +93,49 @@ class TestEncodeRunner:
         assert runner.rows == 8
         assert runner.samples_per_pixel == 3
         assert runner.planar_configuration == 1
+
+    def test_set_source_dataset_big_endian(self):
+        """Big-endian Pixel Data is byte swapped for the encoder."""
+        runner = EncodeRunner(RLELossless)
+        ds = Dataset()
+        ds.file_meta = FileMetaDataset()
+        ds.file_meta.TransferSyntaxUID = ExplicitVRBigEndian
+        ds.Rows = 1
+        ds.Columns = 3
+        ds.SamplesPerPixel = 1
+        ds.PixelRepresentation = 0
+        ds.BitsStored = 16
+        ds.BitsAllocated = 16
+        ds.NumberOfFrames = 1
+        ds.PhotometricInterpretation = "MONOCHROME2"
+        # Samples 1, 2, 3 as big-endian
+        ds.PixelData = b"\x00\x01\x00\x02\x00\x03"
+        runner.set_source(ds)
+        assert runner.src == b"\x01\x00\x02\x00\x03\x00"
+
+        # 32-bit swaps all four bytes of each sample
+        ds.BitsStored = 32
+        ds.BitsAllocated = 32
+        ds.PixelData = b"\x00\x00\x00\x01\x00\x00\x00\x02"
+        runner.set_source(ds)
+        assert runner.src == b"\x01\x00\x00\x00\x02\x00\x00\x00"
+
+        # One byte per sample, nothing to swap
+        ds.BitsStored = 8
+        ds.BitsAllocated = 8
+        ds.PixelData = b"\x01\x02\x03"
+        runner.set_source(ds)
+        assert runner.src == b"\x01\x02\x03"
+
+    @pytest.mark.skipif(not HAVE_NP, reason="Numpy not available")
+    def test_compress_big_endian_roundtrip(self):
+        """Compressing a big-endian dataset is lossless. Regression test for #2340."""
+        ds = get_testdata_file("MR_small_expb.dcm", read=True)
+        assert ds.file_meta.TransferSyntaxUID == ExplicitVRBigEndian
+        expected = ds.pixel_array.copy()
+
+        ds.compress(RLELossless)
+        assert np.array_equal(ds.pixel_array, expected)
 
     @pytest.mark.skipif(not HAVE_NP, reason="Numpy not available")
     def test_set_source_ndarray(self):


### PR DESCRIPTION
Fixes #2340. `Dataset.compress()` byte-swaps big-endian Pixel Data before encoding; a 16-bit 1 no longer becomes 256.
