### PR TITLE
Handle all three deflated transfer syntaxes, not just Deflated Explicit VR Little Endian

### DIFF
--- a/doc/reference/uid.rst
+++ b/doc/reference/uid.rst
@@ -27,6 +27,7 @@ Transfer Syntax UIDs
    JPEG2000
    JPEG2000MCLossless
    JPEG2000MC
+   JPIPReferencedDeflate
    MPEG2MPML
    MPEG2MPMLF
    MPEG2MPHL
@@ -71,6 +72,7 @@ Transfer Syntax Lists
    JPEGXLTransferSyntaxes
    MPEGTransferSyntaxes
    RLETransferSyntaxes
+   DeflatedTransferSyntaxes
    UncompressedTransferSyntaxes
    PrivateTransferSyntaxes
 

--- a/doc/release_notes/v3.1.0.rst
+++ b/doc/release_notes/v3.1.0.rst
@@ -47,6 +47,11 @@ Fixes
 * Correctly handle meta data tags incorrectly written in implicit transfer syntax (:issue:`2290`)
 * Made debugging of :func:`~pydicom.filereader.read_dataset` a bit more robust (:pr:`2292`).
 * Fixed deepcopy of private blocks in :class:`~pydicom.dataset.Dataset` (:issue:`2294`)
+* Fixed :attr:`UID.is_deflated<pydicom.uid.UID.is_deflated>` returning ``False`` for
+  *JPIP Referenced Deflate* and *JPIP HTJ2K Referenced Deflate*, and fixed
+  :func:`~pydicom.filereader.dcmread` and :func:`~pydicom.filewriter.dcmwrite` not
+  inflating/deflating the dataset for those two transfer syntaxes (PS3.5 Sections A.7
+  and A.12).
 * Make float data elements with `NaN` value compare as equal - this is semantically better suited
   then the mathematical comparison, where `NaN != NaN` (:issue:`2273`)
 
@@ -67,6 +72,7 @@ Enhancements
   * :attr:`~pydicom.uid.JPEGXLJPEGRecompression`
   * :attr:`~pydicom.uid.JPEGXL`
   * :attr:`~pydicom.uid.DeflatedImageFrameCompression`
+  * :attr:`~pydicom.uid.JPIPReferencedDeflate`
 * Added ability to specify tag numbers in the CLI commands (allows private tags to be specified)
 * Removed `exec` and `eval` from tests, CLI, and scripts for improved security (:issue:`2193`)
 * Added support for up to 16-bit input images to :func:`~pydicom.pixels.convert_color_space`

--- a/src/pydicom/filereader.py
+++ b/src/pydicom/filereader.py
@@ -893,8 +893,8 @@ def read_partial(
     elif transfer_syntax == pydicom.uid.ExplicitVRBigEndian:
         is_implicit_VR = False
         is_little_endian = False
-    elif transfer_syntax == pydicom.uid.DeflatedExplicitVRLittleEndian:
-        # See PS3.5 section A.5
+    elif transfer_syntax in pydicom.uid.DeflatedTransferSyntaxes:
+        # See PS3.5 sections A.5, A.7 and A.12
         # when written, the entire dataset following
         #     the file metadata was prepared the normal way,
         #     then "deflate" compression applied.

--- a/src/pydicom/filewriter.py
+++ b/src/pydicom/filewriter.py
@@ -37,7 +37,7 @@ from pydicom.tag import (
     _LUT_DESCRIPTOR_TAGS,
 )
 from pydicom.uid import (
-    DeflatedExplicitVRLittleEndian,
+    DeflatedTransferSyntaxes,
     UID,
     ImplicitVRLittleEndian,
     ExplicitVRBigEndian,
@@ -1454,8 +1454,8 @@ def dcmwrite(
         if file_meta:  # May be empty
             write_file_meta_info(fp, file_meta, enforce_standard=enforce_file_format)
 
-        if tsyntax == DeflatedExplicitVRLittleEndian:
-            # See PS3.5 section A.5
+        if tsyntax in DeflatedTransferSyntaxes:
+            # See PS3.5 sections A.5, A.7 and A.12
             # When writing, the entire dataset following the file meta data
             #   is encoded normally, then "deflate" compression applied
             buffer = DicomBytesIO()

--- a/src/pydicom/uid.py
+++ b/src/pydicom/uid.py
@@ -139,15 +139,7 @@ class UID(str):
     def is_deflated(self) -> bool:
         """Return ``True`` if a deflated transfer syntax UID."""
         if self.is_transfer_syntax:
-            # Deflated Explicit VR Little Endian
-            if self == "1.2.840.10008.1.2.1.99":
-                return True
-
-            # Explicit VR Little Endian
-            # Implicit VR Little Endian
-            # Explicit VR Big Endian
-            # All encapsulated transfer syntaxes
-            return False
+            return self in DeflatedTransferSyntaxes
 
         raise ValueError("UID is not a transfer syntax.")
 
@@ -292,6 +284,8 @@ with disable_value_validation():
     """1.2.840.10008.1.2.4.92"""
     JPEG2000MC = UID("1.2.840.10008.1.2.4.93")
     """1.2.840.10008.1.2.4.93"""
+    JPIPReferencedDeflate = UID("1.2.840.10008.1.2.4.95")
+    """1.2.840.10008.1.2.4.95"""
     MPEG2MPML = UID("1.2.840.10008.1.2.4.100")
     """1.2.840.10008.1.2.4.100"""
     MPEG2MPMLF = UID("1.2.840.10008.1.2.4.100.1")
@@ -445,6 +439,16 @@ MPEGTransferSyntaxes = [
 
 RLETransferSyntaxes = [RLELossless]
 """RLE transfer syntaxes."""
+
+DeflatedTransferSyntaxes = [
+    DeflatedExplicitVRLittleEndian,
+    JPIPReferencedDeflate,
+    JPIPHTJ2KReferencedDeflate,
+]
+"""Transfer syntaxes where the encoded *Data Set* following the *File Meta
+Information* is compressed using the Deflate algorithm, from Sections A.5, A.7
+and A.12 of :dcm:`Part 5 of the DICOM Standard<part05/chapter_A.html>`.
+"""
 
 UncompressedTransferSyntaxes = [
     ExplicitVRLittleEndian,

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -12,6 +12,7 @@ from struct import unpack
 import sys
 import tempfile
 import time
+import zlib
 
 import pytest
 
@@ -29,6 +30,7 @@ from pydicom.filereader import (
 from pydicom.dataelem import DataElement, convert_raw_data_element
 from pydicom.errors import InvalidDicomError
 from pydicom.filebase import DicomBytesIO
+from pydicom.filewriter import write_dataset, write_file_meta_info
 from pydicom.multival import MultiValue
 from pydicom.sequence import Sequence
 from pydicom.tag import Tag, TupleTag
@@ -288,6 +290,45 @@ class TestReader:
         assert "WSD" == ds.ConversionType
         assert isinstance(ds.buffer, DicomBytesIO)
         assert ds.filename == deflate_name
+
+    # UIDs hardcoded from PS3.5 Sections A.5, A.7 and A.12 rather than taken
+    #   from pydicom.uid so that an omission there is detectable here
+    @pytest.mark.parametrize(
+        "tsyntax",
+        [
+            "1.2.840.10008.1.2.1.99",  # Deflated Explicit VR Little Endian
+            "1.2.840.10008.1.2.4.95",  # JPIP Referenced Deflate
+            "1.2.840.10008.1.2.4.205",  # JPIP HTJ2K Referenced Deflate
+        ],
+    )
+    def test_read_deflated_syntaxes(self, tsyntax):
+        """A deflated dataset is inflated for every deflated transfer syntax."""
+        # Build the file by hand so the encoder isn't the oracle for the decoder
+        ds = Dataset()
+        ds.SOPClassUID = "1.2.840.10008.5.1.4.1.1.7"
+        ds.SOPInstanceUID = "1.2.3.4"
+        ds.PatientName = "CITIZEN^Jan"
+        buffer = DicomBytesIO()
+        buffer.is_implicit_VR = False
+        buffer.is_little_endian = True
+        write_dataset(buffer, ds)
+        compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+        deflated = compressor.compress(buffer.getvalue()) + compressor.flush()
+
+        meta = FileMetaDataset()
+        meta.MediaStorageSOPClassUID = "1.2.840.10008.5.1.4.1.1.7"
+        meta.MediaStorageSOPInstanceUID = "1.2.3.4"
+        meta.TransferSyntaxUID = tsyntax
+        meta.ImplementationClassUID = "1.2.3.4"
+        meta_buffer = DicomBytesIO()
+        meta_buffer.is_implicit_VR = False
+        meta_buffer.is_little_endian = True
+        write_file_meta_info(meta_buffer, meta, enforce_standard=True)
+
+        raw = b"\x00" * 128 + b"DICM" + meta_buffer.getvalue() + deflated
+        out = dcmread(BytesIO(raw))
+        assert out.PatientName == "CITIZEN^Jan"
+        assert out.SOPInstanceUID == "1.2.3.4"
 
     def test_sequence_with_implicit_vr(self):
         """Test that reading a UN sequence with unknown length and implicit VR

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -327,6 +327,38 @@ class TestWriteFile:
 
         assert unzipped_rewritten == unzipped_original
 
+    # UIDs hardcoded from PS3.5 Sections A.5, A.7 and A.12 rather than taken
+    #   from pydicom.uid so that an omission there is detectable here
+    @pytest.mark.parametrize(
+        "tsyntax",
+        [
+            "1.2.840.10008.1.2.1.99",  # Deflated Explicit VR Little Endian
+            "1.2.840.10008.1.2.4.95",  # JPIP Referenced Deflate
+            "1.2.840.10008.1.2.4.205",  # JPIP HTJ2K Referenced Deflate
+        ],
+    )
+    def test_write_deflated_syntaxes(self, tsyntax):
+        """The dataset is deflated for every deflated transfer syntax."""
+        ds = Dataset()
+        ds.file_meta = FileMetaDataset()
+        ds.file_meta.MediaStorageSOPClassUID = "1.2.840.10008.5.1.4.1.1.7"
+        ds.file_meta.MediaStorageSOPInstanceUID = "1.2.3.4"
+        ds.file_meta.TransferSyntaxUID = tsyntax
+        ds.SOPClassUID = "1.2.840.10008.5.1.4.1.1.7"
+        ds.SOPInstanceUID = "1.2.3.4"
+        ds.PatientName = "CITIZEN^Jan"
+        ds.save_as(self.file_out, enforce_file_format=True)
+
+        self.file_out.seek(0)
+        written = self.file_out.read()
+        # An undeflated dataset would contain the value as plain text
+        assert b"CITIZEN^Jan" not in written
+
+        # Everything past the file meta must be a raw deflate stream
+        group_length = unpack("<I", written[140:144])[0]
+        deflated = written[144 + group_length :]
+        assert b"CITIZEN^Jan" in zlib.decompress(deflated, -zlib.MAX_WBITS)
+
     def test_write_dataset_without_encoding(self):
         """Test that write_dataset() raises if encoding not set."""
         msg = (

--- a/tests/test_uid.py
+++ b/tests/test_uid.py
@@ -181,6 +181,15 @@ class TestUID:
         assert not UID("1.2.840.10008.1.2.2").is_deflated
         assert not UID("1.2.840.10008.1.2.4.50").is_deflated
 
+        # '1.2.840.10008.1.2.4.94' JPIP Referenced (PS3.5 A.6)
+        # '1.2.840.10008.1.2.4.95' JPIP Referenced Deflate (PS3.5 A.7)
+        # '1.2.840.10008.1.2.4.204' JPIP HTJ2K Referenced (PS3.5 A.11)
+        # '1.2.840.10008.1.2.4.205' JPIP HTJ2K Referenced Deflate (PS3.5 A.12)
+        assert not UID("1.2.840.10008.1.2.4.94").is_deflated
+        assert UID("1.2.840.10008.1.2.4.95").is_deflated
+        assert not UID("1.2.840.10008.1.2.4.204").is_deflated
+        assert UID("1.2.840.10008.1.2.4.205").is_deflated
+
         with pytest.raises(ValueError):
             UID("1.2.840.10008.5.1.4.1.1.2").is_deflated
 


### PR DESCRIPTION
`pydicom` treats "deflated" as one hardcoded UID. DICOM PS3.5 defines three.

`UID.is_deflated` (`uid.py:139-152`) is `self == "1.2.840.10008.1.2.1.99"`, and the same single-UID comparison is duplicated at the only inflate site (`filereader.py:896`) and the only deflate site (`filewriter.py:1457`). But [PS3.5 A.7](https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_a.7.html) (`1.2.840.10008.1.2.4.95`, JPIP Referenced Deflate) and [A.12](https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_a.12.html) (`1.2.840.10008.1.2.4.205`, JPIP HTJ2K Referenced Deflate) each say the entire encoded byte stream "is then compressed using the 'Deflate' algorithm defined in Internet RFC 1951" — the same thing A.5 says.

`1.2.840.10008.1.2.4.205` ships as `uid.JPIPHTJ2KReferencedDeflate` and is a member of `uid.AllTransferSyntaxes`, so this is reachable with public API only. The property being wrong is cosmetic. The reader and writer are not:

- **Writing** a dataset with `TransferSyntaxUID = 1.2.840.10008.1.2.4.205` produces an undeflated, non-conformant file, with no warning at all. (`b"CITIZEN^Jan" in written` is `True`; the `1.2.1.99` control is `False`.)
- **Reading** a conformant A.12 file returns a dataset with `PatientName is None` and no exception. It does warn, but the warning is `Expected explicit VR, but found implicit VR` — it is parsing the deflate stream as DICOM bytes and blaming the VR.

The fix puts the set in one place, `uid.DeflatedTransferSyntaxes`, and points all three call sites at it, and adds the missing `uid.JPIPReferencedDeflate` constant. In `filereader` I compare against the list rather than calling `transfer_syntax.is_deflated`, deliberately: that property raises `ValueError` for a non-transfer-syntax UID and the branch sits above the `PrivateTransferSyntaxes` handling.

Why no test caught it: `test_uid.py::TestUID::test_is_deflated` spot-checks five hardcoded UIDs and never touches the `4.9x`/`4.20x` range, and every test that enumerates transfer syntaxes uses `AllTransferSyntaxes` as its own oracle (`test_numpy_pixel_data.py:155`, `test_pillow_pixel_data.py:116`, `test_pylibjpeg.py:74`, `test_rle_pixel_data.py:129`), so a syntax missing from that list is invisible rather than failing. The two new tests therefore hardcode the UID strings.

Full suite, same venv, cache disabled on both sides: 3681 passed / 683 skipped on `main`, 3690 passed / 683 skipped here. Reverting only the three source files fails 5 of the 7 new test nodes (the two `1.2.1.99` params pass, as regression guards rather than new-bug detectors). Two mutants: patching only `is_deflated` and leaving reader/writer alone passes `test_is_deflated` and fails all four read/write params; adding the non-deflate `1.2.840.10008.1.2.4.204` to the list fails `test_is_deflated` and passes everything else, which is what the negative asserts are for. `AllTransferSyntaxes` is deliberately unchanged at 43 entries, since nine pixel-handler tests iterate it.

Not tested: no real-world A.7/A.12 file exists in `pydicom-data`, so the reader fixture is hand-deflated; no round-trip through `FileSet`/DICOMDIR or `Dataset.compress`; mypy could not run in my environment (its numpy stub needs Python ≥3.12 while the repo pins 3.10, so it aborts before reading any pydicom file — pre-existing, but it means I have not verified the typing box); sphinx not built.

Left alone here: `AllTransferSyntaxes` is documented as "All non-retired transfer syntaxes and *Explicit VR Big Endian*" but omits `1.2.840.10008.1.2.1.98`, `1.2.840.10008.1.2.4.94` and `1.2.840.10008.1.2.4.95`, none of which have named constants. Adding members changes what those nine tests iterate, so it wants its own PR.

---

Disclosure: the implementation, tests and this description were drafted with Claude Opus 5. The measurements above are reproducible from the branch.

